### PR TITLE
Add RP, frontchannel and backchannel logout, session mgmt, userinfo to authorization server metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.5.1"
+version = "0.6.0-pre.1"
 dependencies = [
  "arc-swap",
  "base64",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Additions
+
+ - Added some extra OpenID fields to authorization server metadata for logout and userinfo.
+
 ## [0.5.1] - 2026-05-21
 
 ### Additions

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.5.1"
+version = "0.6.0-pre.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-core/src/server_metadata.rs
+++ b/huskarl-core/src/server_metadata.rs
@@ -25,10 +25,13 @@ pub struct MtlsEndpointAliases {
     pub pushed_authorization_request_endpoint: Option<EndpointUrl>,
     /// The mTLS alias for the registration endpoint.
     pub registration_endpoint: Option<EndpointUrl>,
+    /// The mTLS alias for the userinfo endpoint.
+    pub userinfo_endpoint: Option<EndpointUrl>,
 }
 
 /// Authorization server metadata.
 #[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct AuthorizationServerMetadata {
     /// The authorization server's issuer identifier.
     pub issuer: String,
@@ -113,6 +116,38 @@ pub struct AuthorizationServerMetadata {
     /// Indicates support for an `iss` identifier in the authorization endpoint response (RFC 9207 §3).
     #[serde(default)]
     pub authorization_response_iss_parameter_supported: bool,
+    /**
+     * `OpenID` Connect Core 1.0
+     * */
+    /// The URL of the `OpenID` Connect userinfo endpoint.
+    pub userinfo_endpoint: Option<EndpointUrl>,
+    /**
+     * `OpenID` Connect Session Management 1.0
+     * */
+    /// URL of an OP iframe that supports cross-origin communications for session state information
+    /// with the RP Client, using the HTML5 postMessage API.
+    pub check_session_iframe: Option<EndpointUrl>,
+    /**
+     * `OpenID` Connect RP-Initiated Logout 1.0
+     * */
+    /// URL at the OP to which an RP can perform a redirect to request that the End-User be logged out at the OP.
+    pub end_session_endpoint: Option<EndpointUrl>,
+    /**
+     * `OpenID` Connect Front-Channel Logout 1.0
+     * */
+    /// Boolean value specifying whether the OP supports HTTP-based logout, with true indicating support.
+    #[serde(default)]
+    pub frontchannel_logout_supported: bool,
+    /**
+     * `OpenID` Connect Back-Channel Logout 1.0
+     * */
+    /// Boolean value specifying whether the OP supports back-channel logout, with true indicating support.
+    #[serde(default)]
+    pub backchannel_logout_supported: bool,
+    /// Boolean value specifying whether the OP can pass a `sid` (session ID) Claim in the Logout Token
+    /// to identify the RP session with the OP.
+    #[serde(default)]
+    pub backchannel_logout_session_supported: bool,
 }
 
 #[bon]


### PR DESCRIPTION
This is questionable in a way, as these are actually OpenID specifications rather than RFCs. But for practicality, it's probably simpler to have one definition.

Users who are interested in these fields probably should call the OIDC discovery endpoint, since they might not be set at the authorization server metadata endpoint.