### PR TITLE
Run min-versions with --no-default-features for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo +nightly update -Z minimal-versions
-      - run: cargo build --workspace
+      - run: cargo build --workspace --no-default-features
 
   wasm:
     name: WASM


### PR DESCRIPTION
huskarl-crypto-native RC deps break min-versions for now, so skip checking with crypto deps for now.