### PR TITLE
huskarl-core: Make extra claims mandatory, rename field to `claims`, type to `Claims`.

### DIFF
--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changes
+
+- Breaking: makes claims a non-optional type, renames the field to `claims`, type to `Claims`.
+
 ## [0.2.0] - 2026-04-06
 
 ### Additions

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.2.0"
+version = "0.3.0-pre.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-core/src/client_auth/jwt_bearer.rs
+++ b/huskarl-core/src/client_auth/jwt_bearer.rs
@@ -107,6 +107,7 @@ impl<Sgn: JwsSignerSelector> ClientAuthentication for JwtBearer<Sgn> {
             .issuer(client_id)
             .subject(self.subject.as_deref().unwrap_or(client_id))
             .issued_now_expires_after(self.expires_after)
+            .claims(())
             .build();
 
         Ok(AuthenticationParams::builder()

--- a/huskarl-core/src/dpop/implementation.rs
+++ b/huskarl-core/src/dpop/implementation.rs
@@ -177,7 +177,7 @@ async fn sign_proof<Sgn: AsymmetricJwsSigner>(
         .typ("dpop+jwt")
         .issued_now_expires_after(Duration::from_mins(1))
         .jwk(signer.public_key_jwk().into_owned())
-        .extra_claims(extra_claims)
+        .claims(extra_claims)
         .build();
 
     jwt.to_jws_compact(signer).await.map(Some)

--- a/huskarl-core/src/jwt/builder.rs
+++ b/huskarl-core/src/jwt/builder.rs
@@ -9,7 +9,7 @@ use crate::{
     crypto::signer::JwsSigner,
     jwk::PublicJwk,
     jwt::{
-        builder::jwt_builder::{SetExtraClaims, SetExtraHeaders},
+        builder::jwt_builder::{SetClaims, SetExtraHeaders},
         structure::{JwtClaims, JwtHeader},
     },
     platform::{Duration, SystemTime, SystemTimeError},
@@ -27,10 +27,10 @@ use crate::{
     start_fn(vis = "", name = "builder_internal"),
     generics(setters(name = "with_{}"))
 )]
-pub struct Jwt<'a, ExtraHeaders, ExtraClaims>
+pub struct Jwt<'a, ExtraHeaders = (), Claims = ()>
 where
     ExtraHeaders: Serialize + Clone,
-    ExtraClaims: Serialize + Clone,
+    Claims: Serialize + Clone,
 {
     /// The type (`typ`) of the JWT.
     #[builder(default = "JWT", into)]
@@ -58,9 +58,9 @@ where
     /// Extra key/value pairs in the JWT protected header not included above.
     #[builder(setters(vis = "", name = "extra_headers_internal"))]
     pub extra_headers: Option<ExtraHeaders>,
-    /// Extra key/value pairs in the JWT claims not included above.
-    #[builder(setters(vis = "", name = "extra_claims_internal"))]
-    pub extra_claims: Option<ExtraClaims>,
+    /// Additional claims beyond the registered JWT claim set.
+    #[builder(setters(vis = "", name = "claims_internal"))]
+    pub claims: Claims,
 }
 
 impl<'a> Jwt<'a, (), ()> {
@@ -70,17 +70,16 @@ impl<'a> Jwt<'a, (), ()> {
     }
 }
 
-impl<'a, ExtraHeaders, ExtraClaims, S: jwt_builder::State>
-    JwtBuilder<'a, ExtraHeaders, ExtraClaims, S>
+impl<'a, ExtraHeaders, Claims, S: jwt_builder::State> JwtBuilder<'a, ExtraHeaders, Claims, S>
 where
     ExtraHeaders: Serialize + Clone,
-    ExtraClaims: Serialize + Clone,
+    Claims: Serialize + Clone,
 {
     /// Sets a single audience value for the JWT.
     pub fn audience(
         self,
         audience: impl Into<String>,
-    ) -> JwtBuilder<'a, ExtraHeaders, ExtraClaims, jwt_builder::SetAudiences<S>>
+    ) -> JwtBuilder<'a, ExtraHeaders, Claims, jwt_builder::SetAudiences<S>>
     where
         S::Audiences: jwt_builder::IsUnset,
     {
@@ -92,9 +91,7 @@ where
     /// # Panics
     ///
     /// This call panics if the reported time is before the epoch.
-    pub fn issued_now(
-        self,
-    ) -> JwtBuilder<'a, ExtraHeaders, ExtraClaims, jwt_builder::SetIssuedAt<S>>
+    pub fn issued_now(self) -> JwtBuilder<'a, ExtraHeaders, Claims, jwt_builder::SetIssuedAt<S>>
     where
         S::IssuedAt: jwt_builder::IsUnset,
     {
@@ -109,12 +106,7 @@ where
     pub fn issued_now_expires_after(
         self,
         after: Duration,
-    ) -> JwtBuilder<
-        'a,
-        ExtraHeaders,
-        ExtraClaims,
-        jwt_builder::SetExpiration<jwt_builder::SetIssuedAt<S>>,
-    >
+    ) -> JwtBuilder<'a, ExtraHeaders, Claims, jwt_builder::SetExpiration<jwt_builder::SetIssuedAt<S>>>
     where
         S::IssuedAt: jwt_builder::IsUnset,
         S::Expiration: jwt_builder::IsUnset,
@@ -123,20 +115,17 @@ where
         self.issued_at(now).expiration(now + after)
     }
 
-    /// Sets extra claims for the JWT, replacing the current extra-claims type parameter.
-    pub fn extra_claims<E2>(self, claims: E2) -> JwtBuilder<'a, ExtraHeaders, E2, SetExtraClaims<S>>
+    /// Sets additional claims for the JWT, replacing the current claims type parameter.
+    pub fn claims<E2>(self, claims: E2) -> JwtBuilder<'a, ExtraHeaders, E2, SetClaims<S>>
     where
         E2: Serialize + Clone,
-        S::ExtraClaims: jwt_builder::IsUnset,
+        S::Claims: jwt_builder::IsUnset,
     {
-        self.with_extra_claims::<E2>().extra_claims_internal(claims)
+        self.with_claims::<E2>().claims_internal(claims)
     }
 
     /// Sets extra headers for the JWT, replacing the current extra-headers type parameter.
-    pub fn extra_headers<E2>(
-        self,
-        headers: E2,
-    ) -> JwtBuilder<'a, E2, ExtraClaims, SetExtraHeaders<S>>
+    pub fn extra_headers<E2>(self, headers: E2) -> JwtBuilder<'a, E2, Claims, SetExtraHeaders<S>>
     where
         E2: Serialize + Clone,
         S::ExtraHeaders: jwt_builder::IsUnset,
@@ -204,10 +193,10 @@ impl<SgnErr: crate::Error> crate::Error for JwsSerializationError<SgnErr> {
     }
 }
 
-impl<ExtraHeaders, ExtraClaims> Jwt<'_, ExtraHeaders, ExtraClaims>
+impl<ExtraHeaders, Claims> Jwt<'_, ExtraHeaders, Claims>
 where
     ExtraHeaders: Serialize + Clone,
-    ExtraClaims: Serialize + Clone,
+    Claims: Serialize + Clone,
 {
     /// Creates a string using the JWS compact serialization.
     ///
@@ -285,7 +274,7 @@ where
             nbf,
             jti: self.jti.as_deref().map(Cow::Borrowed),
             cnf: None,
-            extra_claims: self.extra_claims.as_ref().map(Cow::Borrowed),
+            claims: Cow::Borrowed(&self.claims),
         };
         let jwt_header_json = serde_json::to_vec(&jwt_header).context(EncodeHeaderSnafu)?;
         let jwt_header_b64 = BASE64_URL_SAFE_NO_PAD.encode(&jwt_header_json);

--- a/huskarl-core/src/jwt/parse.rs
+++ b/huskarl-core/src/jwt/parse.rs
@@ -101,9 +101,6 @@ mod tests {
         assert_eq!(jws.claims.exp, Some(1_300_819_380));
         assert_eq!(jws.claims.nbf, None);
         assert_eq!(jws.claims.jti, None);
-        assert_eq!(
-            jws.claims.extra_claims,
-            Some(Cow::Owned(TestClaims { is_root: true }))
-        );
+        assert_eq!(jws.claims.claims, Cow::Owned(TestClaims { is_root: true }));
     }
 }

--- a/huskarl-core/src/jwt/structure.rs
+++ b/huskarl-core/src/jwt/structure.rs
@@ -214,8 +214,8 @@ pub struct JwtHeader<'a, ExtraHeaders: Clone> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "ExtraClaims: serde::de::Deserialize<'de>"))]
-pub struct JwtClaims<'a, ExtraClaims: Clone> {
+#[serde(bound(deserialize = "Claims: serde::de::Deserialize<'de>"))]
+pub struct JwtClaims<'a, Claims: Clone> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iss: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -250,6 +250,7 @@ pub struct JwtClaims<'a, ExtraClaims: Clone> {
     /// Key confirmation claim (RFC 7800). Binds the token to a `DPoP` key or mTLS certificate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cnf: Option<ConfirmationClaim>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub extra_claims: Option<Cow<'a, ExtraClaims>>,
+    /// Additional claims beyond the registered JWT claim set.
+    #[serde(flatten)]
+    pub claims: Cow<'a, Claims>,
 }

--- a/huskarl-core/src/jwt/validator.rs
+++ b/huskarl-core/src/jwt/validator.rs
@@ -385,10 +385,10 @@ impl JwtValidator {
                 .map(|exp| SystemTime::UNIX_EPOCH + Duration::from_secs(exp)),
             jti: parsed_jwt.claims.jti.map(Into::into),
             cnf: parsed_jwt.claims.cnf,
-            claims: parsed_jwt.claims.extra_claims.map(|c| match c {
+            claims: match parsed_jwt.claims.claims {
                 std::borrow::Cow::Borrowed(c) => c.clone(),
                 std::borrow::Cow::Owned(c) => c,
-            }),
+            },
         })
     }
 
