### PR TITLE
Create AsymmetricJwsSigningKey, remove HasPublicKey.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Additions
+
+- Adds `AsymmetricJwsSigningKey` trait. Provides a blanket implementation for `JwsSigningKey`.
+
+### Removals
+
+- Removes `HasPublicKey` trait.
+
+### Changes
+
+- DPoP uses `AsymmetricJwsSigningKey` as a bound instead of `HasPublicKey`
+
 ## [0.1.0] - 2026-03-24
 
 - Initial implementation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.1.0"
+version = "0.2.0-pre.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1033,12 +1033,12 @@ dependencies = [
  "http",
  "httpmock",
  "huskarl",
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.1.0",
  "huskarl-crypto-native",
  "huskarl-crypto-webcrypto",
  "huskarl-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "huskarl-reqwest",
- "huskarl-resource-server 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-resource-server 0.1.0",
  "huskarl-testkit",
  "pem",
  "rand 0.10.0",
@@ -1049,35 +1049,6 @@ dependencies = [
  "sha2",
  "snafu",
  "subtle",
- "tokio",
- "url",
- "wasm-bindgen-test",
- "web-time",
-]
-
-[[package]]
-name = "huskarl-core"
-version = "0.1.0"
-dependencies = [
- "arc-swap",
- "base64",
- "bon",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "getrandom 0.4.2",
- "gloo-timers",
- "hex",
- "http",
- "httpmock",
- "metrics",
- "rand 0.10.0",
- "reqwest",
- "secrecy",
- "serde",
- "serde_json",
- "sha2",
- "snafu",
  "tokio",
  "url",
  "wasm-bindgen-test",
@@ -1112,6 +1083,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "huskarl-core"
+version = "0.2.0-pre.0"
+dependencies = [
+ "arc-swap",
+ "base64",
+ "bon",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "getrandom 0.4.2",
+ "gloo-timers",
+ "hex",
+ "http",
+ "httpmock",
+ "metrics",
+ "rand 0.10.0",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2",
+ "snafu",
+ "tokio",
+ "url",
+ "wasm-bindgen-test",
+ "web-time",
+]
+
+[[package]]
 name = "huskarl-crypto-native"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1119,7 @@ checksum = "914262416d5e55bfe261637aa8a0ed9a727cfd595f6f88612565fd5b9610436b"
 dependencies = [
  "ed25519-dalek",
  "hmac",
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.1.0",
  "p256",
  "p384",
  "pkcs8",
@@ -1138,7 +1138,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65798342cc300fc299e1d2edd384a1aa8961f37fc1b31bbedcb06ea3161f1119"
 dependencies = [
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.1.0",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -1182,35 +1182,9 @@ dependencies = [
  "bon",
  "bytes",
  "http",
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.1.0",
  "reqwest",
  "snafu",
-]
-
-[[package]]
-name = "huskarl-resource-server"
-version = "0.1.0"
-dependencies = [
- "base64",
- "bon",
- "bytes",
- "form_urlencoded",
- "getrandom 0.4.2",
- "gloo-timers",
- "http",
- "httpmock",
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "huskarl-crypto-native",
- "huskarl-crypto-webcrypto",
- "huskarl-reqwest",
- "metrics",
- "serde",
- "serde_json",
- "sha2",
- "snafu",
- "tokio",
- "wasm-bindgen-test",
- "web-time",
 ]
 
 [[package]]
@@ -1226,7 +1200,7 @@ dependencies = [
  "getrandom 0.4.2",
  "gloo-timers",
  "http",
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.1.0",
  "huskarl-crypto-native",
  "huskarl-crypto-webcrypto",
  "serde",
@@ -1238,11 +1212,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "huskarl-resource-server"
+version = "0.2.0-pre.0"
+dependencies = [
+ "base64",
+ "bon",
+ "bytes",
+ "form_urlencoded",
+ "getrandom 0.4.2",
+ "gloo-timers",
+ "http",
+ "httpmock",
+ "huskarl-core 0.1.0",
+ "huskarl-crypto-native",
+ "huskarl-crypto-webcrypto",
+ "huskarl-reqwest",
+ "metrics",
+ "serde",
+ "serde_json",
+ "sha2",
+ "snafu",
+ "tokio",
+ "wasm-bindgen-test",
+ "web-time",
+]
+
+[[package]]
 name = "huskarl-testkit"
 version = "0.1.0"
 dependencies = [
  "bon",
- "huskarl-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.1.0",
  "reqwest",
  "serde",
  "tokio",

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.1.0"
+version = "0.2.0-pre.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-core/src/crypto/signer/asymmetric/boxed.rs
+++ b/huskarl-core/src/crypto/signer/asymmetric/boxed.rs
@@ -2,8 +2,7 @@ use std::{borrow::Cow, pin::Pin, sync::Arc};
 
 use crate::{
     BoxedError,
-    crypto::signer::{HasPublicKey, JwsSigningKey, SigningKeyMetadata},
-    jwk::PublicJwk,
+    crypto::signer::asymmetric::{AsymmetricJwsSigningKey, AsymmetricSigningKeyMetadata},
     platform::{MaybeSendFuture, MaybeSendSync},
 };
 
@@ -14,18 +13,18 @@ pub struct BoxedAsymmetricJwsSigningKey {
 }
 
 impl BoxedAsymmetricJwsSigningKey {
-    /// Create a boxed signing key from a non-boxed.
-    pub fn new<Sgn: JwsSigningKey + HasPublicKey + std::fmt::Debug + 'static>(signer: Sgn) -> Self {
+    /// Create a boxed asymmetric signing key from a non-boxed.
+    pub fn new<Sgn: AsymmetricJwsSigningKey + 'static>(signer: Sgn) -> Self {
         Self {
             inner: Arc::new(signer),
         }
     }
 }
 
-/// Boxed trait for signing keys that produce RFC 7515 (JWS) / RFC 7518 (JWA) compatible signatures.
+/// Boxed trait for asymmetric signing keys that produce RFC 7515 (JWS) / RFC 7518 (JWA) compatible signatures.
 trait DynAsymmetricJwsSigningKey: std::fmt::Debug + MaybeSendSync {
-    /// Returns metadata about the key used by this signer.
-    fn key_metadata(&self) -> Cow<'_, SigningKeyMetadata>;
+    /// Returns metadata about the asymmetric key used by this signer.
+    fn asymmetric_key_metadata(&self) -> Cow<'_, AsymmetricSigningKeyMetadata>;
 
     /// Asynchronously signs the given input data and returns the signature.
     ///
@@ -35,49 +34,37 @@ trait DynAsymmetricJwsSigningKey: std::fmt::Debug + MaybeSendSync {
     /// # Errors
     ///
     /// Returns an error if the signing operation fails.
-    fn sign_unchecked<'a>(
+    fn sign_asymmetric_unchecked<'a>(
         &'a self,
         input: &'a [u8],
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<Vec<u8>, BoxedError>> + 'a>>;
-
-    fn public_key_jwk(&self) -> &PublicJwk;
 }
 
-impl<Sgn: std::fmt::Debug + JwsSigningKey + HasPublicKey> DynAsymmetricJwsSigningKey for Sgn {
-    fn key_metadata(&self) -> Cow<'_, SigningKeyMetadata> {
-        self.key_metadata()
+impl<Sgn: AsymmetricJwsSigningKey> DynAsymmetricJwsSigningKey for Sgn {
+    fn asymmetric_key_metadata(&self) -> Cow<'_, AsymmetricSigningKeyMetadata> {
+        self.asymmetric_key_metadata()
     }
 
-    fn sign_unchecked<'a>(
+    fn sign_asymmetric_unchecked<'a>(
         &'a self,
         input: &'a [u8],
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<Vec<u8>, BoxedError>> + 'a>> {
         Box::pin(async {
-            self.sign_unchecked(input)
+            self.sign_asymmetric_unchecked(input)
                 .await
                 .map_err(BoxedError::from_err)
         })
     }
-
-    fn public_key_jwk(&self) -> &PublicJwk {
-        self.public_key_jwk()
-    }
 }
 
-impl JwsSigningKey for BoxedAsymmetricJwsSigningKey {
+impl AsymmetricJwsSigningKey for BoxedAsymmetricJwsSigningKey {
     type Error = BoxedError;
 
-    fn key_metadata(&self) -> Cow<'_, SigningKeyMetadata> {
-        self.inner.key_metadata()
+    fn asymmetric_key_metadata(&self) -> Cow<'_, AsymmetricSigningKeyMetadata> {
+        self.inner.asymmetric_key_metadata()
     }
 
-    async fn sign_unchecked(&self, input: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        self.inner.sign_unchecked(input).await
-    }
-}
-
-impl HasPublicKey for BoxedAsymmetricJwsSigningKey {
-    fn public_key_jwk(&self) -> &PublicJwk {
-        self.inner.public_key_jwk()
+    async fn sign_asymmetric_unchecked(&self, input: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        self.inner.sign_asymmetric_unchecked(input).await
     }
 }

--- a/huskarl-core/src/crypto/signer/asymmetric/mod.rs
+++ b/huskarl-core/src/crypto/signer/asymmetric/mod.rs
@@ -1,1 +1,100 @@
+use std::borrow::Cow;
+
+use snafu::prelude::*;
+
+use crate::{
+    Error,
+    crypto::signer::{
+        JwsSigningKey, SigningKeyMetadata,
+        error::{MismatchedKeyMetadataSnafu, UnderlyingSnafu},
+    },
+    jwk::PublicJwk,
+    platform::{MaybeSend, MaybeSendSync},
+};
+
 pub mod boxed;
+
+/// Asymmetric key metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AsymmetricSigningKeyMetadata {
+    /// The base key metadata of the signer.
+    pub key_metadata: SigningKeyMetadata,
+
+    /// The public key of the signer.
+    pub public_key: PublicJwk,
+}
+
+impl AsymmetricSigningKeyMetadata {
+    /// Returns the JWK thumbprint for the public key.
+    #[must_use]
+    pub fn thumbprint(&self) -> Option<String> {
+        self.public_key.thumbprint()
+    }
+}
+
+/// Trait for asymmetric signers that produce RFC 7515 (JWS) / RFC 7518 (JWA) compatible signatures.
+pub trait AsymmetricJwsSigningKey: std::fmt::Debug + Clone + MaybeSendSync {
+    /// The error type returned by this signer's operations.
+    type Error: Error + 'static;
+
+    /// Returns the key metadata for this signer.
+    fn asymmetric_key_metadata(&self) -> Cow<'_, AsymmetricSigningKeyMetadata>;
+
+    /// Asynchronously signs the given input data and returns the signature.
+    ///
+    /// This should not be called directly, as it does not verify that the metadata
+    /// match the values signed (which could happen due to key updates).
+    ///
+    /// Generally implementations should implement this function, and users will
+    /// call `sign_asymmetric`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the signing operation fails.
+    fn sign_asymmetric_unchecked(
+        &self,
+        input: &[u8],
+    ) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + MaybeSend;
+
+    /// Asynchronously signs the given input data, after verifying the caller's expected key metadata.
+    ///
+    /// The metadata must match the values signed. For example, if a key was rotated,
+    /// then either the key ID or algorithm (or both) could have changed, and this will be
+    /// detected by the `sign` implementation. In that case, the caller should retry the operation
+    /// (this is already done internally in the `OAuth2` exchange code).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`super::JwsSignerError::MismatchedKeyMetadata`] if the key metadata is mismatched, or
+    /// [`super::JwsSignerError::UnderlyingError`] if the signing operation fails.
+    fn sign_asymmetric(
+        &self,
+        input: &[u8],
+        key_metadata: &AsymmetricSigningKeyMetadata,
+    ) -> impl Future<Output = Result<Vec<u8>, super::JwsSignerError<Self::Error>>> + MaybeSend {
+        async move {
+            if &*self.asymmetric_key_metadata() == key_metadata {
+                self.sign_asymmetric_unchecked(input)
+                    .await
+                    .context(UnderlyingSnafu)
+            } else {
+                MismatchedKeyMetadataSnafu.fail()
+            }
+        }
+    }
+}
+
+impl<T: AsymmetricJwsSigningKey> JwsSigningKey for T {
+    type Error = T::Error;
+
+    fn key_metadata(&self) -> Cow<'_, SigningKeyMetadata> {
+        match AsymmetricJwsSigningKey::asymmetric_key_metadata(self) {
+            Cow::Borrowed(m) => Cow::Borrowed(&m.key_metadata),
+            Cow::Owned(m) => Cow::Owned(m.key_metadata),
+        }
+    }
+
+    async fn sign_unchecked(&self, input: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        self.sign_asymmetric_unchecked(input).await
+    }
+}

--- a/huskarl-core/src/crypto/signer/mod.rs
+++ b/huskarl-core/src/crypto/signer/mod.rs
@@ -5,5 +5,7 @@ mod error;
 mod symmetric;
 
 pub use asymmetric::boxed::BoxedAsymmetricJwsSigningKey;
+pub use asymmetric::{AsymmetricJwsSigningKey, AsymmetricSigningKeyMetadata};
 pub use error::JwsSignerError;
-pub use symmetric::{HasPublicKey, JwsSigningKey, SigningKeyMetadata, boxed::BoxedJwsSigningKey};
+pub use symmetric::boxed::BoxedJwsSigningKey;
+pub use symmetric::{JwsSigningKey, SigningKeyMetadata};

--- a/huskarl-core/src/crypto/signer/symmetric/mod.rs
+++ b/huskarl-core/src/crypto/signer/symmetric/mod.rs
@@ -9,13 +9,12 @@ use snafu::prelude::*;
 
 use crate::Error;
 use crate::crypto::signer::error::{MismatchedKeyMetadataSnafu, UnderlyingSnafu};
-use crate::jwk::PublicJwk;
 use crate::platform::{MaybeSend, MaybeSendSync};
 
 /// Key metadata.
 #[derive(Debug, Clone, Builder, PartialEq)]
 pub struct SigningKeyMetadata {
-    /// Returns the JWS algorithm identifier.
+    /// The JWS algorithm identifier.
     ///
     /// This is specifically for use in the JWT `alg` header parameter.
     ///
@@ -24,7 +23,7 @@ pub struct SigningKeyMetadata {
     /// polymorphic algorithm when needed.
     #[builder(into)]
     pub jws_algorithm: String,
-    /// Returns the key ID of the signer.
+    /// The key ID of the signer.
     ///
     /// This is specifically for use in the JWT `kid` header parameter.
     ///
@@ -82,12 +81,6 @@ pub trait JwsSigningKey: std::fmt::Debug + Clone + MaybeSendSync {
             }
         }
     }
-}
-
-/// Trait for asymmetric keys that provides its public key in JWK (RFC 7517) format.
-pub trait HasPublicKey: MaybeSendSync {
-    /// Returns the public key for this asymmetric key as a JSON Web Key.
-    fn public_key_jwk(&self) -> &PublicJwk;
 }
 
 #[cfg(all(

--- a/huskarl-core/src/dpop/implementation.rs
+++ b/huskarl-core/src/dpop/implementation.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use sha2::{Digest as _, Sha256};
 
 use crate::{
-    crypto::signer::{BoxedAsymmetricJwsSigningKey, HasPublicKey, JwsSigningKey},
+    crypto::signer::{AsymmetricJwsSigningKey, BoxedAsymmetricJwsSigningKey, JwsSigningKey},
     dpop::{AuthorizationServerDPoP, ResourceServerDPoP},
     jwt::{JwsSerializationError, Jwt},
     secrets::SecretString,
@@ -23,16 +23,16 @@ type Origin = (Option<Scheme>, Option<String>, Option<u16>);
 
 /// This respresents a grant with the ability to create DPoP-bound tokens and sign requests with them.
 #[derive(Debug, Clone, Builder)]
-pub struct DPoP<Sgn: JwsSigningKey + HasPublicKey = BoxedAsymmetricJwsSigningKey> {
+pub struct DPoP<Sgn: AsymmetricJwsSigningKey = BoxedAsymmetricJwsSigningKey> {
     signer: Sgn,
-    #[builder(skip = signer.public_key_jwk().thumbprint())]
+    #[builder(skip = signer.asymmetric_key_metadata().thumbprint())]
     jwk_thumbprint: Option<String>,
     #[builder(skip)]
     nonce: Arc<Mutex<Option<Arc<String>>>>,
 }
 
-impl<Sgn: JwsSigningKey + HasPublicKey + Clone> AuthorizationServerDPoP for DPoP<Sgn> {
-    type Error = JwsSerializationError<<Sgn as JwsSigningKey>::Error>;
+impl<Sgn: AsymmetricJwsSigningKey> AuthorizationServerDPoP for DPoP<Sgn> {
+    type Error = JwsSerializationError<<Sgn as AsymmetricJwsSigningKey>::Error>;
     type ResourceServerDPoP = ResourceDPoP<Sgn>;
 
     fn jwk_thumbprint(&self) -> Option<&str> {
@@ -63,14 +63,14 @@ impl<Sgn: JwsSigningKey + HasPublicKey + Clone> AuthorizationServerDPoP for DPoP
 
 /// This respresents the ability to create proofs for resource servers from DPoP-bound access tokens.
 #[derive(Debug, Clone, Builder)]
-pub struct ResourceDPoP<Sgn: JwsSigningKey + HasPublicKey> {
+pub struct ResourceDPoP<Sgn: AsymmetricJwsSigningKey> {
     signer: Sgn,
     #[builder(default)]
     nonces: Arc<RwLock<HashMap<Origin, Arc<String>>>>,
 }
 
-impl<Sgn: JwsSigningKey + HasPublicKey> ResourceServerDPoP for ResourceDPoP<Sgn> {
-    type Error = JwsSerializationError<<Sgn as JwsSigningKey>::Error>;
+impl<Sgn: AsymmetricJwsSigningKey> ResourceServerDPoP for ResourceDPoP<Sgn> {
+    type Error = JwsSerializationError<Sgn::Error>;
 
     fn update_nonce(&self, uri: &Uri, nonce: String) {
         let origin = origin_from_uri(uri);
@@ -105,7 +105,7 @@ fn origin_from_uri(uri: &Uri) -> Origin {
     )
 }
 
-async fn sign_proof<Sgn: JwsSigningKey + HasPublicKey>(
+async fn sign_proof<Sgn: AsymmetricJwsSigningKey>(
     signer: &Sgn,
     htm: &Method,
     htu: &Uri,
@@ -134,7 +134,7 @@ async fn sign_proof<Sgn: JwsSigningKey + HasPublicKey>(
     let jwt = Jwt::builder()
         .typ("dpop+jwt")
         .issued_now_expires_after(Duration::from_secs(60))
-        .jwk(signer.public_key_jwk().clone())
+        .jwk(signer.asymmetric_key_metadata().public_key.clone())
         .extra_claims(extra_claims)
         .build();
 

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.1.0"
+version = "0.2.0-pre.0"
 edition = "2024"
 rust-version = "1.92"
 description = "OAuth2 resource server (JWT validation) support for the huskarl ecosystem."

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.1.0"
+version = "0.2.0-pre.0"
 edition = "2024"
 rust-version = "1.92"
 description = '''


### PR DESCRIPTION
AsymmetricJwsSigningKey represents its namesake, and includes the public key in its metadata. Adds a blanket implementation over JwsSigningKey for AsymmetricJwsSigningKey.