### PR TITLE
Remove raw data from some debug implementations.

### DIFF
--- a/huskarl/src/grant/core/form.rs
+++ b/huskarl/src/grant/core/form.rs
@@ -194,11 +194,26 @@ fn parse_oauth2_response<T: for<'de> Deserialize<'de>>(
         Error::new(
             ErrorKind::Protocol,
             HandleResponseError::UnparseableSuccessResponse {
-                body: String::from_utf8_lossy(body).into_owned(),
+                body: RedactedBody(String::from_utf8_lossy(body).into_owned()),
                 source,
             },
         )
     })
+}
+
+/// A captured response body whose contents are withheld from `Debug`.
+///
+/// A successful token-endpoint response carries cleartext access and refresh
+/// tokens. Capturing the raw body into an error and letting it surface through
+/// `{:?}` — directly, or via the wrapping [`Error`]'s source chain — would leak
+/// those tokens to logs. The body is retained only so the error can be
+/// constructed; its contents are never rendered.
+pub struct RedactedBody(String);
+
+impl std::fmt::Debug for RedactedBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[REDACTED {} bytes]", self.0.len())
+    }
 }
 
 /// Source vocabulary for `OAuth2` token-endpoint response failures.
@@ -227,7 +242,7 @@ pub enum HandleResponseError {
     #[snafu(display("Failed to parse successful response as an OAuth2 payload"))]
     UnparseableSuccessResponse {
         /// The unparseable body.
-        body: String,
+        body: RedactedBody,
         /// The underlying error.
         source: serde_json::Error,
     },

--- a/huskarl/src/token/id_token.rs
+++ b/huskarl/src/token/id_token.rs
@@ -22,8 +22,14 @@ use crate::core::{
 /// is unverified — validate it with [`IdTokenValidator`] before trusting any
 /// claim. [`token`](Self::token) exposes the raw string, e.g. to pass back as an
 /// `id_token_hint`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdToken(String);
+
+impl std::fmt::Debug for IdToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("IdToken").field(&"[REDACTED]").finish()
+    }
+}
 
 impl IdToken {
     /// Exposes the raw compact-JWS string. Validate with [`IdTokenValidator`]
@@ -675,6 +681,15 @@ mod tests {
             .validate(&token, None)
             .await;
         assert_eq!(result.is_err(), expect_err, "got {result:?}");
+    }
+
+    #[test]
+    fn id_token_debug_redacts_the_raw_jws() {
+        let token = IdToken::from("eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.sig");
+        let rendered = format!("{token:?}");
+        assert!(rendered.contains("[REDACTED]"), "got {rendered}");
+        assert!(!rendered.contains("alice"), "got {rendered}");
+        assert!(!rendered.contains("eyJ"), "got {rendered}");
     }
 
     #[test]


### PR DESCRIPTION
Some debug implementations can show raw PII, e.g. body responses or ID token contents.