### PR TITLE
Fix inmemory token store.

### DIFF
--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+
+### Changes
+
+ - Don't throw away refresh token in inmemory store unless invalid_grant was returned.
+
 ## [0.7.2] - 2026-06-04
 
 ### Changes

--- a/huskarl/src/cache/in_memory.rs
+++ b/huskarl/src/cache/in_memory.rs
@@ -170,6 +170,10 @@ impl<G: OAuth2ExchangeGrant, S: RefreshTokenStore> InMemoryTokenCache<G, S> {
     ///
     /// Returns `Ok(token)` on success, `Err(Some(error))` if refresh failed,
     /// or `Err(None)` if no refresh token is available.
+    ///
+    /// The stored refresh token is discarded only when the server definitively
+    /// rejects it with `invalid_grant` (RFC 6749 §5.2). Transient failures
+    /// (network errors, 5xx responses) leave it in place for later attempts.
     async fn try_refresh<C: HttpClient>(
         &self,
         http_client: &C,
@@ -193,24 +197,243 @@ impl<G: OAuth2ExchangeGrant, S: RefreshTokenStore> InMemoryTokenCache<G, S> {
                 Ok(token_response)
             }
             Err(err) => {
-                self.refresh_store.clear().await;
-                self.has_refresh_token_cached
-                    .store(false, Ordering::Relaxed);
+                if err.is_invalid_grant() {
+                    self.refresh_store.clear().await;
+                    self.has_refresh_token_cached
+                        .store(false, Ordering::Relaxed);
+                }
                 Err(Some(err))
             }
         }
     }
 
+    /// Caches the token response, storing its refresh token if one is present.
+    ///
+    /// When the response carries no refresh token, any previously stored refresh
+    /// token is retained: per RFC 6749 §6 the authorization server may omit the
+    /// refresh token from a refresh response, in which case the client keeps
+    /// using the existing one.
     async fn store_token_response(&self, token: Arc<TokenResponse>) {
         self.cached.store(Some(token.clone()));
 
         if let Some(refresh_token) = token.refresh_token().as_ref() {
             self.refresh_store.set(refresh_token).await;
             self.has_refresh_token_cached.store(true, Ordering::Relaxed);
-        } else {
-            self.refresh_store.clear().await;
-            self.has_refresh_token_cached
-                .store(false, Ordering::Relaxed);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use bytes::Bytes;
+    use http::{HeaderMap, HeaderValue, StatusCode};
+
+    use super::*;
+    use crate::{
+        cache::InMemoryRefreshTokenStore,
+        core::{
+            client_auth::NoAuth, dpop::NoDPoP, http::HttpResponse, platform::SystemTime,
+            secrets::SecretString,
+        },
+        grant::{
+            client_credentials::ClientCredentialsGrant, core::token_response::RawTokenResponse,
+        },
+        token::RefreshToken,
+    };
+
+    struct MockResponse {
+        status: StatusCode,
+        body: Bytes,
+    }
+
+    impl HttpResponse for MockResponse {
+        type Error = Infallible;
+
+        fn status(&self) -> StatusCode {
+            self.status
+        }
+
+        fn headers(&self) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                http::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            headers
+        }
+
+        async fn body(self) -> Result<Bytes, Infallible> {
+            Ok(self.body)
+        }
+    }
+
+    /// Mock HTTP client that returns a preconfigured response once.
+    struct MockHttpClient {
+        response: std::sync::Mutex<Option<MockResponse>>,
+    }
+
+    impl MockHttpClient {
+        fn new(status: StatusCode, body: &str) -> Self {
+            Self {
+                response: std::sync::Mutex::new(Some(MockResponse {
+                    status,
+                    body: Bytes::copy_from_slice(body.as_bytes()),
+                })),
+            }
+        }
+    }
+
+    impl HttpClient for MockHttpClient {
+        type Response = MockResponse;
+        type Error = Infallible;
+        type ResponseError = Infallible;
+
+        async fn execute(
+            &self,
+            _request: http::Request<Bytes>,
+        ) -> Result<MockResponse, Infallible> {
+            Ok(self
+                .response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("MockHttpClient can only be called once"))
+        }
+    }
+
+    /// Cloneable handle over an [`InMemoryRefreshTokenStore`] so tests can
+    /// observe the store after handing it to the cache.
+    #[derive(Clone, Default)]
+    struct SharedRefreshStore(Arc<InMemoryRefreshTokenStore>);
+
+    impl RefreshTokenStore for SharedRefreshStore {
+        async fn get(&self) -> Option<RefreshToken> {
+            self.0.get().await
+        }
+
+        async fn set(&self, token: &RefreshToken) {
+            self.0.set(token).await;
+        }
+
+        async fn clear(&self) {
+            self.0.clear().await;
+        }
+    }
+
+    /// Builds a cache primed with an already-expired access token and the
+    /// refresh token `"rt-original"`, so the next `get_token_response` call
+    /// must attempt a refresh.
+    async fn primed_cache(
+        store: SharedRefreshStore,
+    ) -> InMemoryTokenCache<ClientCredentialsGrant<NoAuth, NoDPoP>, SharedRefreshStore> {
+        let cache = InMemoryTokenCache::builder()
+            .grant(
+                ClientCredentialsGrant::builder()
+                    .client_id("client_id")
+                    .client_auth(NoAuth)
+                    .token_endpoint("https://as.example.com/token")
+                    .unwrap()
+                    .dpop(NoDPoP)
+                    .build(),
+            )
+            .refresh_store(store)
+            .build();
+
+        let expired = RawTokenResponse::builder()
+            .access_token(SecretString::new("expired-access-token"))
+            .token_type("bearer")
+            .expires_in(0)
+            .refresh_token(SecretString::new("rt-original"))
+            .build()
+            .into_token_response(None, SystemTime::now())
+            .expect("valid token response");
+        cache.prime(Arc::new(expired)).await;
+
+        cache
+    }
+
+    async fn stored_refresh_token(store: &SharedRefreshStore) -> Option<String> {
+        store
+            .get()
+            .await
+            .map(|t| t.token().expose_secret().to_owned())
+    }
+
+    #[tokio::test]
+    async fn refresh_response_without_refresh_token_retains_existing() {
+        let store = SharedRefreshStore::default();
+        let cache = primed_cache(store.clone()).await;
+
+        let http = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"access_token":"new-access-token","token_type":"bearer","expires_in":3600}"#,
+        );
+
+        let token = cache.get_token_response(&http).await.unwrap();
+        assert_eq!(
+            token.raw_token_response().access_token.expose_secret(),
+            "new-access-token"
+        );
+
+        // RFC 6749 §6: no new refresh token issued means the existing one stays valid.
+        assert_eq!(
+            stored_refresh_token(&store).await.as_deref(),
+            Some("rt-original")
+        );
+        assert!(cache.has_refresh_token_cached());
+    }
+
+    #[tokio::test]
+    async fn refresh_response_with_rotated_refresh_token_replaces_existing() {
+        let store = SharedRefreshStore::default();
+        let cache = primed_cache(store.clone()).await;
+
+        let http = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"access_token":"new-access-token","token_type":"bearer","expires_in":3600,"refresh_token":"rt-rotated"}"#,
+        );
+
+        cache.get_token_response(&http).await.unwrap();
+
+        assert_eq!(
+            stored_refresh_token(&store).await.as_deref(),
+            Some("rt-rotated")
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_refresh_failure_retains_refresh_token() {
+        let store = SharedRefreshStore::default();
+        let cache = primed_cache(store.clone()).await;
+
+        let http = MockHttpClient::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":"temporarily_unavailable"}"#,
+        );
+
+        let err = cache.get_token_response(&http).await.unwrap_err();
+        assert!(matches!(err, GetTokenError::RefreshFailed { .. }));
+
+        assert_eq!(
+            stored_refresh_token(&store).await.as_deref(),
+            Some("rt-original")
+        );
+        assert!(cache.has_refresh_token_cached());
+    }
+
+    #[tokio::test]
+    async fn invalid_grant_clears_refresh_token() {
+        let store = SharedRefreshStore::default();
+        let cache = primed_cache(store.clone()).await;
+
+        let http = MockHttpClient::new(StatusCode::BAD_REQUEST, r#"{"error":"invalid_grant"}"#);
+
+        let err = cache.get_token_response(&http).await.unwrap_err();
+        assert!(matches!(err, GetTokenError::RefreshFailed { .. }));
+
+        assert_eq!(stored_refresh_token(&store).await, None);
+        assert!(!cache.has_refresh_token_cached());
     }
 }

