### PR TITLE
Fix path for OIDC/authorization server metadata.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,7 @@ dependencies = [
  "http",
  "httpmock",
  "huskarl",
- "huskarl-core 0.6.0",
+ "huskarl-core 0.6.2",
  "huskarl-crypto-native",
  "huskarl-crypto-webcrypto",
  "huskarl-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c43c72d562a4e6b2c4b632fb56341ee4079c91a201b77de15af609443d09dc"
+checksum = "5ea80b79b270dd5240535db40da7e9256f700a7388357c41d4219764be4958e1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1169,7 +1169,7 @@ dependencies = [
  "aes-gcm",
  "ed25519-dalek",
  "hmac",
- "huskarl-core 0.6.0",
+ "huskarl-core 0.6.2",
  "p256",
  "p384",
  "pkcs8",
@@ -1189,7 +1189,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3919a900e09e39f85699e3cb4b3c5b7353641dc5fb51a4f5aaf8052d22e95f2"
 dependencies = [
- "huskarl-core 0.6.0",
+ "huskarl-core 0.6.2",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -1234,7 +1234,7 @@ dependencies = [
  "bon",
  "bytes",
  "http",
- "huskarl-core 0.6.0",
+ "huskarl-core 0.6.2",
  "reqwest",
  "snafu",
 ]
@@ -1251,7 +1251,7 @@ dependencies = [
  "gloo-timers",
  "http",
  "httpmock",
- "huskarl-core 0.6.0",
+ "huskarl-core 0.6.2",
  "huskarl-crypto-native",
  "huskarl-crypto-webcrypto",
  "huskarl-reqwest",
@@ -1270,7 +1270,7 @@ name = "huskarl-testkit"
 version = "0.1.0"
 dependencies = [
  "bon",
- "huskarl-core 0.6.0",
+ "huskarl-core 0.6.2",
  "reqwest",
  "serde",
  "tokio",

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.6.1"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-core/src/server_metadata.rs
+++ b/huskarl-core/src/server_metadata.rs
@@ -260,9 +260,9 @@ fn add_issuer_to_known_path(
     let path = issuer_as_uri.path();
     let cleaned_path = path.strip_suffix('/').unwrap_or(path);
     let new_path = if use_legacy_transformation {
-        format!("{uri_suffix}{cleaned_path}")
-    } else {
         format!("{cleaned_path}{uri_suffix}")
+    } else {
+        format!("{uri_suffix}{cleaned_path}")
     };
     let mut parts = issuer_as_uri.into_parts();
     parts.path_and_query = Some(new_path.try_into()?);


### PR DESCRIPTION
The legacy and non-legacy paths were swapped (only an issue where the base URL includes a sub-path).