### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-native"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-webcrypto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "huskarl-core",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bon",
  "darling",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-reqwest"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bon",
  "bytes",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-resource-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ default-members = [
 exclude = ["huskarl-core/fuzz"]
 
 [workspace.dependencies]
-huskarl = { version = "0.8", path = "./huskarl" }
-huskarl-core = { version = "0.7", path = "./huskarl-core" }
+huskarl = { version = "0.9", path = "./huskarl" }
+huskarl-core = { version = "0.8", path = "./huskarl-core" }
 huskarl-macros = { version = "0.3", path = "./huskarl-macros" }
 huskarl-reqwest = { version = "0.7", path = "./huskarl-reqwest" }
-huskarl-crypto-native = { version = "0.8", path = "./huskarl-crypto-native" }
-huskarl-crypto-webcrypto = { version = "0.8", path = "./huskarl-crypto-webcrypto" }
+huskarl-crypto-native = { version = "0.9", path = "./huskarl-crypto-native" }
+huskarl-crypto-webcrypto = { version = "0.9", path = "./huskarl-crypto-webcrypto" }
 
 bon = { version = "3.9", default-features = false, features = [
   "alloc",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.7.1...huskarl-core-v0.8.0) - 2026-07-02
+
+### Added
+
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+- *(core)* Add configurable TTL to JwksSource ([#129](https://github.com/huskarl-rs/huskarl/pull/129))
+
+### Fixed
+
+- *(core)* Remove fuzz Cargo.lock
+- *(core)* Bound metrics alg label to registered JWS algorithms ([#125](https://github.com/huskarl-rs/huskarl/pull/125))
+
+### Other
+
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- *(core)* [**breaking**] Remove dead UnsealError::AuthenticationFailed variant ([#128](https://github.com/huskarl-rs/huskarl/pull/128))
+- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
+- Limit body size of responses (default 1Mb) ([#123](https://github.com/huskarl-rs/huskarl/pull/123))
+
 ## [0.7.1] - 2026-06-29
 
 ### Changes

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-native/CHANGELOG.md
+++ b/huskarl-crypto-native/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.8.5...huskarl-crypto-native-v0.9.0) - 2026-07-02
+
+### Added
+
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Other
+
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+
 ## [0.8.5] - 2026-06-30
 
 ### Changes

--- a/huskarl-crypto-native/Cargo.toml
+++ b/huskarl-crypto-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-native"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Native crypto for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-webcrypto/CHANGELOG.md
+++ b/huskarl-crypto-webcrypto/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.8.0...huskarl-crypto-webcrypto-v0.9.0) - 2026-07-02
+
+### Added
+
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Other
+
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- Require RSA keys to be 2024 bits or more for webcrypto. ([#120](https://github.com/huskarl-rs/huskarl/pull/120))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+
  - Require RSA keys to be at least 2048 bits.
 
 ## [0.8.0] - 2026-06-15

--- a/huskarl-crypto-webcrypto/Cargo.toml
+++ b/huskarl-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-webcrypto"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "WebCrypto support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-macros/CHANGELOG.md
+++ b/huskarl-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.3.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.0...huskarl-macros-v0.3.1) - 2026-07-02
+
+### Other
+
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+
 ### Removed
 
 - `#[try_builder]` and its `#[try_setter(Trait::method)]` field attribute.

--- a/huskarl-macros/Cargo.toml
+++ b/huskarl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Procedural macros for the huskarl OAuth2 client library."

--- a/huskarl-reqwest/Cargo.toml
+++ b/huskarl-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-reqwest"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.92"
 description = "reqwest support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.8.0...huskarl-resource-server-v0.9.0) - 2026-07-02
+
+### Added
+
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Other
+
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- Reduce version numbers to init release-plz without publishing.
+- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
+- Strip control chars from www-authenticate parameters ([#122](https://github.com/huskarl-rs/huskarl/pull/122))
+- Add MultiIssuerValidator, box futures in AccessTokenValidator to make them dyn compatible. ([#121](https://github.com/huskarl-rs/huskarl/pull/121))
+- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
+- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
+- Build the RFC 7662 introspection request via oauth_form ([#100](https://github.com/huskarl-rs/huskarl/pull/100))
+- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
+- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+- Simplify some code
+
  - Breaking: Make AccessTokenValidator dyn-compatible (with boxed futures).
  - Add MultiIssuerValidator which can route validator by iss value.
  - Add `non_exhaustive` to various error types.

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "OAuth2 resource server (JWT validation) support for the huskarl ecosystem."

--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.8.0...huskarl-v0.9.0) - 2026-07-02
+
+### Added
+
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Fixed
+
+- *(client)* Serialize authorization-request max_age as seconds ([#133](https://github.com/huskarl-rs/huskarl/pull/133))
+
+### Other
+
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- Reduce version numbers to init release-plz without publishing.
+- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
+- Update integration tests to support keycloak/dex/node-oidc-provider/Okta. ([#119](https://github.com/huskarl-rs/huskarl/pull/119))
+- Prefer form over basic client credentials auth (aligning with OAuth 2.1). ([#117](https://github.com/huskarl-rs/huskarl/pull/117))
+- Add DCR fields from OIDC DCR. ([#116](https://github.com/huskarl-rs/huskarl/pull/116))
+- Add Dynamic Client Registration (RFC 7591) ([#115](https://github.com/huskarl-rs/huskarl/pull/115))
+- Tighten documentation across grants, cache, and authorizer ([#113](https://github.com/huskarl-rs/huskarl/pull/113))
+- Add cache state reporting, refresh jitter, and shared-store-safe refresh. ([#112](https://github.com/huskarl-rs/huskarl/pull/112))
+- Implement PartialEq/Eq for RefreshToken ([#111](https://github.com/huskarl-rs/huskarl/pull/111))
+- Include client_id in the PAR request body (RFC 9126) ([#110](https://github.com/huskarl-rs/huskarl/pull/110))
+- Some API visibility updates ([#109](https://github.com/huskarl-rs/huskarl/pull/109))
+- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
+- Add TokenResponse::get_extra for non-standard token fields ([#106](https://github.com/huskarl-rs/huskarl/pull/106))
+- Gate the OIDC nonce parameter on the openid scope ([#105](https://github.com/huskarl-rs/huskarl/pull/105))
+- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
+- Read granted authorization_details from the token response ([#102](https://github.com/huskarl-rs/huskarl/pull/102))
+- Add RFC 9396 Rich Authorization Requests on the request side ([#101](https://github.com/huskarl-rs/huskarl/pull/101))
+- Replace serde_html_form with oauth_form across the client ([#99](https://github.com/huskarl-rs/huskarl/pull/99))
+- Remove raw data from some debug implementations. ([#96](https://github.com/huskarl-rs/huskarl/pull/96))
+- Harden www-authenticate parsing. ([#95](https://github.com/huskarl-rs/huskarl/pull/95))
+- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
+- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+- New HttpAuthorizer approach - adds GrantTokenSource. ([#91](https://github.com/huskarl-rs/huskarl/pull/91))
+- Simplify some code
+
 ### Changes
 
  - Breaking: Update HttpAuthorizer to accept a GrantTokenSource which is capable

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = '''

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -406,7 +406,7 @@ fn build_authorization_payload<'a>(
             },
             display: start_input.display.as_ref(),
             prompt: start_input.prompt.as_ref(),
-            max_age: start_input.max_age.as_ref(),
+            max_age: start_input.max_age.map(|d| d.as_secs()),
             ui_locales: start_input.ui_locales.as_ref().map(|l| l.join(" ")),
             id_token_hint: start_input.id_token_hint.as_ref(),
             login_hint: start_input.login_hint.as_deref(),

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -30,8 +30,10 @@ pub struct AuthorizationPayload<'a> {
     pub(super) display: Option<&'a Display>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) prompt: Option<&'a Prompt>,
+    /// Whole seconds — the wire shape OIDC Core §3.1.2.1 requires (serde's
+    /// default `Duration` representation is a `{secs, nanos}` struct).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) max_age: Option<&'a Duration>,
+    pub(super) max_age: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) ui_locales: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -219,6 +221,35 @@ pub(super) fn generate_random_value() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn max_age_serializes_as_seconds() {
+        let payload = AuthorizationPayload {
+            response_type: "code",
+            redirect_uri: "http://127.0.0.1/cb",
+            scope: Some("openid"),
+            state: "state",
+            code_challenge: None,
+            code_challenge_method: None,
+            dpop_jkt: None,
+            nonce: None,
+            display: None,
+            prompt: None,
+            max_age: Some(300),
+            ui_locales: None,
+            id_token_hint: None,
+            login_hint: None,
+            acr_values: None,
+            resource: None,
+            authorization_details: None,
+        };
+
+        let form = crate::core::oauth_form::to_string(&payload).unwrap();
+        assert!(
+            form.contains("max_age=300"),
+            "max_age must be a number of seconds (OIDC Core §3.1.2.1), got: {form}"
+        );
+    }
 
     #[test]
     fn pending_state_debug_redacts_secrets() {


### PR DESCRIPTION



## 🤖 New release

* `huskarl-core`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)
* `huskarl-macros`: 0.3.0 -> 0.3.1
* `huskarl-crypto-webcrypto`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `huskarl-crypto-native`: 0.8.5 -> 0.9.0 (✓ API compatible changes)
* `huskarl`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `huskarl-resource-server`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `huskarl-reqwest`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

### ⚠ `huskarl-core` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant UnsealError::AuthenticationFailed, previously in file /tmp/.tmpZY9dKN/huskarl-core/src/crypto/cipher/error.rs:53

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ScheduledRefreshSigner::try_refresh, previously in file /tmp/.tmpZY9dKN/huskarl-core/src/crypto/signer/scheduled.rs:67

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct KeyMatch in /tmp/.tmp9my7u5/huskarl/huskarl-core/src/crypto/verifier/trait.rs:21

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl_core::crypto::verifier::RefreshingVerifier, previously in file /tmp/.tmpZY9dKN/huskarl-core/src/crypto/verifier/refreshing.rs:19

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait huskarl_core::crypto::cipher::AeadCipherSelector gained Debug in file /tmp/.tmp9my7u5/huskarl/huskarl-core/src/crypto/cipher/mod.rs:188

--- failure trait_newly_sealed: pub trait became sealed ---

Description:
A publicly-visible trait became sealed, so downstream crates are no longer able to implement it
        ref: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_newly_sealed.ron

Failed in:
  trait huskarl_core::crypto::cipher::AeadCipherSelector in file /tmp/.tmp9my7u5/huskarl/huskarl-core/src/crypto/cipher/mod.rs:188
  trait huskarl_core::crypto::signer::AsymmetricJwsSignerSelector in file /tmp/.tmp9my7u5/huskarl/huskarl-core/src/crypto/signer/asymmetric/mod.rs:23
  trait huskarl_core::crypto::signer::JwsSignerSelector in file /tmp/.tmp9my7u5/huskarl/huskarl-core/src/crypto/signer/symmetric/mod.rs:21
```

### ⚠ `huskarl` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum GetTokenError in /tmp/.tmp9my7u5/huskarl/huskarl/src/cache/mod.rs:100
  enum IdTokenValidationError in /tmp/.tmp9my7u5/huskarl/huskarl/src/token/id_token.rs:336
  enum BuildError in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/error.rs:50
  enum CompleteError in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/error.rs:13
  enum ErrorContext in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/loopback.rs:101
  enum UserInfoError in /tmp/.tmp9my7u5/huskarl/huskarl/src/userinfo.rs:393
  enum PollError in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/device_authorization/grant.rs:402
  enum UserInfoBuildError in /tmp/.tmp9my7u5/huskarl/huskarl/src/userinfo.rs:378
  enum InvalidTokenResponse in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/core/token_response.rs:208
  enum LoopbackError in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/loopback.rs:30

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant LoopbackError::MissingParameter 4 -> 5 in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/loopback.rs:66
  variant LoopbackError::Complete 5 -> 6 in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/loopback.rs:72
  variant GetTokenError::NoTokenSource 2 -> 3 in /tmp/.tmp9my7u5/huskarl/huskarl/src/cache/mod.rs:127

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature keycloak-tests in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  HttpAuthorizer::prime, previously in file /tmp/.tmpZY9dKN/huskarl/src/authorizer/mod.rs:193
  InMemoryTokenCacheBuilder::grant, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:26
  InMemoryTokenCacheBuilder::grant_parameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:37
  InMemoryTokenCacheBuilder::maybe_grant_parameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:37
  InMemoryTokenCacheBuilder::refresh_store, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:38
  InMemoryTokenCache::grant, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:186
  InMemoryTokenCache::has_grant_parameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:195
  InMemoryTokenCache::has_refresh_token_cached, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:207
  InMemoryTokenCache::has_refresh_token, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/in_memory.rs:218

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct UserInfo in /tmp/.tmp9my7u5/huskarl/huskarl/src/userinfo.rs:358
  struct StartOutput in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/types.rs:145
  struct PendingState in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/types.rs:169
  struct StandardOidcAddressClaims in /tmp/.tmp9my7u5/huskarl/huskarl/src/token/id_token.rs:169
  struct PendingState in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/device_authorization/grant.rs:389
  struct IdTokenClaims in /tmp/.tmp9my7u5/huskarl/huskarl/src/token/id_token.rs:58
  struct StartOutput in /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/device_authorization/grant.rs:372
  struct StandardOidcProfileClaims in /tmp/.tmp9my7u5/huskarl/huskarl/src/token/id_token.rs:102

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field dpop_jkt of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/authorization_code/grant.rs:274
  field code of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/authorization_code/grant.rs:277
  field pkce_verifier of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/authorization_code/grant.rs:280
  field resource of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/authorization_code/grant.rs:282
  field device_code of struct DeviceAuthorizationGrantParameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/device_authorization/grant.rs:236
  field resource of struct DeviceAuthorizationGrantParameters, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/device_authorization/grant.rs:238

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field AuthorizationCodeGrantParameters.dpop_jkt in file /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/grant.rs:294
  field AuthorizationCodeGrantParameters.code in file /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/grant.rs:294
  field AuthorizationCodeGrantParameters.pkce_verifier in file /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/grant.rs:294
  field AuthorizationCodeGrantParameters.resource in file /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/authorization_code/grant.rs:294
  field DeviceAuthorizationGrantParameters.device_code in file /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/device_authorization/grant.rs:249
  field DeviceAuthorizationGrantParameters.resource in file /tmp/.tmp9my7u5/huskarl/huskarl/src/grant/device_authorization/grant.rs:249

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait huskarl::cache::TokenCache gained TokenSource in file /tmp/.tmp9my7u5/huskarl/huskarl/src/cache/mod.rs:81

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method reusable_parameters of trait OAuth2ExchangeGrant, previously in file /tmp/.tmpZY9dKN/huskarl/src/grant/core/grant.rs:42
  method get_token_response of trait TokenCache, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/mod.rs:40
  method resource_server_dpop of trait TokenCache, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/mod.rs:45
  method prime of trait TokenCache, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/mod.rs:53
  method invalidate of trait TokenCache, previously in file /tmp/.tmpZY9dKN/huskarl/src/cache/mod.rs:56

--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct InMemoryTokenCacheBuilder allows 3 -> 2 generic types in /tmp/.tmp9my7u5/huskarl/huskarl/src/cache/in_memory.rs:50
  Struct InMemoryTokenCache allows 2 -> 1 generic types in /tmp/.tmp9my7u5/huskarl/huskarl/src/cache/in_memory.rs:51
```

### ⚠ `huskarl-resource-server` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum ValidateHeadersError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/error.rs:112
  enum TokenBindingError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/error.rs:25
  enum IntrospectionCallError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/introspection.rs:393
  enum IntrospectionValidateError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/introspection/error.rs:16
  enum IntrospectionValidateError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/introspection/error.rs:16
  enum DpopProofError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/dpop_proof.rs:216
  enum TokenExtractError in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/extract.rs:67
  enum TokenErrorCode in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/error.rs:128

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct ValidatedDpopProof in /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/validator/dpop_proof.rs:29

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait huskarl_resource_server::error::ToRfc6750Error gained Debug in file /tmp/.tmp9my7u5/huskarl/huskarl-resource-server/src/error.rs:231
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl-core`

<blockquote>

## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.7.1...huskarl-core-v0.8.0) - 2026-07-02

### Added

- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
- *(core)* Add configurable TTL to JwksSource ([#129](https://github.com/huskarl-rs/huskarl/pull/129))

### Fixed

- *(core)* Remove fuzz Cargo.lock
- *(core)* Bound metrics alg label to registered JWS algorithms ([#125](https://github.com/huskarl-rs/huskarl/pull/125))

### Other

- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- *(core)* [**breaking**] Remove dead UnsealError::AuthenticationFailed variant ([#128](https://github.com/huskarl-rs/huskarl/pull/128))
- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
- Limit body size of responses (default 1Mb) ([#123](https://github.com/huskarl-rs/huskarl/pull/123))
</blockquote>

## `huskarl-macros`

<blockquote>

## [0.3.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.0...huskarl-macros-v0.3.1) - 2026-07-02

### Other

- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))

### Removed

- `#[try_builder]` and its `#[try_setter(Trait::method)]` field attribute.
  Superseded by bon's native fallible `with` closures —
  `#[builder(with = |value: impl Trait| -> Result<_, huskarl_core::Error> { … })]` —
  which became expressible once the converter traits returned the concrete
  `huskarl_core::Error` instead of a per-impl associated error type.

### Changed

- `#[from_metadata]` no longer routes converted fields through hidden
  `{field}_internal` setters. Metadata values now go through the public
  setter; when that setter is a fallible `with` closure, the generated
  `builder_from_metadata` unwraps the `Result` — metadata fields already have
  the target type, so the conversion must be an infallible identity case.
</blockquote>

## `huskarl-crypto-webcrypto`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.8.0...huskarl-crypto-webcrypto-v0.9.0) - 2026-07-02

### Added

- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Other

- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- Require RSA keys to be 2024 bits or more for webcrypto. ([#120](https://github.com/huskarl-rs/huskarl/pull/120))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))

 - Require RSA keys to be at least 2048 bits.
</blockquote>

## `huskarl-crypto-native`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.8.5...huskarl-crypto-native-v0.9.0) - 2026-07-02

### Added

- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Other

- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
</blockquote>

## `huskarl`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.8.0...huskarl-v0.9.0) - 2026-07-02

### Added

- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Fixed

- *(client)* Serialize authorization-request max_age as seconds ([#133](https://github.com/huskarl-rs/huskarl/pull/133))

### Other

- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- Reduce version numbers to init release-plz without publishing.
- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
- Update integration tests to support keycloak/dex/node-oidc-provider/Okta. ([#119](https://github.com/huskarl-rs/huskarl/pull/119))
- Prefer form over basic client credentials auth (aligning with OAuth 2.1). ([#117](https://github.com/huskarl-rs/huskarl/pull/117))
- Add DCR fields from OIDC DCR. ([#116](https://github.com/huskarl-rs/huskarl/pull/116))
- Add Dynamic Client Registration (RFC 7591) ([#115](https://github.com/huskarl-rs/huskarl/pull/115))
- Tighten documentation across grants, cache, and authorizer ([#113](https://github.com/huskarl-rs/huskarl/pull/113))
- Add cache state reporting, refresh jitter, and shared-store-safe refresh. ([#112](https://github.com/huskarl-rs/huskarl/pull/112))
- Implement PartialEq/Eq for RefreshToken ([#111](https://github.com/huskarl-rs/huskarl/pull/111))
- Include client_id in the PAR request body (RFC 9126) ([#110](https://github.com/huskarl-rs/huskarl/pull/110))
- Some API visibility updates ([#109](https://github.com/huskarl-rs/huskarl/pull/109))
- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
- Add TokenResponse::get_extra for non-standard token fields ([#106](https://github.com/huskarl-rs/huskarl/pull/106))
- Gate the OIDC nonce parameter on the openid scope ([#105](https://github.com/huskarl-rs/huskarl/pull/105))
- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
- Read granted authorization_details from the token response ([#102](https://github.com/huskarl-rs/huskarl/pull/102))
- Add RFC 9396 Rich Authorization Requests on the request side ([#101](https://github.com/huskarl-rs/huskarl/pull/101))
- Replace serde_html_form with oauth_form across the client ([#99](https://github.com/huskarl-rs/huskarl/pull/99))
- Remove raw data from some debug implementations. ([#96](https://github.com/huskarl-rs/huskarl/pull/96))
- Harden www-authenticate parsing. ([#95](https://github.com/huskarl-rs/huskarl/pull/95))
- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
- New HttpAuthorizer approach - adds GrantTokenSource. ([#91](https://github.com/huskarl-rs/huskarl/pull/91))
- Simplify some code

### Changes

 - Breaking: Update HttpAuthorizer to accept a GrantTokenSource which is capable
   of regenerating grant parameters (e.g. useful for JWT bearer grant). Also this
   unifies with the idea of priming the token source.
 - Allow token cache to refresh before the token actually expires, while all but
   one request use the existing still valid token.
 - Save RAR `authorization_details` as an extra field in token response.
 - Read allowed ID tokens algorithms from AS metadata.
 - Only send `nonce` value in authorization request for openid scope (overrideable).
 - Always include `client_id` parameter in PAR requests.
 - Add Dynamic Client Registration client (RFC 7591).
</blockquote>

## `huskarl-resource-server`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.8.0...huskarl-resource-server-v0.9.0) - 2026-07-02

### Added

- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Other

- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- Reduce version numbers to init release-plz without publishing.
- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
- Strip control chars from www-authenticate parameters ([#122](https://github.com/huskarl-rs/huskarl/pull/122))
- Add MultiIssuerValidator, box futures in AccessTokenValidator to make them dyn compatible. ([#121](https://github.com/huskarl-rs/huskarl/pull/121))
- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
- Build the RFC 7662 introspection request via oauth_form ([#100](https://github.com/huskarl-rs/huskarl/pull/100))
- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
- Simplify some code

 - Breaking: Make AccessTokenValidator dyn-compatible (with boxed futures).
 - Add MultiIssuerValidator which can route validator by iss value.
 - Add `non_exhaustive` to various error types.
 - Breaking: Add Debug bound to ToRfc6750Error.
 - Strip control chars from www-authenticate parameters.
</blockquote>

## `huskarl-reqwest`

<blockquote>

## [0.7.1] - 2026-06-30

### Changes

 - Add max_response_bytes builder parameter (defaults to 1024 x 1024).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).