--- a/huskarl/src/grant/core/form.rs
+++ b/huskarl/src/grant/core/form.rs
@@ -215,6 +215,21 @@ impl<HttpReqErr: crate::core::Error, HttpRespErr: crate::core::Error, DPoPErr: c
             } if error == "use_dpop_nonce"
         )
     }
+
+    /// Returns `true` if the server definitively rejected the grant itself with
+    /// `invalid_grant` (RFC 6749 §5.2), e.g. a revoked, expired, or otherwise
+    /// invalid refresh token or authorization code.
+    pub fn is_invalid_grant(&self) -> bool {
+        matches!(
+            self,
+            Self::Response {
+                source: HandleResponseError::OAuth2 {
+                    body: OAuth2ErrorBody { error, .. },
+                    ..
+                },
+            } if error == "invalid_grant"
+        )
+    }
 }
 
 impl<HttpReqErr: crate::core::Error, HttpRespErr: crate::core::Error, DPoPErr: crate::core::Error>

--- a/huskarl/src/grant/core/grant.rs
+++ b/huskarl/src/grant/core/grant.rs
@@ -193,6 +193,21 @@ impl<
     HttpRespErr: crate::core::Error,
     AuthErr: crate::core::Error,
     DPoPErr: crate::core::Error,
+> OAuth2ExchangeGrantError<HttpErr, HttpRespErr, AuthErr, DPoPErr>
+{
+    /// Returns `true` if the server definitively rejected the grant itself with
+    /// `invalid_grant` (RFC 6749 §5.2), e.g. a revoked, expired, or otherwise
+    /// invalid refresh token or authorization code.
+    pub fn is_invalid_grant(&self) -> bool {
+        matches!(self, Self::OAuth2Form { source } if source.is_invalid_grant())
+    }
+}
+
+impl<
+    HttpErr: crate::core::Error,
+    HttpRespErr: crate::core::Error,
+    AuthErr: crate::core::Error,
+    DPoPErr: crate::core::Error,
 > crate::core::Error for OAuth2ExchangeGrantError<HttpErr, HttpRespErr, AuthErr, DPoPErr>
 {
     fn is_retryable(&self) -> bool {


### PR DESCRIPTION
Don't throw away refresh token unless invalid_grant was returned.