### PR TITLE
huskarl-core: Add `ExtraClaims` error, and return it if the JWT extra claims could not be parsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
  "http",
  "httpmock",
  "huskarl",
- "huskarl-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.3.0",
  "huskarl-crypto-native",
  "huskarl-crypto-webcrypto",
  "huskarl-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1107,35 +1107,6 @@ dependencies = [
  "sha2",
  "snafu",
  "subtle",
- "tokio",
- "url",
- "wasm-bindgen-test",
- "web-time",
-]
-
-[[package]]
-name = "huskarl-core"
-version = "0.3.0"
-dependencies = [
- "arc-swap",
- "base64",
- "bon",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "getrandom 0.4.2",
- "gloo-timers",
- "hex",
- "http",
- "httpmock",
- "metrics",
- "rand 0.10.1",
- "reqwest",
- "secrecy",
- "serde",
- "serde_json",
- "sha2",
- "snafu",
  "tokio",
  "url",
  "wasm-bindgen-test",
@@ -1170,6 +1141,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "huskarl-core"
+version = "0.4.0-pre.1"
+dependencies = [
+ "arc-swap",
+ "base64",
+ "bon",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "getrandom 0.4.2",
+ "gloo-timers",
+ "hex",
+ "http",
+ "httpmock",
+ "metrics",
+ "rand 0.10.1",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2",
+ "snafu",
+ "tokio",
+ "url",
+ "wasm-bindgen-test",
+ "web-time",
+]
+
+[[package]]
 name = "huskarl-crypto-native"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,7 +1178,7 @@ dependencies = [
  "aes-gcm",
  "ed25519-dalek",
  "hmac",
- "huskarl-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.3.0",
  "p256",
  "p384",
  "pkcs8",
@@ -1197,7 +1197,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20a9e97e3e0617a5093527c95a04044e86e132d314978d9943107882749cf75"
 dependencies = [
- "huskarl-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.3.0",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -1242,7 +1242,7 @@ dependencies = [
  "bon",
  "bytes",
  "http",
- "huskarl-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.3.0",
  "reqwest",
  "snafu",
 ]
@@ -1259,7 +1259,7 @@ dependencies = [
  "gloo-timers",
  "http",
  "httpmock",
- "huskarl-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.3.0",
  "huskarl-crypto-native",
  "huskarl-crypto-webcrypto",
  "huskarl-reqwest",
@@ -1278,7 +1278,7 @@ name = "huskarl-testkit"
 version = "0.1.0"
 dependencies = [
  "bon",
- "huskarl-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "huskarl-core 0.3.0",
  "reqwest",
  "serde",
  "tokio",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changes
+
+- Breaking: add an ExtraClaims error when parsing a JWT, which is returned if the custom claim type cannot be parsed into.
+
 ## [0.3.0] - 2026-04-28
 
 ### Changes

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.3.0"
+version = "0.4.0-pre.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-core/src/jwt/validator.rs
+++ b/huskarl-core/src/jwt/validator.rs
@@ -394,6 +394,12 @@ impl JwtValidator {
 
     /// Validate a JWT token, returning a [`ValidatedJwt`] on success.
     ///
+    /// Uses two-phase parsing: the JWT is first parsed and validated structurally
+    /// (signature, standard claims), then the extra claims are deserialized into
+    /// the target type `C`. If the token is valid but does not contain the required
+    /// extra claims, returns [`JwtValidationError::ExtraClaims`] instead of
+    /// [`JwtValidationError::Parse`].
+    ///
     /// # Errors
     ///
     /// Returns a [`JwtValidationError`] if the token is invalid.
@@ -401,8 +407,9 @@ impl JwtValidator {
         &self,
         token: &str,
     ) -> Result<ValidatedJwt<C>, JwtValidationError> {
-        let parsed_jwt = parse_compact_jws::<(), _>(token).context(ParseSnafu)?;
-        self.validate_parsed_jws(parsed_jwt).await
+        let parsed_jwt = parse_compact_jws::<(), serde_json::Value>(token).context(ParseSnafu)?;
+        let validated = self.validate_parsed_jws(parsed_jwt).await?;
+        validated.try_map_claims(|value| serde_json::from_value(value).context(ExtraClaimsSnafu))
     }
 }
 
@@ -446,6 +453,27 @@ impl<Claims> ValidatedJwt<Claims> {
             cnf: self.cnf,
             claims: f(self.claims),
         }
+    }
+
+    /// Maps the claims of the JWT using a fallible function.
+    ///
+    /// # Errors
+    ///
+    /// Returns the eror of the mapper, if it fails.
+    pub fn try_map_claims<C1, E, F>(self, f: F) -> Result<ValidatedJwt<C1>, E>
+    where
+        F: FnOnce(Claims) -> Result<C1, E>,
+    {
+        Ok(ValidatedJwt {
+            issuer: self.issuer,
+            subject: self.subject,
+            audience: self.audience,
+            jti: self.jti,
+            issued_at: self.issued_at,
+            expiration: self.expiration,
+            cnf: self.cnf,
+            claims: f(self.claims)?,
+        })
     }
 }
 
@@ -527,5 +555,10 @@ pub enum JwtValidationError {
     JtiCheck {
         /// The underlying error.
         source: BoxedError,
+    },
+    /// The token is structurally valid but does not contain the required extra claims.
+    ExtraClaims {
+        /// The underlying deserialization error.
+        source: serde_json::Error,
     },
 }


### PR DESCRIPTION
This allows downstream callers to differentiate between not being able to parse core parts of the JWT, and not being able to parse into a user-chosen serialization target.