@@ -408,7 +408,7 @@ impl JwtValidator {
 
 /// A validated JWT, containing the parsed claims and other metadata.
 #[derive(Debug)]
-pub struct ValidatedJwt<C> {
+pub struct ValidatedJwt<Claims> {
     /// The issuer of the JWT, if present.
     pub issuer: Option<String>,
     /// The subject of the JWT, if present.
@@ -426,15 +426,15 @@ pub struct ValidatedJwt<C> {
     /// Binds the token to a `DPoP` key (`jkt`, RFC 9449) or mTLS certificate
     /// (`x5t#S256`, RFC 8705). Independent of the token profile and claims type.
     pub cnf: Option<ConfirmationClaim>,
-    /// The claims of the JWT, if present.
-    pub claims: Option<C>,
+    /// Additional claims beyond the registered JWT claim set.
+    pub claims: Claims,
 }
 
-impl<C> ValidatedJwt<C> {
+impl<Claims> ValidatedJwt<Claims> {
     /// Maps the claims of the JWT using the provided function.
     pub fn map_claims<C1, F>(self, f: F) -> ValidatedJwt<C1>
     where
-        F: FnOnce(C) -> C1,
+        F: FnOnce(Claims) -> C1,
     {
         ValidatedJwt {
             issuer: self.issuer,
@@ -444,7 +444,7 @@ impl<C> ValidatedJwt<C> {
             issued_at: self.issued_at,
             expiration: self.expiration,
             cnf: self.cnf,
-            claims: self.claims.map(f),
+            claims: f(self.claims),
         }
     }
 }


### PR DESCRIPTION
This simplifies the use of JWT claims; before, there was always an Option layer that had to be unwrapped. Now, the choice of Option is still there, by making that your claim type.