### PR TITLE
Expand JWK types to include public/private variants.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "url",
  "wasm-bindgen-test",
  "web-time",
+ "zeroize",
 ]
 
 [[package]]

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added some extra OpenID fields to authorization server metadata for logout and userinfo.
  - Added a max JTI length check to the JWT validator.
  - Added MultiKeySigner that allows signer selection by thumbprint.
+ - Breaking: Expanded JWK code to public/private types and conversions between them.
 
 ### Changes
 

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -40,6 +40,7 @@ sha2 = { workspace = true, default-features = false }
 snafu = { workspace = true }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 url = { workspace = true, optional = true }
+zeroize = { version = "1", default-features = false }
 
 ### Dependencies available on native and WASI (not browser WASM)
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]

--- a/huskarl-core/src/crypto/signer/multi.rs
+++ b/huskarl-core/src/crypto/signer/multi.rs
@@ -39,7 +39,7 @@ impl<S: AsymmetricJwsSigner> AsymmetricJwsSignerSelector for MultiKeySigner<S> {
     fn select_signer_by_thumbprint(&self, thumbprint: &str) -> Option<S> {
         let all = std::iter::once(&self.default).chain(self.additional.iter());
         for signer in all {
-            if signer.public_key_jwk().thumbprint().as_deref() == Some(thumbprint) {
+            if signer.public_key_jwk().thumbprint() == thumbprint {
                 return Some(signer.clone());
             }
         }

--- a/huskarl-core/src/dpop/implementation.rs
+++ b/huskarl-core/src/dpop/implementation.rs
@@ -50,7 +50,7 @@ impl<Sgn: AsymmetricJwsSignerSelector> AuthorizationServerDPoP for DPoP<Sgn> {
     }
 
     fn get_current_thumbprint(&self) -> Option<String> {
-        self.signer.select_signer().public_key_jwk().thumbprint()
+        Some(self.signer.select_signer().public_key_jwk().thumbprint())
     }
 
     async fn proof(

--- a/huskarl-core/src/jwk/mod.rs
+++ b/huskarl-core/src/jwk/mod.rs
@@ -39,12 +39,15 @@ use bon::Builder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 pub use source::JwksSource;
+use zeroize::Zeroize;
 
-use crate::jwk::serde_utils::{base64url, base64url_uint, trim_leading_zeros};
+use crate::jwk::serde_utils::{
+    base64url, base64url_uint, option_base64url, option_base64url_uint, trim_leading_zeros,
+};
 
 /// A JSON Web Key Set (RFC 7517 §5).
 #[non_exhaustive]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct PublicJwks {
     /// List of keys
     pub keys: Vec<PublicJwk>,
@@ -61,11 +64,7 @@ impl PublicJwks {
 /// A JSON Web Key (RFC 7517 §4).
 #[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize, Builder, PartialEq, Clone)]
-#[builder(derive(Into), builder_type(
-    doc {
-        /// Builder for creating a [`PublicJwk`] value (call `build()` or `into()` to finish).
-    }
-))]
+#[builder(derive(Into))]
 pub struct PublicJwk {
     /// The key details.
     #[builder(into)]
@@ -98,22 +97,17 @@ pub struct PublicJwk {
 }
 
 impl PublicJwk {
-    /// Returns the JWK thumbprint for the key if it is a known type.
+    /// Returns the JWK thumbprint (RFC 7638) for the key.
     #[must_use]
-    pub fn thumbprint(&self) -> Option<String> {
+    pub fn thumbprint(&self) -> String {
         let canonical_form = match &self.key {
-            PublicKey::Rsa(rsa_public_key) => Some(rsa_public_key.canonical_form()),
-            PublicKey::Ec(ec_public_key) => Some(ec_public_key.canonical_form()),
-            PublicKey::Okp(okp_public_key) => Some(okp_public_key.canonical_form()),
-            PublicKey::UnknownOrPrivate => None,
+            PublicKey::Rsa(rsa) => rsa.canonical_form(),
+            PublicKey::Ec(ec) => ec.canonical_form(),
+            PublicKey::Okp(okp) => okp.canonical_form(),
         };
-
-        canonical_form.map(|canonical| {
-            let mut hasher = Sha256::new();
-            hasher.update(canonical.as_bytes());
-            let hash = hasher.finalize();
-            URL_SAFE_NO_PAD.encode(hash)
-        })
+        let mut hasher = Sha256::new();
+        hasher.update(canonical_form.as_bytes());
+        URL_SAFE_NO_PAD.encode(hasher.finalize())
     }
 }
 
@@ -176,19 +170,12 @@ pub enum PublicKey {
     /// An Octet Key Pair public key.
     #[serde(rename = "OKP")]
     Okp(OkpPublicKey),
-    /// Unknown or private key.
-    #[serde(skip, other)]
-    UnknownOrPrivate,
 }
 
 /// An RSA public key.
 #[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize, Builder, PartialEq, Clone)]
-#[builder(derive(Into), builder_type(
-    doc {
-        /// Builder for creating an [`RsaPublicKey`] value (call `build()` or `into()` to finish).
-    }
-))]
+#[builder(derive(Into))]
 pub struct RsaPublicKey {
     /// The n coordinate of the key.
     #[builder(with = <_>::from_iter)]
@@ -230,11 +217,7 @@ where
 /// Technically, the `y` field is optional, but all currently defined `EC`-type keys require a value.
 #[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize, Builder, PartialEq, Clone)]
-#[builder(derive(Into), builder_type(
-    doc {
-        /// Builder for creating a [`EcPublicKey`] value (call `build()` or `into()` to finish).
-    }
-))]
+#[builder(derive(Into))]
 pub struct EcPublicKey {
     /// The curve type.
     #[builder(into)]
@@ -279,11 +262,7 @@ where
 /// Parameters are defined in RFC 8037 §2.
 #[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize, Builder, PartialEq, Clone)]
-#[builder(derive(Into), builder_type(
-    doc {
-        /// Builder for creating a [`OkpPublicKey`] value (call `build()` or `into()` to finish).
-    }
-))]
+#[builder(derive(Into))]
 pub struct OkpPublicKey {
     /// The curve type.
     #[builder(into)]
@@ -318,55 +297,898 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+// ---------------------------------------------------------------------------
+// Private-key JWK types
+// ---------------------------------------------------------------------------
 
-    use super::*;
+/// Additional prime factor info for multi-prime RSA keys (RFC 7518 §6.3.2.7).
+///
+/// Each entry represents a prime factor beyond `p` and `q`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Builder, PartialEq, Clone)]
+pub struct OtherPrimeInfo {
+    /// The additional prime factor.
+    #[builder(with = <_>::from_iter)]
+    #[serde(with = "base64url_uint")]
+    pub r: Vec<u8>,
+    /// The CRT exponent for this prime factor.
+    #[builder(with = <_>::from_iter)]
+    #[serde(with = "base64url_uint")]
+    pub d: Vec<u8>,
+    /// The CRT coefficient for this prime factor.
+    #[builder(with = <_>::from_iter)]
+    #[serde(with = "base64url_uint")]
+    pub t: Vec<u8>,
+}
 
-    // Example public key from https://www.rfc-editor.org/rfc/rfc7517.html#appendix-A.1
-    #[test]
-    fn test_parse_jwks_appendix_a1() {
-        let jwks_json = r#"{"keys":[
-            {"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use":"enc","kid":"1"},
-            {"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","alg":"RS256","kid":"2011-04-29"}
-        ]}"#;
-
-        let jwks: PublicJwks = serde_json::from_str(jwks_json).unwrap();
-
-        let key1 = PublicJwk::builder()
-            .key(
-                EcPublicKey::builder()
-                    .crv("P-256")
-                    .x(BASE64_URL_SAFE_NO_PAD
-                        .decode("MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4")
-                        .unwrap())
-                    .y(BASE64_URL_SAFE_NO_PAD
-                        .decode("4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM")
-                        .unwrap()),
-            )
-            .key_use(KeyUse::Encrypt)
-            .kid("1")
-            .build();
-
-        let key2 = PublicJwk::builder().key(
-            RsaPublicKey::builder()
-                .n(BASE64_URL_SAFE_NO_PAD.decode(
-                    "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
-                ).unwrap())
-                .e(BASE64_URL_SAFE_NO_PAD.decode("AQAB").unwrap())
-        )
-        .algorithm("RS256")
-        .kid("2011-04-29")
-        .build();
-
-        assert_eq!(jwks.keys, vec![key1, key2]);
-    }
-
-    #[test]
-    fn test_unknown_curve_parses() {
-        // Unknown curve should parse successfully
-        let unknown_curve = r#"{"kty":"EC","crv":"brainpoolP256r1","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"}"#;
-        let _: PublicJwk = serde_json::from_str(unknown_curve).unwrap();
+impl std::fmt::Debug for OtherPrimeInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OtherPrimeInfo").finish_non_exhaustive()
     }
 }
