### PR TITLE
Add a mandatory dpop_jkt parameter for DPoP signing.

### DIFF
--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improves matching of wasm targets with actual ability.
 - Split out use side of `JwsSigningKey` into `JwsSigner`, update boxed trait.
 - Allow asymmetric signers to have secondary as well as primary signing keys (useful for DPoP key rotation).
+- Generating DPoP proofs requires a known thumbprint to be provided.
 
 ## [0.1.0] - 2026-03-24
 

--- a/huskarl-core/src/dpop/implementation.rs
+++ b/huskarl-core/src/dpop/implementation.rs
@@ -51,14 +51,19 @@ impl<Sgn: AsymmetricJwsSigner> AuthorizationServerDPoP for DPoP<Sgn> {
             .insert(Arc::new(nonce));
     }
 
-    async fn proof(&self, method: &Method, uri: &Uri) -> Result<Option<SecretString>, Self::Error> {
+    async fn proof(
+        &self,
+        method: &Method,
+        uri: &Uri,
+        dpop_jkt: &str,
+    ) -> Result<Option<SecretString>, Self::Error> {
         // See comment in `update_nonce` for why poison recovery is intentional here.
         let nonce = self
             .nonce
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
-        sign_proof(&self.signer, method, uri, None, nonce).await
+        sign_proof(&self.signer, method, uri, None, nonce, dpop_jkt).await
     }
 
     fn to_resource_server_dpop(&self) -> Self::ResourceServerDPoP {
@@ -94,6 +99,7 @@ impl<Sgn: AsymmetricJwsSigner> ResourceServerDPoP for ResourceDPoP<Sgn> {
         method: &Method,
         uri: &Uri,
         access_token: &AccessToken,
+        dpop_jkt: &str,
     ) -> Result<Option<SecretString>, Self::Error> {
         let origin = origin_from_uri(uri);
         // See comment in `update_nonce` for why poison recovery is intentional here.
@@ -103,7 +109,15 @@ impl<Sgn: AsymmetricJwsSigner> ResourceServerDPoP for ResourceDPoP<Sgn> {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(&origin)
             .cloned();
-        sign_proof(&self.signer, method, uri, Some(access_token), nonce).await
+        sign_proof(
+            &self.signer,
+            method,
+            uri,
+            Some(access_token),
+            nonce,
+            dpop_jkt,
+        )
+        .await
     }
 }
 
@@ -121,6 +135,7 @@ async fn sign_proof<Sgn: AsymmetricJwsSigner>(
     htu: &Uri,
     access_token: Option<&AccessToken>,
     nonce: Option<Arc<String>>,
+    dpop_jkt: &str,
 ) -> Result<Option<SecretString>, JwsSerializationError<Sgn::Error>> {
     #[derive(Debug, Clone, Serialize)]
     struct DPoPClaims<'a> {
@@ -141,14 +156,20 @@ async fn sign_proof<Sgn: AsymmetricJwsSigner>(
         nonce,
     };
 
+    let metadata = signer
+        .key_metadata_by_thumbprint(dpop_jkt)
+        .ok_or(JwsSerializationError::NoMatchingKeyForThumbprint)?;
+
     let jwt = Jwt::builder()
         .typ("dpop+jwt")
         .issued_now_expires_after(Duration::from_mins(1))
-        .jwk(signer.asymmetric_key_metadata().public_key.clone())
+        .jwk(metadata.public_key.clone())
         .extra_claims(extra_claims)
         .build();
 
-    jwt.to_jws_compact(signer).await.map(Some)
+    jwt.to_jws_compact_with_thumbprint(signer, dpop_jkt)
+        .await
+        .map(Some)
 }
 
 /// Normalizes a URI for inclusion in a `DPoP` proof by stripping query and fragment components.

--- a/huskarl-core/src/dpop/mod.rs
+++ b/huskarl-core/src/dpop/mod.rs
@@ -42,6 +42,7 @@ pub trait AuthorizationServerDPoP: Clone + MaybeSendSync {
         &self,
         method: &Method,
         uri: &Uri,
+        dpop_jkt: &str,
     ) -> impl Future<Output = Result<Option<SecretString>, Self::Error>> + MaybeSend;
 
     /// Returns the corresponding resource server variant.
@@ -61,8 +62,13 @@ impl<D: AuthorizationServerDPoP> AuthorizationServerDPoP for Arc<D> {
         self.as_ref().update_nonce(nonce);
     }
 
-    async fn proof(&self, method: &Method, uri: &Uri) -> Result<Option<SecretString>, Self::Error> {
-        self.as_ref().proof(method, uri).await
+    async fn proof(
+        &self,
+        method: &Method,
+        uri: &Uri,
+        dpop_jkt: &str,
+    ) -> Result<Option<SecretString>, Self::Error> {
+        self.as_ref().proof(method, uri, dpop_jkt).await
     }
 
     fn to_resource_server_dpop(&self) -> Self::ResourceServerDPoP {
@@ -84,5 +90,6 @@ pub trait ResourceServerDPoP: MaybeSendSync {
         method: &Method,
         uri: &Uri,
         access_token: &AccessToken,
+        dpop_jkt: &str,
     ) -> impl Future<Output = Result<Option<SecretString>, Self::Error>> + MaybeSend;
 }

--- a/huskarl-core/src/dpop/no_dpop.rs
+++ b/huskarl-core/src/dpop/no_dpop.rs
@@ -26,6 +26,7 @@ impl AuthorizationServerDPoP for NoDPoP {
         &self,
         _method: &Method,
         _uri: &Uri,
+        _dpop_jkt: &str,
     ) -> Result<Option<SecretString>, Self::Error> {
         Ok(None)
     }
@@ -45,6 +46,7 @@ impl ResourceServerDPoP for NoDPoP {
         _method: &Method,
         _uri: &Uri,
         _access_token: &AccessToken,
+        _dpop_jkt: &str,
     ) -> Result<Option<SecretString>, Self::Error> {
         Ok(None)
     }


### PR DESCRIPTION
This should be the thumbprint of the bound key used to request the token.