### PR TITLE
Add MultiIssuerValidator, box futures in AccessTokenValidator to make them dyn compatible

### DIFF
--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+ - Breaking: Make AccessTokenValidator dyn-compatible (with boxed futures).
+ - Add MultiIssuerValidator which can route validator by iss value.
+ - Add `non_exhaustive` to various error types.
+ - Breaking: Add Debug bound to ToRfc6750Error.
+ 
 ## [0.8.0] - 2026-06-15
 
  - Breaking: ported to the dyn-first huskarl-core.

--- a/huskarl-resource-server/src/error.rs
+++ b/huskarl-resource-server/src/error.rs
@@ -195,7 +195,7 @@ impl ToRfc6750Error for InsufficientUserAuthentication {
 }
 
 /// A trait for errors that can be classified into an RFC 6750-style error response.
-pub trait ToRfc6750Error: MaybeSendSync {
+pub trait ToRfc6750Error: std::fmt::Debug + MaybeSendSync {
     /// Returns the attempted authentication scheme, if known.
     fn attempted_scheme(&self) -> Option<TokenType>;
 

--- a/huskarl-resource-server/src/validator/custom/mod.rs
+++ b/huskarl-resource-server/src/validator/custom/mod.rs
@@ -367,15 +367,15 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + MaybeSendSync + 'static> Access
     type Claims = Claims;
     type Error = ValidateHeadersError;
 
-    async fn validate_request(
-        &self,
-        headers: &http::HeaderMap,
-        method: &http::Method,
-        uri: &http::Uri,
-        client_cert_der: Option<&[u8]>,
-    ) -> ValidationResult<Self::Claims, Self::Error> {
-        self.validate_request(headers, method, uri, client_cert_der)
-            .await
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> crate::core::platform::MaybeSendBoxFuture<'a, ValidationResult<Self::Claims, Self::Error>>
+    {
+        Box::pin(self.validate_request(headers, method, uri, client_cert_der))
     }
 }
 

--- a/huskarl-resource-server/src/validator/extract.rs
+++ b/huskarl-resource-server/src/validator/extract.rs
@@ -108,3 +108,109 @@ impl ToRfc6750Error for TokenExtractError {
         self.get_message().map(str::to_string)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderValue, header::AUTHORIZATION};
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Builds a `HeaderMap` carrying `value` under the `Authorization` header.
+    fn auth_headers(value: &'static str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static(value));
+        headers
+    }
+
+    /// Runs `extract_token` against the default `Authorization` header.
+    fn extract(
+        value: &'static str,
+    ) -> Result<Option<(TokenType, SecretString)>, TokenExtractError> {
+        extract_token(&auth_headers(value), &AUTHORIZATION)
+    }
+
+    #[rstest]
+    #[case::bearer("Bearer mF_9.B5f-4.1JqM", TokenType::Bearer, "mF_9.B5f-4.1JqM")]
+    #[case::dpop("DPoP mF_9.B5f-4.1JqM", TokenType::DPoP, "mF_9.B5f-4.1JqM")]
+    // Scheme matching is case-insensitive (RFC 7235 §2.1).
+    #[case::lower_bearer("bearer tok", TokenType::Bearer, "tok")]
+    #[case::upper_bearer("BEARER tok", TokenType::Bearer, "tok")]
+    #[case::lower_dpop("dpop tok", TokenType::DPoP, "tok")]
+    #[case::upper_dpop("DPOP tok", TokenType::DPoP, "tok")]
+    // Leading/trailing whitespace and collapsed separators still leave exactly
+    // two fields: the scheme and the token.
+    #[case::whitespace("  Bearer   the-token  ", TokenType::Bearer, "the-token")]
+    fn valid_token_is_extracted(
+        #[case] header: &'static str,
+        #[case] expected_type: TokenType,
+        #[case] expected_token: &str,
+    ) {
+        let (token_type, token) = extract(header).unwrap().unwrap();
+        assert_eq!(token_type, expected_type);
+        assert_eq!(token.expose_secret(), expected_token);
+    }
+
+    #[rstest]
+    #[case::scheme_only("Bearer")]
+    #[case::empty("   ")]
+    // A token value must not contain whitespace; a third field is rejected
+    // rather than silently truncated.
+    #[case::three_fields("Bearer tok extra")]
+    fn invalid_format_is_rejected(#[case] header: &'static str) {
+        assert!(
+            matches!(
+                extract(header),
+                Err(TokenExtractError::InvalidTokenHeaderFormat)
+            ),
+            "expected InvalidTokenHeaderFormat for {header:?}"
+        );
+    }
+
+    #[test]
+    fn absent_header_is_none() {
+        let headers = HeaderMap::new();
+        assert!(matches!(extract_token(&headers, &AUTHORIZATION), Ok(None)));
+    }
+
+    #[test]
+    fn unsupported_scheme_is_rejected() {
+        let err = extract("Basic dXNlcjpwYXNz").unwrap_err();
+        assert!(
+            matches!(err, TokenExtractError::UnsupportedTokenType { ref token_type } if token_type == "Basic"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn non_utf8_header_value_is_rejected() {
+        let mut headers = HeaderMap::new();
+        // 0xFF is never valid UTF-8, so `to_str` fails before any parsing.
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_bytes(b"Bearer \xff").unwrap(),
+        );
+        assert!(matches!(
+            extract_token(&headers, &AUTHORIZATION),
+            Err(TokenExtractError::TokenNotString { .. })
+        ));
+    }
+
+    #[test]
+    fn token_is_read_from_the_configured_header() {
+        let header = HeaderName::from_static("x-access-token");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            &header,
+            HeaderValue::from_static("Bearer custom-header-token"),
+        );
+
+        // The configured header is used...
+        let (token_type, token) = extract_token(&headers, &header).unwrap().unwrap();
+        assert_eq!(token_type, TokenType::Bearer);
+        assert_eq!(token.expose_secret(), "custom-header-token");
+
+        // ...and the default `Authorization` header is not consulted.
+        assert!(matches!(extract_token(&headers, &AUTHORIZATION), Ok(None)));
+    }
+}

--- a/huskarl-resource-server/src/validator/introspection/mod.rs
+++ b/huskarl-resource-server/src/validator/introspection/mod.rs
@@ -566,15 +566,15 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + MaybeSendSync + 'static> Access
     type Claims = Claims;
     type Error = IntrospectionValidateError;
 
-    async fn validate_request(
-        &self,
-        headers: &http::HeaderMap,
-        method: &http::Method,
-        uri: &http::Uri,
-        client_cert_der: Option<&[u8]>,
-    ) -> ValidationResult<Self::Claims, Self::Error> {
-        self.validate_request(headers, method, uri, client_cert_der)
-            .await
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> crate::core::platform::MaybeSendBoxFuture<'a, ValidationResult<Self::Claims, Self::Error>>
+    {
+        Box::pin(self.validate_request(headers, method, uri, client_cert_der))
     }
 }
 

--- a/huskarl-resource-server/src/validator/metadata.rs
+++ b/huskarl-resource-server/src/validator/metadata.rs
@@ -217,6 +217,7 @@ mod tests {
     };
 
     /// A configurable [`ToRfc6750Error`] test double.
+    #[derive(Debug)]
     struct TestError {
         scheme: Option<TokenType>,
         token_error: TokenValidationError,

--- a/huskarl-resource-server/src/validator/mod.rs
+++ b/huskarl-resource-server/src/validator/mod.rs
@@ -16,13 +16,14 @@ pub mod error;
 pub mod extract;
 pub mod introspection;
 pub mod metadata;
+pub mod multi_issuer;
 pub mod observe;
 pub mod rfc9068;
 
 use crate::{
     core::{
         jwt::{ConfirmationClaim, validator::ValidatedJwt},
-        platform::{MaybeSend, MaybeSendSync, SystemTime},
+        platform::{MaybeSendBoxFuture, MaybeSendSync, SystemTime},
     },
     error::ToRfc6750Error,
 };
@@ -42,13 +43,18 @@ pub trait AccessTokenValidator: MaybeSendSync {
     type Error: ToRfc6750Error;
 
     /// Validates an access token from the given HTTP request headers.
-    fn validate_request(
-        &self,
-        headers: &http::HeaderMap,
-        method: &http::Method,
-        uri: &http::Uri,
-        client_cert_der: Option<&[u8]>,
-    ) -> impl Future<Output = ValidationResult<Self::Claims, Self::Error>> + MaybeSend;
+    ///
+    /// Returns a boxed future so the trait is object-safe: heterogeneous
+    /// validators can be stored as `Box<dyn AccessTokenValidator<…>>` (see
+    /// [`multi_issuer`]). Concrete validators also expose an inherent `validate_request`
+    /// that returns an unboxed future for zero-cost direct use.
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> MaybeSendBoxFuture<'a, ValidationResult<Self::Claims, Self::Error>>;
 }
 
 /// The result of an [`AccessTokenValidator::validate_request`] call.

--- a/huskarl-resource-server/src/validator/multi_issuer/error.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/error.rs
@@ -1,0 +1,75 @@
+//! Error type for [`MultiIssuerValidator`](super::MultiIssuerValidator).
+
+use snafu::Snafu;
+
+use crate::{
+    TokenType,
+    error::{ChallengeParam, ToRfc6750Error, TokenErrorCode, TokenValidationError},
+    validator::extract::TokenExtractError,
+};
+
+/// A failure of a [`MultiIssuerValidator`](super::MultiIssuerValidator).
+///
+/// Distinct from the inner validators' errors because routing has a failure mode
+/// they do not: a token whose issuer cannot be determined or is not registered.
+/// Inner-validator failures are wrapped in [`MultiIssuerError::Validation`] and
+/// their RFC 6750 classification is forwarded unchanged.
+///
+/// `Debug`, `Display`, and [`std::error::Error`] are derived; the RFC 6750
+/// classification is provided by the [`ToRfc6750Error`] impl below.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum MultiIssuerError {
+    /// The access token could not be extracted from the request headers.
+    #[snafu(display("token presentation error"), context(false))]
+    Extract {
+        /// The underlying extraction error.
+        source: TokenExtractError,
+    },
+    /// A token was present, but its `iss` claim was missing, unparseable, or did
+    /// not match any registered issuer. Treated as `invalid_token`.
+    #[snafu(display("unrecognized token issuer"))]
+    UnrecognizedIssuer,
+    /// The validator selected for the token's issuer rejected it; its RFC 6750
+    /// classification is forwarded unchanged.
+    #[snafu(display("token validation error"))]
+    Validation {
+        /// The inner validator's error. Not named `source` because it is a
+        /// [`ToRfc6750Error`], not a [`std::error::Error`], so it does not chain.
+        error: Box<dyn ToRfc6750Error>,
+    },
+}
+
+impl ToRfc6750Error for MultiIssuerError {
+    fn attempted_scheme(&self) -> Option<TokenType> {
+        match self {
+            Self::Extract { source } => source.attempted_scheme(),
+            Self::UnrecognizedIssuer => None,
+            Self::Validation { error } => error.attempted_scheme(),
+        }
+    }
+
+    fn token_error(&self) -> TokenValidationError {
+        match self {
+            Self::Extract { source } => source.token_error(),
+            Self::UnrecognizedIssuer => TokenValidationError::Client(TokenErrorCode::InvalidToken),
+            Self::Validation { error } => error.token_error(),
+        }
+    }
+
+    fn error_description(&self) -> Option<String> {
+        match self {
+            Self::Extract { source } => source.error_description(),
+            Self::UnrecognizedIssuer => Some("unrecognized token issuer".to_owned()),
+            Self::Validation { error } => error.error_description(),
+        }
+    }
+
+    fn extra_params(&self) -> Vec<ChallengeParam> {
+        match self {
+            Self::Extract { source } => source.extra_params(),
+            Self::UnrecognizedIssuer => Vec::new(),
+            Self::Validation { error } => error.extra_params(),
+        }
+    }
+}

--- a/huskarl-resource-server/src/validator/multi_issuer/map.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/map.rs
@@ -1,0 +1,113 @@
+//! Claim normalization adapter for [`MultiIssuerValidator`](super::MultiIssuerValidator).
+
+use crate::{
+    AccessTokenValidator, ValidatedRequest,
+    core::platform::{MaybeSendBoxFuture, MaybeSendSync},
+    validator::{
+        ValidationResult,
+        metadata::{ProvideValidatorMetadata, ValidatorMetadata},
+    },
+};
+
+/// Wraps a validator, normalizing its source-specific claims into a common type `C`.
+///
+/// The mapping is an ordinary `Fn(SourceClaims) -> C`; the library attaches no
+/// semantics to it. Use this to give several per-issuer validators a single
+/// claims type so they can be combined in a
+/// [`MultiIssuerValidator`](super::MultiIssuerValidator). The normalization
+/// function is then handed to [`MapClaims::new`] alongside a validator:
+///
+/// ```
+/// #[derive(serde::Deserialize)]
+/// struct WireClaims {
+///     scope: Option<String>,
+/// }
+/// struct Principal {
+///     scopes: Vec<String>,
+/// }
+///
+/// // `normalize` is the `Fn(SourceClaims) -> C` passed to `MapClaims::new(validator, normalize)`.
+/// let normalize = |c: WireClaims| Principal {
+///     scopes: c
+///         .scope
+///         .unwrap_or_default()
+///         .split_whitespace()
+///         .map(str::to_owned)
+///         .collect(),
+/// };
+/// # let _ = normalize(WireClaims { scope: Some("a b".into()) });
+/// ```
+pub struct MapClaims<V, F> {
+    inner: V,
+    f: F,
+}
+
+impl<V, F> MapClaims<V, F> {
+    /// Wraps `inner`, applying `f` to the claims of every validated request.
+    pub fn new(inner: V, f: F) -> Self {
+        Self { inner, f }
+    }
+
+    /// Returns a reference to the wrapped validator.
+    pub fn inner(&self) -> &V {
+        &self.inner
+    }
+}
+
+impl<V, F, C> AccessTokenValidator for MapClaims<V, F>
+where
+    V: AccessTokenValidator,
+    F: Fn(V::Claims) -> C + MaybeSendSync,
+    C: MaybeSendSync,
+{
+    type Claims = C;
+    type Error = V::Error;
+
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> MaybeSendBoxFuture<'a, ValidationResult<C, V::Error>> {
+        Box::pin(async move {
+            let result = self
+                .inner
+                .validate_request(headers, method, uri, client_cert_der)
+                .await;
+
+            ValidationResult {
+                outcome: result.outcome.map(|opt| opt.map(|v| self.remap(v))),
+                dpop_nonce: result.dpop_nonce,
+            }
+        })
+    }
+}
+
+impl<V, F, C> MapClaims<V, F>
+where
+    V: AccessTokenValidator,
+    F: Fn(V::Claims) -> C,
+{
+    /// Transforms only the extra-claims payload; the universal token fields
+    /// (`iss`, `sub`, `aud`, `exp`, `cnf`, …) pass through unchanged.
+    fn remap(&self, v: ValidatedRequest<V::Claims>) -> ValidatedRequest<C> {
+        ValidatedRequest {
+            issuer: v.issuer,
+            subject: v.subject,
+            audience: v.audience,
+            jti: v.jti,
+            issued_at: v.issued_at,
+            expiration: v.expiration,
+            cnf: v.cnf,
+            claims: (self.f)(v.claims),
+            introspection_jwt: v.introspection_jwt,
+        }
+    }
+}
+
+impl<V: ProvideValidatorMetadata, F> ProvideValidatorMetadata for MapClaims<V, F> {
+    fn validator_metadata(&self, resource: Option<&str>) -> ValidatorMetadata {
+        self.inner.validator_metadata(resource)
+    }
+}

--- a/huskarl-resource-server/src/validator/multi_issuer/mod.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/mod.rs
@@ -1,0 +1,373 @@
+//! Accept access tokens from several issuers with one validator.
+//!
+//! [`MultiIssuerValidator`] routes each request to a per-issuer validator by
+//! reading the token's `iss` claim, then delegates the full validation to it. It
+//! implements [`AccessTokenValidator`], so it drops into a `ValidatorLayer`,
+//! Pingora guard, or any other consumer exactly like a single-issuer validator.
+//!
+//! # How routing stays safe
+//!
+//! The issuer is read from the token's payload **without verifying the
+//! signature**, and is used *only* to select a validator. The selected validator
+//! independently re-checks `iss`, the signature (against its own JWKS), the
+//! audience, and any sender-constraint binding — so a token that lies about its
+//! issuer is merely routed to a validator that rejects it. Routing grants no
+//! trust; verification is still done in full by the chosen validator.
+//!
+//! Each per-issuer validator carries its own audience: pin it exactly, because
+//! the audience check is the access boundary. This matters most when a validator
+//! accepts tokens (such as OIDC ID tokens) that a different relying party could
+//! also obtain.
+//!
+//! # Unifying claim types
+//!
+//! Per-issuer validators usually have different claims types. Give them a common
+//! type `C` by wrapping each in [`MapClaims`], whose mapping is a plain
+//! `Fn(SourceClaims) -> C`. The library attaches no semantics to that mapping —
+//! any authorization model your application layers on top of `C` is its own
+//! concern.
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//!
+//! use huskarl_resource_server::{
+//!     core::{jwk::JwksSource, jwt::validator::ClaimCheck},
+//!     validator::{
+//!         custom::CustomValidator,
+//!         multi_issuer::{MapClaims, MultiIssuerValidator},
+//!     },
+//! };
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! # let http = huskarl_reqwest::ReqwestClient::builder().build().await?;
+//! #[derive(Clone, serde::Deserialize)]
+//! struct GoogleIdClaims {
+//!     email: Option<String>,
+//!     email_verified: Option<bool>,
+//! }
+//! #[derive(Clone, serde::Deserialize)]
+//! struct OktaClaims {
+//!     #[serde(default)]
+//!     scp: Vec<String>,
+//! }
+//!
+//! #[derive(Clone)]
+//! struct Principal {
+//!     email: Option<String>,
+//!     scopes: Vec<String>,
+//! }
+//!
+//! let google = CustomValidator::builder()
+//!     .with_claims::<GoogleIdClaims>()
+//!     .authorization_server("https://accounts.google.com")
+//!     .issuer(ClaimCheck::required_value("https://accounts.google.com"))
+//!     .audience(ClaimCheck::required_value("<your-google-oauth-client-id>"))
+//!     .token_type(ClaimCheck::NoCheck)
+//!     .require_jti(false)
+//!     .jwks_uri("https://www.googleapis.com/oauth2/v3/certs".parse()?)
+//!     .jws_verifier_factory(Arc::new(
+//!         JwksSource::builder().http_client(http.clone()).build(),
+//!     ))
+//!     .build()
+//!     .await?;
+//!
+//! let okta = CustomValidator::builder()
+//!     .with_claims::<OktaClaims>()
+//!     .authorization_server("https://example.okta.com/oauth2/default")
+//!     .issuer(ClaimCheck::required_value(
+//!         "https://example.okta.com/oauth2/default",
+//!     ))
+//!     .audience(ClaimCheck::required_value("api://my-resource"))
+//!     .jwks_uri("https://example.okta.com/oauth2/default/v1/keys".parse()?)
+//!     .jws_verifier_factory(Arc::new(
+//!         JwksSource::builder().http_client(http.clone()).build(),
+//!     ))
+//!     .build()
+//!     .await?;
+//!
+//! let validator = MultiIssuerValidator::<Principal>::builder()
+//!     .source(
+//!         "https://accounts.google.com",
+//!         MapClaims::new(google, |c: GoogleIdClaims| Principal {
+//!             email: c.email.filter(|_| c.email_verified == Some(true)),
+//!             scopes: Vec::new(),
+//!         }),
+//!     )
+//!     .source(
+//!         "https://example.okta.com/oauth2/default",
+//!         MapClaims::new(okta, |c: OktaClaims| Principal {
+//!             email: None,
+//!             scopes: c.scp,
+//!         }),
+//!     )
+//!     .build();
+//! # let _ = validator;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod error;
+mod map;
+mod source;
+
+use std::collections::HashMap;
+
+use base64::prelude::*;
+pub use error::MultiIssuerError;
+use http::{HeaderName, header::AUTHORIZATION};
+pub use map::MapClaims;
+use serde::Deserialize;
+
+use crate::{
+    AccessTokenValidator,
+    core::platform::{MaybeSendBoxFuture, MaybeSendSync},
+    error::ToRfc6750Error,
+    validator::{
+        ValidationResult,
+        extract::extract_token,
+        metadata::{ProvideValidatorMetadata, ValidatorMetadata},
+        multi_issuer::source::{FoldError, SourceValidator},
+    },
+};
+
+/// A validator that accepts tokens from several issuers, routing each request to
+/// a per-issuer validator that produces a common claims type `C`.
+///
+/// Build one with [`MultiIssuerValidator::builder`]. See the [module
+/// documentation](self) for routing semantics and an example.
+pub struct MultiIssuerValidator<C> {
+    by_issuer: HashMap<String, Box<dyn SourceValidator<C>>>,
+    metadata: ValidatorMetadata,
+    token_header: HeaderName,
+}
+
+#[bon::bon]
+impl<C: MaybeSendSync + 'static> MultiIssuerValidator<C> {
+    /// Creates a [`MultiIssuerValidator`], precomputing the union of the
+    /// registered validators' metadata.
+    ///
+    /// Register validators with [`source`](MultiIssuerValidatorBuilder::source);
+    /// the build is invoked via [`MultiIssuerValidator::builder`].
+    #[builder]
+    pub fn new(
+        /// Per-issuer validators, accumulated by
+        /// [`source`](MultiIssuerValidatorBuilder::source).
+        #[builder(field)]
+        sources: Vec<(String, Box<dyn SourceValidator<C>>)>,
+        /// The HTTP header to extract the access token from. Defaults to
+        /// `Authorization`.
+        #[builder(default = AUTHORIZATION)]
+        token_header: HeaderName,
+    ) -> Self {
+        let metadata = union_metadata(&sources, None);
+        Self {
+            by_issuer: sources.into_iter().collect(),
+            metadata,
+            token_header,
+        }
+    }
+}
+
+impl<C: MaybeSendSync + 'static, S: multi_issuer_validator_builder::State>
+    MultiIssuerValidatorBuilder<C, S>
+{
+    /// Registers `validator` for tokens whose `iss` claim equals `issuer`.
+    ///
+    /// The validator must produce `Claims = C`; wrap source-specific validators
+    /// in [`MapClaims`] to normalize their claims into `C`. If the same issuer is
+    /// registered twice, the last registration wins. Call repeatedly, once per
+    /// authorization server.
+    pub fn source<V>(mut self, issuer: impl Into<String>, validator: V) -> Self
+    where
+        V: AccessTokenValidator<Claims = C> + ProvideValidatorMetadata + 'static,
+        V::Error: ToRfc6750Error + 'static,
+    {
+        self.sources
+            .push((issuer.into(), Box::new(FoldError(validator))));
+        self
+    }
+}
+
+impl<C: MaybeSendSync + 'static> AccessTokenValidator for MultiIssuerValidator<C> {
+    type Claims = C;
+    type Error = MultiIssuerError;
+
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> MaybeSendBoxFuture<'a, ValidationResult<C, MultiIssuerError>> {
+        Box::pin(async move {
+            // Extract the token. No token is an unauthenticated request, matching
+            // the single-issuer validators (`Ok(None)`), not an error.
+            let token = match extract_token(headers, &self.token_header) {
+                Ok(Some((_token_type, token))) => token,
+                Ok(None) => {
+                    return ValidationResult {
+                        outcome: Ok(None),
+                        dpop_nonce: None,
+                    };
+                }
+                Err(e) => {
+                    return ValidationResult {
+                        outcome: Err(MultiIssuerError::Extract { source: e }),
+                        dpop_nonce: None,
+                    };
+                }
+            };
+
+            // Route on the unverified issuer; the selected validator does all
+            // real verification. A missing/unparseable/unregistered issuer is
+            // rejected.
+            let Some(validator) =
+                peek_issuer(token.expose_secret()).and_then(|iss| self.by_issuer.get(&iss))
+            else {
+                return ValidationResult {
+                    outcome: Err(MultiIssuerError::UnrecognizedIssuer),
+                    dpop_nonce: None,
+                };
+            };
+
+            validator
+                .validate_request(headers, method, uri, client_cert_der)
+                .await
+        })
+    }
+}
+
+impl<C> ProvideValidatorMetadata for MultiIssuerValidator<C> {
+    fn validator_metadata(&self, resource: Option<&str>) -> ValidatorMetadata {
+        // `resource` is per-deployment, so stamp it onto the precomputed union.
+        ValidatorMetadata {
+            resource: resource.map(str::to_owned),
+            ..self.metadata.clone()
+        }
+    }
+}
+
+/// Reads the `iss` claim from a JWS compact payload **without verifying the
+/// signature**.
+///
+/// The result is used only to select a validator (see the [module
+/// documentation](self)); it carries no trust. Returns `None` if the token is
+/// not a three-part JWS, the payload is not valid base64url JSON, or it has no
+/// string `iss`.
+fn peek_issuer(token: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct IssOnly {
+        iss: String,
+    }
+
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    parts.next()?; // require a signature segment
+    if parts.next().is_some() {
+        return None; // more than three segments is not a JWS
+    }
+
+    let bytes = BASE64_URL_SAFE_NO_PAD.decode(payload).ok()?;
+    serde_json::from_slice::<IssOnly>(&bytes)
+        .ok()
+        .map(|i| i.iss)
+}
+
+/// Builds the union of the registered validators' [`ValidatorMetadata`]:
+/// concatenated `authorization_servers`, unioned `DPoP` signing algorithms, and
+/// `dpop_bound_access_tokens_required` only if *every* source requires it (so a
+/// token may still be presented as Bearer if any source accepts Bearer).
+fn union_metadata<C>(
+    sources: &[(String, Box<dyn SourceValidator<C>>)],
+    resource: Option<&str>,
+) -> ValidatorMetadata {
+    let mut authorization_servers = Vec::new();
+    let mut dpop_algs: Vec<String> = Vec::new();
+    let mut all_require_dpop = !sources.is_empty();
+
+    for (_issuer, validator) in sources {
+        let m = validator.validator_metadata(resource);
+        if let Some(servers) = m.authorization_servers {
+            authorization_servers.extend(servers);
+        }
+        if let Some(algs) = m.dpop_signing_alg_values_supported {
+            for alg in algs {
+                if !dpop_algs.contains(&alg) {
+                    dpop_algs.push(alg);
+                }
+            }
+        }
+        all_require_dpop &= m.dpop_bound_access_tokens_required.unwrap_or(false);
+    }
+
+    ValidatorMetadata {
+        realm: None,
+        authorization_servers: (!authorization_servers.is_empty()).then_some(authorization_servers),
+        dpop_signing_alg_values_supported: (!dpop_algs.is_empty()).then_some(dpop_algs),
+        dpop_bound_access_tokens_required: Some(all_require_dpop),
+        resource: resource.map(str::to_owned),
+        bearer_methods_supported: Some(vec!["header"]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// base64url-no-pad encodes `s` as one JWS segment.
+    fn seg(s: &str) -> String {
+        BASE64_URL_SAFE_NO_PAD.encode(s)
+    }
+
+    /// Assembles a three-part compact JWS with the given base64url payload.
+    /// The header and signature are opaque to `peek_issuer`, so they are fixed.
+    fn token_with_payload(payload_b64: &str) -> String {
+        format!("{}.{payload_b64}.{}", seg(r#"{"alg":"RS256"}"#), seg("sig"))
+    }
+
+    #[rstest]
+    // The signature is never checked, so any non-empty signature segment works.
+    #[case::standard(
+        token_with_payload(&seg(r#"{"iss":"https://issuer.example","sub":"abc"}"#)),
+        "https://issuer.example"
+    )]
+    // RFC 7519 permits an empty signature (`alg: none`); it is still three
+    // segments, and routing carries no trust regardless.
+    #[case::empty_signature(
+        format!("{}.{}.", seg(r#"{"alg":"none"}"#), seg(r#"{"iss":"iss-a"}"#)),
+        "iss-a"
+    )]
+    fn reads_iss_from_unverified_payload(#[case] token: String, #[case] expected: &str) {
+        assert_eq!(peek_issuer(&token).as_deref(), Some(expected));
+    }
+
+    #[rstest]
+    #[case::single_segment("not-a-jwt".to_owned())]
+    // No signature segment: not a JWS.
+    #[case::two_segments(format!("{}.{}", seg(r#"{"alg":"none"}"#), seg(r#"{"iss":"iss-a"}"#)))]
+    // More than three segments (e.g. a JWE) is not a compact JWS.
+    #[case::four_segments(format!(
+        "{}.{}.{}.{}",
+        seg(r#"{"alg":"none"}"#),
+        seg(r#"{"iss":"iss-a"}"#),
+        seg("sig"),
+        seg("extra"),
+    ))]
+    fn wrong_segment_count_is_rejected(#[case] token: String) {
+        assert_eq!(peek_issuer(&token), None);
+    }
+
+    #[rstest]
+    // `!` is outside the base64url alphabet.
+    #[case::non_base64url("not!base64".to_owned())]
+    #[case::not_json(seg("this is not json"))]
+    #[case::no_iss(seg(r#"{"sub":"abc","aud":"api"}"#))]
+    // `iss` deserializes as a `String`; a numeric value fails to parse.
+    #[case::non_string_iss(seg(r#"{"iss":42}"#))]
+    fn malformed_payload_is_rejected(#[case] payload_b64: String) {
+        assert_eq!(peek_issuer(&token_with_payload(&payload_b64)), None);
+    }
+}

--- a/huskarl-resource-server/src/validator/multi_issuer/source.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/source.rs
@@ -1,0 +1,75 @@
+//! What a registered source is, internally: the [`SourceValidator`] trait object
+//! the composite stores per issuer, and the [`FoldError`] wrapper that turns an
+//! arbitrary validator into one.
+//!
+//! Since [`AccessTokenValidator`] is object-safe, the only adaptation a source
+//! needs is (a) folding its error into [`MultiIssuerError`] so all stored sources
+//! share one error type, and (b) combining [`AccessTokenValidator`] and
+//! [`ProvideValidatorMetadata`] into a single trait object (a trait object can
+//! name only one non-auto trait).
+
+use crate::{
+    AccessTokenValidator,
+    core::platform::{MaybeSendBoxFuture, MaybeSendSync},
+    validator::{
+        ValidationResult,
+        metadata::{ProvideValidatorMetadata, ValidatorMetadata},
+        multi_issuer::error::MultiIssuerError,
+    },
+};
+
+/// A per-issuer entry: an access token validator producing `Claims = C` with its
+/// error folded to [`MultiIssuerError`], plus its RFC 9728 metadata.
+///
+/// Implemented for any [`FoldError`]-wrapped source; stored as
+/// `Box<dyn SourceValidator<C>>`.
+pub(super) trait SourceValidator<C>:
+    AccessTokenValidator<Claims = C, Error = MultiIssuerError> + ProvideValidatorMetadata
+{
+}
+
+impl<C, T> SourceValidator<C> for T where
+    T: AccessTokenValidator<Claims = C, Error = MultiIssuerError> + ProvideValidatorMetadata
+{
+}
+
+/// Wraps a validator, folding its error into [`MultiIssuerError::Validation`] so
+/// heterogeneous sources present one error type to the composite.
+pub(super) struct FoldError<V>(pub(super) V);
+
+impl<V, C> AccessTokenValidator for FoldError<V>
+where
+    V: AccessTokenValidator<Claims = C>,
+    V::Error: 'static,
+    C: MaybeSendSync,
+{
+    type Claims = C;
+    type Error = MultiIssuerError;
+
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> MaybeSendBoxFuture<'a, ValidationResult<C, MultiIssuerError>> {
+        Box::pin(async move {
+            let result = self
+                .0
+                .validate_request(headers, method, uri, client_cert_der)
+                .await;
+            ValidationResult {
+                outcome: result
+                    .outcome
+                    .map_err(|e| MultiIssuerError::Validation { error: Box::new(e) }),
+                dpop_nonce: result.dpop_nonce,
+            }
+        })
+    }
+}
+
+impl<V: ProvideValidatorMetadata> ProvideValidatorMetadata for FoldError<V> {
+    fn validator_metadata(&self, resource: Option<&str>) -> ValidatorMetadata {
+        self.0.validator_metadata(resource)
+    }
+}

--- a/huskarl-resource-server/src/validator/rfc9068/mod.rs
+++ b/huskarl-resource-server/src/validator/rfc9068/mod.rs
@@ -368,15 +368,15 @@ impl<ExtraClaims: for<'de> Deserialize<'de> + Clone + MaybeSendSync + 'static> A
     type Claims = Rfc9068AccessTokenClaims<ExtraClaims>;
     type Error = ValidateHeadersError;
 
-    async fn validate_request(
-        &self,
-        headers: &http::HeaderMap,
-        method: &http::Method,
-        uri: &http::Uri,
-        client_cert_der: Option<&[u8]>,
-    ) -> ValidationResult<Self::Claims, Self::Error> {
-        self.validate_request(headers, method, uri, client_cert_der)
-            .await
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> crate::core::platform::MaybeSendBoxFuture<'a, ValidationResult<Self::Claims, Self::Error>>
+    {
+        Box::pin(self.validate_request(headers, method, uri, client_cert_der))
     }
 }
 

--- a/huskarl-resource-server/tests/multi_issuer.rs
+++ b/huskarl-resource-server/tests/multi_issuer.rs
@@ -1,0 +1,334 @@
+#![cfg(not(target_family = "wasm"))]
+
+//! Integration tests for [`MultiIssuerValidator`]: routing by issuer, the
+//! audience-confusion boundary, unrecognized issuers, unauthenticated requests,
+//! and metadata union.
+
+use std::sync::Arc;
+
+use httpmock::prelude::*;
+use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
+use huskarl_reqwest::ReqwestClient;
+use huskarl_resource_server::{
+    core::{
+        EndpointUrl,
+        crypto::signer::AsymmetricJwsSigner,
+        jwk::{JwksSource, PublicJwks},
+        jwt::Jwt,
+        platform::SystemTime,
+    },
+    error::{TokenErrorCode, TokenValidationError},
+    validator::{
+        AccessTokenValidator,
+        custom::CustomValidator,
+        metadata::ProvideValidatorMetadata,
+        multi_issuer::{MapClaims, MultiIssuerError, MultiIssuerValidator},
+    },
+};
+use serde::{Deserialize, Serialize};
+
+const GOOGLE_AUDIENCE: &str = "google-oauth-client-id";
+const OKTA_AUDIENCE: &str = "api://my-resource";
+
+#[derive(Clone, Deserialize)]
+struct GoogleIdClaims {
+    email: Option<String>,
+    email_verified: Option<bool>,
+}
+
+#[derive(Clone, Deserialize)]
+struct OktaClaims {
+    #[serde(default)]
+    scp: Vec<String>,
+}
+
+/// The canonical, source-agnostic claims an application would consume.
+#[derive(Clone, Debug, PartialEq)]
+struct Principal {
+    email: Option<String>,
+    scopes: Vec<String>,
+}
+
+/// A mock authorization server: a signing key and a JWKS endpoint.
+struct MockAs {
+    // Held only to keep the mock server (and its JWKS endpoint) alive.
+    #[allow(dead_code)]
+    server: MockServer,
+    key: PrivateKey,
+    issuer: String,
+}
+
+impl MockAs {
+    fn start() -> Self {
+        let server = MockServer::start();
+        let key = PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap();
+        let jwks = PublicJwks::new(vec![key.public_key_jwk().into_owned()]);
+        server.mock(|when, then| {
+            when.method(GET).path("/jwks.json");
+            then.status(200)
+                .header("content-type", "application/jwk-set+json")
+                .json_body_obj(&jwks);
+        });
+        let issuer = format!("http://{}", server.address());
+        Self {
+            server,
+            key,
+            issuer,
+        }
+    }
+
+    fn jwks_uri(&self) -> EndpointUrl {
+        format!("{}/jwks.json", self.issuer).parse().unwrap()
+    }
+
+    /// Mints a token signed by this AS with the given issuer/audience/claims.
+    /// `issuer` is a parameter so tests can forge a mismatching `iss`.
+    async fn mint<C: Serialize + Clone>(&self, issuer: &str, audience: &str, claims: C) -> String {
+        let jwt = Jwt::builder()
+            .typ("JWT")
+            .issuer(issuer.to_owned())
+            .audience(audience.to_owned())
+            .subject("user-123")
+            .issued_now()
+            .expiration(SystemTime::now() + std::time::Duration::from_secs(3600))
+            .claims(claims)
+            .build();
+        jwt.to_jws_compact(&self.key)
+            .await
+            .unwrap()
+            .expose_secret()
+            .to_owned()
+    }
+}
+
+#[derive(Serialize, Clone)]
+struct GoogleWire {
+    email: String,
+    email_verified: bool,
+}
+
+#[derive(Serialize, Clone)]
+struct OktaWire {
+    scp: Vec<String>,
+}
+
+/// Builds a `MultiIssuerValidator` over the two mock authorization servers.
+async fn build(
+    http: &ReqwestClient,
+    google: &MockAs,
+    okta: &MockAs,
+) -> MultiIssuerValidator<Principal> {
+    let google_validator = CustomValidator::builder()
+        .with_claims::<GoogleIdClaims>()
+        .authorization_server(google.issuer.clone())
+        .issuer(
+            huskarl_resource_server::core::jwt::validator::ClaimCheck::required_value(
+                &google.issuer,
+            ),
+        )
+        .audience(
+            huskarl_resource_server::core::jwt::validator::ClaimCheck::required_value(
+                GOOGLE_AUDIENCE,
+            ),
+        )
+        .require_jti(false)
+        .jwks_uri(google.jwks_uri())
+        .jws_verifier_factory(Arc::new(
+            JwksSource::builder().http_client(http.clone()).build(),
+        ))
+        .build()
+        .await
+        .unwrap();
+
+    let okta_validator = CustomValidator::builder()
+        .with_claims::<OktaClaims>()
+        .authorization_server(okta.issuer.clone())
+        .issuer(
+            huskarl_resource_server::core::jwt::validator::ClaimCheck::required_value(&okta.issuer),
+        )
+        .audience(
+            huskarl_resource_server::core::jwt::validator::ClaimCheck::required_value(
+                OKTA_AUDIENCE,
+            ),
+        )
+        .require_jti(false)
+        .jwks_uri(okta.jwks_uri())
+        .jws_verifier_factory(Arc::new(
+            JwksSource::builder().http_client(http.clone()).build(),
+        ))
+        .build()
+        .await
+        .unwrap();
+
+    MultiIssuerValidator::<Principal>::builder()
+        .source(
+            google.issuer.clone(),
+            MapClaims::new(google_validator, |c: GoogleIdClaims| Principal {
+                email: c.email.filter(|_| c.email_verified == Some(true)),
+                scopes: Vec::new(),
+            }),
+        )
+        .source(
+            okta.issuer.clone(),
+            MapClaims::new(okta_validator, |c: OktaClaims| Principal {
+                email: None,
+                scopes: c.scp,
+            }),
+        )
+        .build()
+}
+
+fn bearer(token: &str) -> http::HeaderMap {
+    let mut headers = http::HeaderMap::new();
+    headers.insert(
+        http::header::AUTHORIZATION,
+        format!("Bearer {token}").parse().unwrap(),
+    );
+    headers
+}
+
+async fn validate(
+    v: &MultiIssuerValidator<Principal>,
+    headers: &http::HeaderMap,
+) -> Result<Option<Principal>, MultiIssuerError> {
+    v.validate_request(
+        headers,
+        &http::Method::GET,
+        &"https://api.example.com/data".parse().unwrap(),
+        None,
+    )
+    .await
+    .outcome
+    .map(|opt| opt.map(|vr| vr.claims))
+}
+
+#[tokio::test]
+async fn routes_each_issuer_to_its_validator() {
+    let google = MockAs::start();
+    let okta = MockAs::start();
+    let http = ReqwestClient::builder().build().await.unwrap();
+    let validator = build(&http, &google, &okta).await;
+
+    let g_token = google
+        .mint(
+            &google.issuer,
+            GOOGLE_AUDIENCE,
+            GoogleWire {
+                email: "alice@example.com".into(),
+                email_verified: true,
+            },
+        )
+        .await;
+    let principal = validate(&validator, &bearer(&g_token))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(principal.email.as_deref(), Some("alice@example.com"));
+    assert!(principal.scopes.is_empty());
+
+    let o_token = okta
+        .mint(
+            &okta.issuer,
+            OKTA_AUDIENCE,
+            OktaWire {
+                scp: vec!["read".into(), "write".into()],
+            },
+        )
+        .await;
+    let principal = validate(&validator, &bearer(&o_token))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(principal.email, None);
+    assert_eq!(principal.scopes, vec!["read", "write"]);
+}
+
+/// A validly Google-signed token minted for a *different* audience must be
+/// rejected — the per-source audience pin is the access boundary.
+#[tokio::test]
+async fn rejects_audience_confusion() {
+    let google = MockAs::start();
+    let okta = MockAs::start();
+    let http = ReqwestClient::builder().build().await.unwrap();
+    let validator = build(&http, &google, &okta).await;
+
+    let token = google
+        .mint(
+            &google.issuer,
+            "some-other-relying-party", // not GOOGLE_AUDIENCE
+            GoogleWire {
+                email: "alice@example.com".into(),
+                email_verified: true,
+            },
+        )
+        .await;
+
+    let err = validate(&validator, &bearer(&token)).await.unwrap_err();
+    assert!(matches!(err, MultiIssuerError::Validation { .. }));
+    assert!(matches!(
+        err.token_error_code(),
+        Some(TokenErrorCode::InvalidToken)
+    ));
+}
+
+#[tokio::test]
+async fn rejects_unrecognized_issuer() {
+    let google = MockAs::start();
+    let okta = MockAs::start();
+    let http = ReqwestClient::builder().build().await.unwrap();
+    let validator = build(&http, &google, &okta).await;
+
+    // Signed by a real key, but `iss` is not registered.
+    let token = google
+        .mint(
+            "https://evil.example",
+            GOOGLE_AUDIENCE,
+            GoogleWire {
+                email: "mallory@evil.example".into(),
+                email_verified: true,
+            },
+        )
+        .await;
+
+    let err = validate(&validator, &bearer(&token)).await.unwrap_err();
+    assert!(matches!(err, MultiIssuerError::UnrecognizedIssuer));
+}
+
+#[tokio::test]
+async fn no_token_is_unauthenticated() {
+    let google = MockAs::start();
+    let okta = MockAs::start();
+    let http = ReqwestClient::builder().build().await.unwrap();
+    let validator = build(&http, &google, &okta).await;
+
+    let outcome = validate(&validator, &http::HeaderMap::new()).await.unwrap();
+    assert!(outcome.is_none());
+}
+
+#[tokio::test]
+async fn metadata_unions_authorization_servers() {
+    let google = MockAs::start();
+    let okta = MockAs::start();
+    let http = ReqwestClient::builder().build().await.unwrap();
+    let validator = build(&http, &google, &okta).await;
+
+    let meta = validator.validator_metadata(Some("https://api.example.com"));
+    let servers = meta.authorization_servers.unwrap();
+    assert!(servers.contains(&google.issuer));
+    assert!(servers.contains(&okta.issuer));
+    assert_eq!(meta.resource.as_deref(), Some("https://api.example.com"));
+}
+
+/// Small helper to read the RFC 6750 error code off a classification.
+trait TokenErrorCodeExt {
+    fn token_error_code(&self) -> Option<TokenErrorCode>;
+}
+impl TokenErrorCodeExt for MultiIssuerError {
+    fn token_error_code(&self) -> Option<TokenErrorCode> {
+        use huskarl_resource_server::error::ToRfc6750Error as _;
+        match self.token_error() {
+            TokenValidationError::Client(code) => Some(code),
+            TokenValidationError::Server(_) => None,
+        }
+    }
+}


### PR DESCRIPTION
MultiIssuerValidator can route between validators based on the issuer value of a JWT. Also adds Debug bound to ToRfc6750Error.