+
+impl Zeroize for OtherPrimeInfo {
+    fn zeroize(&mut self) {
+        self.r.zeroize();
+        self.d.zeroize();
+        self.t.zeroize();
+    }
+}
+
+impl Drop for OtherPrimeInfo {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// An RSA private key (RFC 7518 §6.3).
+///
+/// Composes [`RsaPublicKey`] with the private exponent and optional CRT parameters.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Builder, PartialEq, Clone)]
+#[builder(derive(Into))]
+pub struct RsaKey {
+    /// The public key components.
+    #[serde(flatten)]
+    #[builder(into)]
+    pub public: RsaPublicKey,
+    /// The private exponent.
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url_uint",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub d: Option<Vec<u8>>,
+    /// First prime factor (CRT parameter, RFC 7518 §6.3.2).
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url_uint",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub p: Option<Vec<u8>>,
+    /// Second prime factor (CRT parameter).
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url_uint",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub q: Option<Vec<u8>>,
+    /// First factor CRT exponent.
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url_uint",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub dp: Option<Vec<u8>>,
+    /// Second factor CRT exponent.
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url_uint",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub dq: Option<Vec<u8>>,
+    /// First CRT coefficient.
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url_uint",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub qi: Option<Vec<u8>>,
+    /// Additional prime factors for multi-prime RSA (RFC 7518 §6.3.2.7).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub oth: Option<Vec<OtherPrimeInfo>>,
+}
+
+impl std::fmt::Debug for RsaKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RsaKey")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for RsaKey {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+        self.p.zeroize();
+        self.q.zeroize();
+        self.dp.zeroize();
+        self.dq.zeroize();
+        self.qi.zeroize();
+        if let Some(oth) = &mut self.oth {
+            for info in oth.iter_mut() {
+                info.zeroize();
+            }
+        }
+    }
+}
+
+impl Drop for RsaKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl From<RsaKey> for RsaPublicKey {
+    fn from(mut key: RsaKey) -> Self {
+        std::mem::replace(
+            &mut key.public,
+            RsaPublicKey {
+                n: vec![],
+                e: vec![],
+            },
+        )
+    }
+}
+
+impl From<RsaKey> for Key {
+    fn from(value: RsaKey) -> Self {
+        Self::Rsa(value)
+    }
+}
+
+impl<S: rsa_key_builder::State> From<RsaKeyBuilder<S>> for Key
+where
+    S: rsa_key_builder::IsComplete,
+{
+    fn from(value: RsaKeyBuilder<S>) -> Self {
+        Self::Rsa(value.build())
+    }
+}
+
+/// An Elliptic Curve private key (RFC 7518 §6.2).
+///
+/// Composes [`EcPublicKey`] with the private key parameter `d`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Builder, PartialEq, Clone)]
+#[builder(derive(Into))]
+pub struct EcKey {
+    /// The public key components.
+    #[serde(flatten)]
+    #[builder(into)]
+    pub public: EcPublicKey,
+    /// The private key value.
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub d: Option<Vec<u8>>,
+}
+
+impl std::fmt::Debug for EcKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EcKey")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for EcKey {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+    }
+}
+
+impl Drop for EcKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl From<EcKey> for EcPublicKey {
+    fn from(mut key: EcKey) -> Self {
+        std::mem::replace(
+            &mut key.public,
+            EcPublicKey {
+                crv: String::new(),
+                x: vec![],
+                y: vec![],
+            },
+        )
+    }
+}
+
+impl From<EcKey> for Key {
+    fn from(value: EcKey) -> Self {
+        Self::Ec(value)
+    }
+}
+
+impl<S: ec_key_builder::State> From<EcKeyBuilder<S>> for Key
+where
+    S: ec_key_builder::IsComplete,
+{
+    fn from(value: EcKeyBuilder<S>) -> Self {
+        Self::Ec(value.build())
+    }
+}
+
+/// An Octet Key Pair private key (RFC 8037 §2).
+///
+/// Composes [`OkpPublicKey`] with the private key parameter `d`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Builder, PartialEq, Clone)]
+#[builder(derive(Into))]
+pub struct OkpKey {
+    /// The public key components.
+    #[serde(flatten)]
+    #[builder(into)]
+    pub public: OkpPublicKey,
+    /// The private key value.
+    #[builder(with = <_>::from_iter)]
+    #[serde(
+        with = "option_base64url",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub d: Option<Vec<u8>>,
+}
+
+impl std::fmt::Debug for OkpKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OkpKey")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for OkpKey {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+    }
+}
+
+impl Drop for OkpKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl From<OkpKey> for OkpPublicKey {
+    fn from(mut key: OkpKey) -> Self {
+        std::mem::replace(
+            &mut key.public,
+            OkpPublicKey {
+                crv: String::new(),
+                x: vec![],
+            },
+        )
+    }
+}
+
+impl From<OkpKey> for Key {
+    fn from(value: OkpKey) -> Self {
+        Self::Okp(value)
+    }
+}
+
+impl<S: okp_key_builder::State> From<OkpKeyBuilder<S>> for Key
+where
+    S: okp_key_builder::IsComplete,
+{
+    fn from(value: OkpKeyBuilder<S>) -> Self {
+        Self::Okp(value.build())
+    }
+}
+
+/// A symmetric octet sequence key (RFC 7518 §6.4).
+///
+/// Used for HMAC signing and symmetric encryption (e.g., `A128KW`).
+/// Has no public key equivalent — purely secret material.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Builder, PartialEq, Clone)]
+#[builder(derive(Into))]
+pub struct OctKey {
+    /// The key value.
+    #[builder(with = <_>::from_iter)]
+    #[serde(with = "base64url")]
+    pub k: Vec<u8>,
+}
+
+impl std::fmt::Debug for OctKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OctKey").finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for OctKey {
+    fn zeroize(&mut self) {
+        self.k.zeroize();
+    }
+}
+
+impl Drop for OctKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl From<OctKey> for Key {
+    fn from(value: OctKey) -> Self {
+        Self::Oct(value)
+    }
+}
+
+impl<S: oct_key_builder::State> From<OctKeyBuilder<S>> for Key
+where
+    S: oct_key_builder::IsComplete,
+{
+    fn from(value: OctKeyBuilder<S>) -> Self {
+        Self::Oct(value.build())
+    }
+}
+
+/// A JSON Web Key with private key material (RFC 7517/7518).
+///
+/// Superset of [`PublicKey`] — includes all asymmetric key types plus symmetric
+/// (`oct`) keys. The [`Unknown`](Key::Unknown) variant allows tolerant
+/// deserialization of unrecognized `kty` values; it carries no key material and
+/// is skipped during serialization.
+#[non_exhaustive]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(tag = "kty")]
+pub enum Key {
+    /// An RSA private key.
+    #[serde(rename = "RSA")]
+    Rsa(RsaKey),
+    /// An Elliptic Curve private key.
+    #[serde(rename = "EC")]
+    Ec(EcKey),
+    /// An Octet Key Pair private key.
+    #[serde(rename = "OKP")]
+    Okp(OkpKey),
+    /// A symmetric octet sequence key.
+    #[serde(rename = "oct")]
+    Oct(OctKey),
+    /// Unknown key type (unrecognized `kty` value).
+    #[serde(skip, other)]
+    Unknown,
+}
+
+impl Key {
+    /// Returns the public key if this is an asymmetric key, or `None` for
+    /// symmetric (`Oct`) or unknown keys.
+    #[must_use]
+    pub fn public_key(&self) -> Option<PublicKey> {
+        match self {
+            Key::Rsa(rsa) => Some(PublicKey::Rsa(rsa.public.clone())),
+            Key::Ec(ec) => Some(PublicKey::Ec(ec.public.clone())),
+            Key::Okp(okp) => Some(PublicKey::Okp(okp.public.clone())),
+            Key::Oct(_) | Key::Unknown => None,
+        }
+    }
+
+    /// Returns a validated [`PrivateKey`] if this is an asymmetric key with
+    /// private material present, or `None` for public-only, symmetric (`Oct`),
+    /// or unknown keys.
+    #[must_use]
+    pub fn private_key(&self) -> Option<PrivateKey> {
+        match self {
+            Key::Rsa(rsa) => rsa.private_key().map(PrivateKey::Rsa),
+            Key::Ec(ec) => ec.private_key().map(PrivateKey::Ec),
+            Key::Okp(okp) => okp.private_key().map(PrivateKey::Okp),
+            Key::Oct(_) | Key::Unknown => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validated private-key types
+// ---------------------------------------------------------------------------
+
+/// An RSA private key with guaranteed private material.
+///
+/// Obtained via [`RsaKey::private_key()`]. The private exponent `d` is
+/// guaranteed present; CRT parameters remain optional.
+#[non_exhaustive]
+#[derive(PartialEq, Clone)]
+pub struct RsaPrivateKey {
+    /// The public key components.
+    pub public: RsaPublicKey,
+    /// The private exponent (guaranteed present).
+    pub d: Vec<u8>,
+    /// First prime factor (CRT parameter, RFC 7518 §6.3.2).
+    pub p: Option<Vec<u8>>,
+    /// Second prime factor (CRT parameter).
+    pub q: Option<Vec<u8>>,
+    /// First factor CRT exponent.
+    pub dp: Option<Vec<u8>>,
+    /// Second factor CRT exponent.
+    pub dq: Option<Vec<u8>>,
+    /// First CRT coefficient.
+    pub qi: Option<Vec<u8>>,
+    /// Additional prime factors for multi-prime RSA (RFC 7518 §6.3.2.7).
+    pub oth: Option<Vec<OtherPrimeInfo>>,
+}
+
+impl std::fmt::Debug for RsaPrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RsaPrivateKey")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for RsaPrivateKey {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+        self.p.zeroize();
+        self.q.zeroize();
+        self.dp.zeroize();
+        self.dq.zeroize();
+        self.qi.zeroize();
+        if let Some(oth) = &mut self.oth {
+            for info in oth.iter_mut() {
+                info.zeroize();
+            }
+        }
+    }
+}
+
+impl Drop for RsaPrivateKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// An EC private key with guaranteed private material.
+///
+/// Obtained via [`EcKey::private_key()`].
+#[non_exhaustive]
+#[derive(PartialEq, Clone)]
+pub struct EcPrivateKey {
+    /// The public key components.
+    pub public: EcPublicKey,
+    /// The private key value (guaranteed present).
+    pub d: Vec<u8>,
+}
+
+impl std::fmt::Debug for EcPrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EcPrivateKey")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for EcPrivateKey {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+    }
+}
+
+impl Drop for EcPrivateKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// An OKP private key with guaranteed private material.
+///
+/// Obtained via [`OkpKey::private_key()`].
+#[non_exhaustive]
+#[derive(PartialEq, Clone)]
+pub struct OkpPrivateKey {
+    /// The public key components.
+    pub public: OkpPublicKey,
+    /// The private key value (guaranteed present).
+    pub d: Vec<u8>,
+}
+
+impl std::fmt::Debug for OkpPrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OkpPrivateKey")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Zeroize for OkpPrivateKey {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+    }
+}
+
+impl Drop for OkpPrivateKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// A validated private key with guaranteed private material.
+///
+/// Obtained via [`Key::private_key()`] or [`Jwk::private_key()`]. Each variant
+/// guarantees that the private exponent / key parameter `d` is present.
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Clone)]
+pub enum PrivateKey {
+    /// An RSA private key.
+    Rsa(RsaPrivateKey),
+    /// An Elliptic Curve private key.
+    Ec(EcPrivateKey),
+    /// An Octet Key Pair private key.
+    Okp(OkpPrivateKey),
+}
+
+impl PrivateKey {
+    /// Returns the public key, stripping all private material.
+    #[must_use]
+    pub fn public_key(&self) -> PublicKey {
+        match self {
+            PrivateKey::Rsa(rsa) => PublicKey::Rsa(rsa.public.clone()),
+            PrivateKey::Ec(ec) => PublicKey::Ec(ec.public.clone()),
+            PrivateKey::Okp(okp) => PublicKey::Okp(okp.public.clone()),
+        }
+    }
+}
+
+// --- From: variant → PrivateKey enum ---
+
+impl From<RsaPrivateKey> for PrivateKey {
+    fn from(value: RsaPrivateKey) -> Self {
+        Self::Rsa(value)
+    }
+}
+
+impl From<EcPrivateKey> for PrivateKey {
+    fn from(value: EcPrivateKey) -> Self {
+        Self::Ec(value)
+    }
+}
+
+impl From<OkpPrivateKey> for PrivateKey {
+    fn from(value: OkpPrivateKey) -> Self {
+        Self::Okp(value)
+    }
+}
+
+// --- From: private → serde type (infallible widening) ---
+
+impl From<RsaPrivateKey> for RsaKey {
+    fn from(mut key: RsaPrivateKey) -> Self {
+        Self {
+            public: std::mem::replace(
+                &mut key.public,
+                RsaPublicKey {
+                    n: vec![],
+                    e: vec![],
+                },
+            ),
+            d: Some(std::mem::take(&mut key.d)),
+            p: key.p.take(),
+            q: key.q.take(),
+            dp: key.dp.take(),
+            dq: key.dq.take(),
+            qi: key.qi.take(),
+            oth: key.oth.take(),
+        }
+    }
+}
+
+impl From<EcPrivateKey> for EcKey {
+    fn from(mut key: EcPrivateKey) -> Self {
+        Self {
+            public: std::mem::replace(
+                &mut key.public,
+                EcPublicKey {
+                    crv: String::new(),
+                    x: vec![],
+                    y: vec![],
+                },
+            ),
+            d: Some(std::mem::take(&mut key.d)),
+        }
+    }
+}
+
+impl From<OkpPrivateKey> for OkpKey {
+    fn from(mut key: OkpPrivateKey) -> Self {
+        Self {
+            public: std::mem::replace(
+                &mut key.public,
+                OkpPublicKey {
+                    crv: String::new(),
+                    x: vec![],
+                },
+            ),
+            d: Some(std::mem::take(&mut key.d)),
+        }
+    }
+}
+
+impl From<PrivateKey> for Key {
+    fn from(value: PrivateKey) -> Self {
+        match value {
+            PrivateKey::Rsa(rsa) => Key::Rsa(rsa.into()),
+            PrivateKey::Ec(ec) => Key::Ec(ec.into()),
+            PrivateKey::Okp(okp) => Key::Okp(okp.into()),
+        }
+    }
+}
+
+// --- From: private → public (strip private material) ---
+
+impl From<RsaPrivateKey> for RsaPublicKey {
+    fn from(mut key: RsaPrivateKey) -> Self {
+        std::mem::replace(
+            &mut key.public,
+            RsaPublicKey {
+                n: vec![],
+                e: vec![],
+            },
+        )
+    }
+}
+
+impl From<EcPrivateKey> for EcPublicKey {
+    fn from(mut key: EcPrivateKey) -> Self {
+        std::mem::replace(
+            &mut key.public,
+            EcPublicKey {
+                crv: String::new(),
+                x: vec![],
+                y: vec![],
+            },
+        )
+    }
+}
+
+impl From<OkpPrivateKey> for OkpPublicKey {
+    fn from(mut key: OkpPrivateKey) -> Self {
+        std::mem::replace(
+            &mut key.public,
+            OkpPublicKey {
+                crv: String::new(),
+                x: vec![],
+            },
+        )
+    }
+}
+
+impl From<PrivateKey> for PublicKey {
+    fn from(value: PrivateKey) -> Self {
+        value.public_key()
+    }
+}
+
+// --- private_key() methods on serde types ---
+
+impl RsaKey {
+    /// Returns a validated [`RsaPrivateKey`] if private material is present.
+    #[must_use]
+    pub fn private_key(&self) -> Option<RsaPrivateKey> {
+        Some(RsaPrivateKey {
+            public: self.public.clone(),
+            d: self.d.clone()?,
+            p: self.p.clone(),
+            q: self.q.clone(),
+            dp: self.dp.clone(),
+            dq: self.dq.clone(),
+            qi: self.qi.clone(),
+            oth: self.oth.clone(),
+        })
+    }
+}
+
+impl EcKey {
+    /// Returns a validated [`EcPrivateKey`] if private material is present.
+    #[must_use]
+    pub fn private_key(&self) -> Option<EcPrivateKey> {
+        Some(EcPrivateKey {
+            public: self.public.clone(),
+            d: self.d.clone()?,
+        })
+    }
+}
+
+impl OkpKey {
+    /// Returns a validated [`OkpPrivateKey`] if private material is present.
+    #[must_use]
+    pub fn private_key(&self) -> Option<OkpPrivateKey> {
+        Some(OkpPrivateKey {
+            public: self.public.clone(),
+            d: self.d.clone()?,
+        })
+    }
+}
+
+/// A JSON Web Key containing private key material (RFC 7517 §4).
+///
+/// Mirrors [`PublicJwk`] but holds a [`Key`] (which may contain private
+/// parameters). Use [`Jwk::public_jwk`] to strip private material.
+#[non_exhaustive]
+#[derive(Debug, Serialize, Deserialize, Builder, PartialEq, Clone)]
+#[builder(derive(Into))]
+pub struct Jwk {
+    /// The key details (includes private material).
+    #[builder(into)]
+    #[serde(flatten)]
+    pub key: Key,
+    /// The key use for this key.
+    #[serde(rename = "use", skip_serializing_if = "Option::is_none")]
+    pub key_use: Option<KeyUse>,
+    /// The key operations for this key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(with = <_>::from_iter)]
+    #[serde(rename = "key_ops")]
+    pub key_operations: Option<Vec<KeyOperation>>,
+    /// The algorithm of this key.
+    #[builder(into)]
+    #[serde(rename = "alg", skip_serializing_if = "Option::is_none")]
+    pub algorithm: Option<String>,
+    /// The key ID of this key.
+    #[builder(into)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
+    /// X.509 URL (RFC 7517 §4.6).
+    ///
+    /// See [`PublicJwk::x5u`] for rationale.
+    #[builder(skip)]
+    #[serde(rename = "x5u", default, skip_serializing)]
+    pub x5u: Option<String>,
+}
+
+impl Jwk {
+    /// Converts to a [`PublicJwk`] by stripping private key material.
+    ///
+    /// Returns `None` for symmetric (`Oct`) keys, which have no public
+    /// representation.
+    #[must_use]
+    pub fn public_jwk(&self) -> Option<PublicJwk> {
+        self.key.public_key().map(|key| PublicJwk {
+            key,
+            key_use: self.key_use,
+            key_operations: self.key_operations.clone(),
+            algorithm: self.algorithm.clone(),
+            kid: self.kid.clone(),
+            x5u: self.x5u.clone(),
+        })
+    }
+
+    /// Returns a validated [`PrivateKey`] if the underlying key has private
+    /// material present.
+    #[must_use]
+    pub fn private_key(&self) -> Option<PrivateKey> {
+        self.key.private_key()
+    }
+
+    /// Returns a [`PrivateJwk`] if the underlying key has private material
+    /// present, or `None` for public-only, symmetric (`Oct`), or unknown keys.
+    #[must_use]
+    pub fn private_jwk(&self) -> Option<PrivateJwk> {
+        self.key.private_key().map(|key| PrivateJwk {
+            key,
+            key_use: self.key_use,
+            key_operations: self.key_operations.clone(),
+            algorithm: self.algorithm.clone(),
+            kid: self.kid.clone(),
+            x5u: self.x5u.clone(),
+        })
+    }
+}
+
+/// A JSON Web Key with guaranteed private material (RFC 7517 §4).
+///
+/// Like [`Jwk`], but the key is a [`PrivateKey`] — the private exponent `d` is
+/// guaranteed present. Obtained via [`Jwk::private_jwk()`]; to
+/// serialize/deserialize, convert to/from [`Jwk`].
+#[non_exhaustive]
+#[derive(Debug, Builder, PartialEq, Clone)]
+#[builder(derive(Into))]
+pub struct PrivateJwk {
+    /// The private key (guaranteed to contain private material).
+    #[builder(into)]
+    pub key: PrivateKey,
+    /// The key use for this key.
+    pub key_use: Option<KeyUse>,
+    /// The key operations for this key.
+    #[builder(with = <_>::from_iter)]
+    pub key_operations: Option<Vec<KeyOperation>>,
+    /// The algorithm of this key.
+    #[builder(into)]
+    pub algorithm: Option<String>,
+    /// The key ID of this key.
+    #[builder(into)]
+    pub kid: Option<String>,
+    /// X.509 URL (RFC 7517 §4.6).
+    ///
+    /// See [`PublicJwk::x5u`] for rationale.
+    #[builder(skip)]
+    pub x5u: Option<String>,
+}
+
+impl PrivateJwk {
+    /// Converts to a [`PublicJwk`] by stripping private key material.
+    #[must_use]
+    pub fn public_jwk(&self) -> PublicJwk {
+        PublicJwk {
+            key: self.key.public_key(),
+            key_use: self.key_use,
+            key_operations: self.key_operations.clone(),
+            algorithm: self.algorithm.clone(),
+            kid: self.kid.clone(),
+            x5u: self.x5u.clone(),
+        }
+    }
+
+    /// Returns the JWK thumbprint (RFC 7638) for the key.
+    #[must_use]
+    pub fn thumbprint(&self) -> String {
+        self.public_jwk().thumbprint()
+    }
+}
+
+impl From<PrivateJwk> for Jwk {
+    fn from(pjwk: PrivateJwk) -> Self {
+        Self {
+            key: pjwk.key.into(),
+            key_use: pjwk.key_use,
+            key_operations: pjwk.key_operations,
+            algorithm: pjwk.algorithm,
+            kid: pjwk.kid,
+            x5u: pjwk.x5u,
+        }
+    }
+}
+
+impl From<PrivateJwk> for PublicJwk {
+    fn from(pjwk: PrivateJwk) -> Self {
+        pjwk.public_jwk()
+    }
+}
+
+/// A JSON Web Key Set containing private key material (RFC 7517 §5).
+///
+/// Mirrors [`PublicJwks`]. Convert to `PublicJwks` via `From` to strip private
+/// material (symmetric keys are filtered out).
+#[non_exhaustive]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct Jwks {
+    /// List of keys.
+    pub keys: Vec<Jwk>,
+}
+
+impl Jwks {
+    /// Creates a new `Jwks` from the given keys.
+    #[must_use]
+    pub fn new(keys: Vec<Jwk>) -> Self {
+        Self { keys }
+    }
+}
+
+impl From<Jwks> for PublicJwks {
+    fn from(jwks: Jwks) -> Self {
+        PublicJwks::new(jwks.keys.iter().filter_map(Jwk::public_jwk).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/huskarl-core/src/jwk/serde_utils.rs
+++ b/huskarl-core/src/jwk/serde_utils.rs
@@ -22,6 +22,58 @@ pub(super) fn trim_leading_zeros(bytes: &[u8]) -> &[u8] {
     }
 }
 
+pub mod option_base64url_uint {
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    // serde's `#[serde(with)]` requires `&Option<T>`, not `Option<&T>`.
+    #[allow(clippy::ref_option)]
+    pub fn serialize<S: Serializer>(value: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(bytes) => {
+                s.serialize_str(&URL_SAFE_NO_PAD.encode(super::trim_leading_zeros(bytes)))
+            }
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u8>>, D::Error> {
+        let s: Option<String> = Deserialize::deserialize(d)?;
+        match s {
+            Some(s) => URL_SAFE_NO_PAD
+                .decode(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
+
+pub mod option_base64url {
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    // serde's `#[serde(with)]` requires `&Option<T>`, not `Option<&T>`.
+    #[allow(clippy::ref_option)]
+    pub fn serialize<S: Serializer>(value: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(bytes) => s.serialize_str(&URL_SAFE_NO_PAD.encode(bytes)),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u8>>, D::Error> {
+        let s: Option<String> = Deserialize::deserialize(d)?;
+        match s {
+            Some(s) => URL_SAFE_NO_PAD
+                .decode(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
+
 pub mod base64url_uint {
     use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     use serde::{Deserialize, Deserializer, Serializer};

--- a/huskarl-core/src/jwk/source.rs
+++ b/huskarl-core/src/jwk/source.rs
@@ -10,7 +10,7 @@ use crate::{
         MultiKeyVerifier, RetryingVerifier, ScheduledRefreshVerifier,
     },
     http::HttpClient,
-    jwk::PublicJwks,
+    jwk::{Jwks, PublicJwks},
     platform::MaybeSendFuture,
 };
 
@@ -50,12 +50,13 @@ impl<C: HttpClient + Clone + 'static> JwsVerifierFactory for JwksSource<C> {
                     let uri = uri.clone();
                     let platform = platform.clone();
                     Box::pin(async move {
-                        let jwks: PublicJwks =
+                        let jwks: Jwks =
                             crate::http::get(&client, uri.as_uri().clone(), HeaderMap::new())
                                 .await
                                 .map_err(BoxedError::from_err)?;
+                        let public_jwks: PublicJwks = jwks.into();
 
-                        MultiKeyVerifier::from_jwks(&jwks, platform.as_ref())
+                        MultiKeyVerifier::from_jwks(&public_jwks, platform.as_ref())
                             .await
                             .map_err(BoxedError::from_err)
                     })

--- a/huskarl-core/src/jwk/tests.rs
+++ b/huskarl-core/src/jwk/tests.rs
@@ -1,0 +1,499 @@
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+
+use super::*;
+
+// Example public key from https://www.rfc-editor.org/rfc/rfc7517.html#appendix-A.1
+#[test]
+fn test_parse_jwks_appendix_a1() {
+    let jwks_json = r#"{"keys":[
+            {"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use":"enc","kid":"1"},
+            {"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","alg":"RS256","kid":"2011-04-29"}
+        ]}"#;
+
+    let jwks: PublicJwks = serde_json::from_str::<Jwks>(jwks_json).unwrap().into();
+
+    let key1 = PublicJwk::builder()
+        .key(
+            EcPublicKey::builder()
+                .crv("P-256")
+                .x(BASE64_URL_SAFE_NO_PAD
+                    .decode("MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4")
+                    .unwrap())
+                .y(BASE64_URL_SAFE_NO_PAD
+                    .decode("4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM")
+                    .unwrap()),
+        )
+        .key_use(KeyUse::Encrypt)
+        .kid("1")
+        .build();
+
+    let key2 = PublicJwk::builder().key(
+        RsaPublicKey::builder()
+            .n(BASE64_URL_SAFE_NO_PAD.decode(
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+            ).unwrap())
+            .e(BASE64_URL_SAFE_NO_PAD.decode("AQAB").unwrap())
+    )
+    .algorithm("RS256")
+    .kid("2011-04-29")
+    .build();
+
+    assert_eq!(jwks.keys, vec![key1, key2]);
+}
+
+#[test]
+fn test_unknown_curve_parses() {
+    // Unknown curve should parse successfully
+    let unknown_curve = r#"{"kty":"EC","crv":"brainpoolP256r1","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"}"#;
+    let _: PublicJwk = serde_json::from_str(unknown_curve).unwrap();
+}
+
+// --- Private key type tests ---
+
+// RFC 7517 Appendix A.2 — JWK Set containing private keys (EC + RSA)
+#[test]
+fn test_parse_jwks_appendix_a2() {
+    let jwks_json = r#"{"keys":
+          [
+            {"kty":"EC",
+             "crv":"P-256",
+             "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+             "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+             "d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE",
+             "use":"enc",
+             "kid":"1"},
+
+            {"kty":"RSA",
+             "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+             "e":"AQAB",
+             "d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q",
+             "p":"83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs",
+             "q":"3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk",
+             "dp":"G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0",
+             "dq":"s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk",
+             "qi":"GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
+             "alg":"RS256",
+             "kid":"2011-04-29"}
+          ]
+        }
+"#;
+
+    let jwks: Jwks = serde_json::from_str(jwks_json).unwrap();
+    assert_eq!(jwks.keys.len(), 2);
+
+    // First key is EC with private material
+    assert!(matches!(&jwks.keys[0].key, Key::Ec(_)));
+    assert_eq!(jwks.keys[0].key_use, Some(KeyUse::Encrypt));
+    assert_eq!(jwks.keys[0].kid.as_deref(), Some("1"));
+
+    // Second key is RSA with CRT params
+    let Key::Rsa(rsa) = &jwks.keys[1].key else {
+        unreachable!("Expected RSA key");
+    };
+    assert!(rsa.p.is_some());
+    assert!(rsa.q.is_some());
+    assert!(rsa.dp.is_some());
+    assert!(rsa.dq.is_some());
+    assert!(rsa.qi.is_some());
+    assert_eq!(jwks.keys[1].algorithm.as_deref(), Some("RS256"));
+    assert_eq!(jwks.keys[1].kid.as_deref(), Some("2011-04-29"));
+}
+
+// RFC 7517 Appendix A.3 — Symmetric keys
+#[test]
+fn test_parse_jwks_appendix_a3() {
+    let jwks_json = r#"{"keys":[
+            {"kty":"oct","alg":"A128KW","k":"GawgguFyGrWKav7AX4VKUg"},
+            {"kty":"oct","k":"AyM32fqVEfJG4jS1GDRTE3ElK08OuKBj","kid":"HMAC key used in JWS spec Appendix A.1 example"}
+        ]}"#;
+
+    let jwks: Jwks = serde_json::from_str(jwks_json).unwrap();
+    assert_eq!(jwks.keys.len(), 2);
+
+    assert!(matches!(&jwks.keys[0].key, Key::Oct(_)));
+    assert_eq!(jwks.keys[0].algorithm.as_deref(), Some("A128KW"));
+
+    assert!(matches!(&jwks.keys[1].key, Key::Oct(_)));
+    assert_eq!(
+        jwks.keys[1].kid.as_deref(),
+        Some("HMAC key used in JWS spec Appendix A.1 example")
+    );
+}
+
+#[test]
+fn test_roundtrip_ec_key() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    let deserialized: Jwk = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(jwk, deserialized);
+}
+
+#[test]
+fn test_roundtrip_rsa_key() {
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    let deserialized: Jwk = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(jwk, deserialized);
+}
+
+// RFC 8037 Appendix A — Ed25519 private key
+#[test]
+fn test_roundtrip_okp_key() {
+    let json = r#"{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo","d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    let deserialized: Jwk = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(jwk, deserialized);
+}
+
+#[test]
+fn test_roundtrip_oct_key() {
+    let json = r#"{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    let deserialized: Jwk = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(jwk, deserialized);
+}
+
+#[test]
+fn test_public_jwk_strips_private_material() {
+    let ec_json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE","use":"enc","kid":"1"}"#;
+    let jwk: Jwk = serde_json::from_str(ec_json).unwrap();
+    let public = jwk.public_jwk().unwrap();
+
+    // Metadata preserved
+    assert_eq!(public.kid.as_deref(), Some("1"));
+    assert_eq!(public.key_use, Some(KeyUse::Encrypt));
+
+    // No private material in serialized output
+    let serialized = serde_json::to_string(&public).unwrap();
+    assert!(!serialized.contains("\"d\""));
+}
+
+#[test]
+fn test_public_jwk_none_for_oct() {
+    let oct_json = r#"{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg","alg":"A128KW"}"#;
+    let jwk: Jwk = serde_json::from_str(oct_json).unwrap();
+    assert!(jwk.public_jwk().is_none());
+}
+
+#[test]
+fn test_jwks_to_public_filters_oct() {
+    let jwks_json = r#"{"keys":[
+            {"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE","kid":"1"},
+            {"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg","alg":"A128KW"},
+            {"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ","kid":"2011-04-29"}
+        ]}"#;
+
+    let jwks: Jwks = serde_json::from_str(jwks_json).unwrap();
+    assert_eq!(jwks.keys.len(), 3);
+
+    let public_jwks: PublicJwks = jwks.into();
+    // Oct key filtered out, only EC and RSA remain
+    assert_eq!(public_jwks.keys.len(), 2);
+    assert_eq!(public_jwks.keys[0].kid.as_deref(), Some("1"));
+    assert_eq!(public_jwks.keys[1].kid.as_deref(), Some("2011-04-29"));
+}
+
+#[test]
+fn test_thumbprint_via_public_jwk() {
+    let ec_json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(ec_json).unwrap();
+    let public_jwk = jwk.public_jwk().unwrap();
+
+    assert!(!public_jwk.thumbprint().is_empty());
+}
+
+#[test]
+fn test_rsa_key_without_crt_params() {
+    // RSA key with only d, no CRT params
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let Key::Rsa(rsa) = &jwk.key else {
+        unreachable!("Expected RSA key");
+    };
+    assert!(rsa.p.is_none());
+    assert!(rsa.q.is_none());
+    assert!(rsa.dp.is_none());
+    assert!(rsa.dq.is_none());
+    assert!(rsa.qi.is_none());
+    // Round-trip preserves absence of CRT params
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    assert!(!serialized.contains("\"p\""));
+    assert!(!serialized.contains("\"q\""));
+}
+
+// --- Validated private key type tests ---
+
+#[test]
+fn test_private_key_ec_some() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key();
+    assert!(pk.is_some());
+    assert!(matches!(pk.unwrap(), PrivateKey::Ec(_)));
+}
+
+#[test]
+fn test_private_key_rsa_some() {
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key();
+    assert!(pk.is_some());
+    assert!(matches!(pk.unwrap(), PrivateKey::Rsa(_)));
+}
+
+#[test]
+fn test_private_key_okp_some() {
+    let json = r#"{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo","d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key();
+    assert!(pk.is_some());
+    assert!(matches!(pk.unwrap(), PrivateKey::Okp(_)));
+}
+
+#[test]
+fn test_private_key_none_when_d_absent() {
+    // EC without d
+    let ec_json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"}"#;
+    let jwk: Jwk = serde_json::from_str(ec_json).unwrap();
+    assert!(jwk.private_key().is_none());
+
+    // RSA without d
+    let rsa_json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}"#;
+    let jwk: Jwk = serde_json::from_str(rsa_json).unwrap();
+    assert!(jwk.private_key().is_none());
+
+    // OKP without d
+    let okp_json =
+        r#"{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}"#;
+    let jwk: Jwk = serde_json::from_str(okp_json).unwrap();
+    assert!(jwk.private_key().is_none());
+}
+
+#[test]
+fn test_private_key_none_for_oct_and_unknown() {
+    let oct_json = r#"{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg"}"#;
+    let jwk: Jwk = serde_json::from_str(oct_json).unwrap();
+    assert!(jwk.private_key().is_none());
+
+    assert!(Key::Unknown.private_key().is_none());
+}
+
+#[test]
+fn test_private_key_roundtrip_ec() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key().unwrap();
+    let key_back: Key = pk.into();
+    assert_eq!(jwk.key, key_back);
+}
+
+#[test]
+fn test_private_key_roundtrip_rsa() {
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key().unwrap();
+    let key_back: Key = pk.into();
+    assert_eq!(jwk.key, key_back);
+}
+
+#[test]
+fn test_private_key_roundtrip_okp() {
+    let json = r#"{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo","d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key().unwrap();
+    let key_back: Key = pk.into();
+    assert_eq!(jwk.key, key_back);
+}
+
+#[test]
+fn test_private_key_public_key_strips_material() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key().unwrap();
+    let public = pk.public_key();
+
+    // Matches the public key from the full key
+    assert_eq!(Some(public.clone()), jwk.key.public_key());
+
+    // Serialized public key has no d
+    let serialized = serde_json::to_string(&public).unwrap();
+    assert!(!serialized.contains("\"d\""));
+}
+
+#[test]
+fn test_private_key_debug_hides_secrets() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let pk = jwk.private_key().unwrap();
+    let debug = format!("{pk:?}");
+
+    // Should not contain the base64-encoded d value
+    assert!(!debug.contains("870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"));
+    // Should contain the type name
+    assert!(debug.contains("EcPrivateKey"));
+}
+
+// --- OtherPrimeInfo / oth tests ---
+
+#[test]
+fn test_rsa_key_with_oth_roundtrip() {
+    // RSA key with oth (multi-prime) — synthetic but structurally valid
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ","oth":[{"r":"AQAB","d":"AQAB","t":"AQAB"}]}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+
+    // oth is present on RsaKey
+    let Key::Rsa(rsa) = &jwk.key else {
+        unreachable!("Expected RSA key");
+    };
+    let oth = rsa.oth.as_ref().expect("oth should be present");
+    assert_eq!(oth.len(), 1);
+
+    // Round-trip preserves oth
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    assert!(serialized.contains("\"oth\""));
+    let deserialized: Jwk = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(jwk, deserialized);
+
+    // oth passes through to RsaPrivateKey
+    let pk = jwk.private_key().unwrap();
+    let PrivateKey::Rsa(rsa_pk) = pk else {
+        unreachable!("Expected RSA private key");
+    };
+    assert!(rsa_pk.oth.is_some());
+    assert_eq!(rsa_pk.oth.as_ref().unwrap().len(), 1);
+}
+
+#[test]
+fn test_rsa_key_without_oth_has_none() {
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let Key::Rsa(rsa) = &jwk.key else {
+        unreachable!("Expected RSA key");
+    };
+    assert!(rsa.oth.is_none());
+    // oth not serialized when absent
+    let serialized = serde_json::to_string(&jwk).unwrap();
+    assert!(!serialized.contains("\"oth\""));
+}
+
+#[test]
+fn test_other_prime_info_debug_hides_secrets() {
+    let info = OtherPrimeInfo::builder()
+        .r(vec![1, 2, 3])
+        .d(vec![4, 5, 6])
+        .t(vec![7, 8, 9])
+        .build();
+    let debug = format!("{info:?}");
+    assert!(debug.contains("OtherPrimeInfo"));
+    // Should not contain raw byte values
+    assert!(!debug.contains("[1, 2, 3]"));
+}
+
+// --- PrivateJwk tests ---
+
+#[test]
+fn test_private_jwk_from_ec() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE","use":"enc","kid":"1"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let private_jwk = jwk.private_jwk().unwrap();
+
+    assert!(matches!(&private_jwk.key, PrivateKey::Ec(_)));
+    assert_eq!(private_jwk.key_use, Some(KeyUse::Encrypt));
+    assert_eq!(private_jwk.kid.as_deref(), Some("1"));
+}
+
+#[test]
+fn test_private_jwk_from_rsa() {
+    let json = r#"{"kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB","d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYjqxnf7vQoSmcnVQ","alg":"RS256","kid":"rsa-1"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let private_jwk = jwk.private_jwk().unwrap();
+
+    assert!(matches!(&private_jwk.key, PrivateKey::Rsa(_)));
+    assert_eq!(private_jwk.algorithm.as_deref(), Some("RS256"));
+    assert_eq!(private_jwk.kid.as_deref(), Some("rsa-1"));
+}
+
+#[test]
+fn test_private_jwk_from_okp() {
+    let json = r#"{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo","d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let private_jwk = jwk.private_jwk().unwrap();
+
+    assert!(matches!(&private_jwk.key, PrivateKey::Okp(_)));
+}
+
+#[test]
+fn test_private_jwk_none_for_public_only() {
+    // EC without d
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    assert!(jwk.private_jwk().is_none());
+}
+
+#[test]
+fn test_private_jwk_none_for_oct() {
+    let json = r#"{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    assert!(jwk.private_jwk().is_none());
+}
+
+#[test]
+fn test_private_jwk_to_public_jwk() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE","use":"enc","kid":"1"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let private_jwk = jwk.private_jwk().unwrap();
+    let public_jwk: PublicJwk = private_jwk.clone().into();
+
+    // Metadata preserved
+    assert_eq!(public_jwk.kid.as_deref(), Some("1"));
+    assert_eq!(public_jwk.key_use, Some(KeyUse::Encrypt));
+
+    // Matches the public_jwk() from Jwk
+    assert_eq!(Some(public_jwk), jwk.public_jwk());
+}
+
+#[test]
+fn test_private_jwk_to_jwk_roundtrip() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE","kid":"ec-1"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let private_jwk = jwk.private_jwk().unwrap();
+
+    // Convert back to Jwk
+    let jwk_back: Jwk = private_jwk.into();
+    assert_eq!(jwk, jwk_back);
+}
+
+#[test]
+fn test_private_jwk_thumbprint_matches_public() {
+    let json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}"#;
+    let jwk: Jwk = serde_json::from_str(json).unwrap();
+    let private_jwk = jwk.private_jwk().unwrap();
+    let public_jwk = jwk.public_jwk().unwrap();
+
+    assert_eq!(private_jwk.thumbprint(), public_jwk.thumbprint());
+}
+
+#[test]
+fn test_private_jwk_builder() {
+    let ec_key = EcPrivateKey {
+        public: EcPublicKey::builder()
+            .crv("P-256")
+            .x(vec![1, 2, 3])
+            .y(vec![4, 5, 6])
+            .build(),
+        d: vec![7, 8, 9],
+    };
+    let pjwk = PrivateJwk::builder()
+        .key(ec_key)
+        .kid("test-key")
+        .algorithm("ES256")
+        .build();
+
+    assert_eq!(pjwk.kid.as_deref(), Some("test-key"));
+    assert_eq!(pjwk.algorithm.as_deref(), Some("ES256"));
+    assert!(matches!(&pjwk.key, PrivateKey::Ec(_)));
+}


### PR DESCRIPTION
This allows code which expects public or private keys, to get a type that exactly represents that set of options.