### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-native"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-webcrypto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "huskarl-core",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bon",
  "darling",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-reqwest"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bon",
  "bytes",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-resource-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ default-members = [
 exclude = ["huskarl-core/fuzz"]
 
 [workspace.dependencies]
-huskarl = { version = "0.8", path = "./huskarl" }
-huskarl-core = { version = "0.7", path = "./huskarl-core" }
+huskarl = { version = "0.9", path = "./huskarl" }
+huskarl-core = { version = "0.8", path = "./huskarl-core" }
 huskarl-macros = { version = "0.3", path = "./huskarl-macros" }
 huskarl-reqwest = { version = "0.7", path = "./huskarl-reqwest" }
-huskarl-crypto-native = { version = "0.8", path = "./huskarl-crypto-native" }
-huskarl-crypto-webcrypto = { version = "0.8", path = "./huskarl-crypto-webcrypto" }
+huskarl-crypto-native = { version = "0.9", path = "./huskarl-crypto-native" }
+huskarl-crypto-webcrypto = { version = "0.9", path = "./huskarl-crypto-webcrypto" }
 
 bon = { version = "3.9", default-features = false, features = [
   "alloc",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.7.1...huskarl-core-v0.8.0) - 2026-07-08
+
+### Added
+
+- Add supported_signature_algorithms to JwsVerifierPlatform. ([#196](https://github.com/huskarl-rs/huskarl/pull/196))
+- *(crypto)* [**breaking**] Load private keys through JWKs ([#184](https://github.com/huskarl-rs/huskarl/pull/184))
+- *(core)* Add ProvidedSecret for when you have a live secret to pass to secret API. ([#180](https://github.com/huskarl-rs/huskarl/pull/180))
+- *(core)* Let ClaimCheck fields accept plain strings ([#178](https://github.com/huskarl-rs/huskarl/pull/178))
+- *(core)* Add the RFC 9728 ProtectedResourceMetadata document ([#174](https://github.com/huskarl-rs/huskarl/pull/174))
+- *(core)* Add RFC 9728 protected resource metadata URL derivation ([#172](https://github.com/huskarl-rs/huskarl/pull/172))
+- *(core)* Reject non-http(s) schemes and userinfo in EndpointUrl ([#169](https://github.com/huskarl-rs/huskarl/pull/169))
+- *(core)* Give EndpointUrl Display and Uri conversions ([#168](https://github.com/huskarl-rs/huskarl/pull/168))
+- *(resource-server)* Refuse to validate DPoP keys that have a private component. ([#155](https://github.com/huskarl-rs/huskarl/pull/155))
+- *(core)* [**breaking**] Enable mapping of secret output, make b64/hex more forgiving. ([#153](https://github.com/huskarl-rs/huskarl/pull/153))
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+- *(core)* Add configurable TTL to JwksSource ([#129](https://github.com/huskarl-rs/huskarl/pull/129))
+
+### Fixed
+
+- *(dpop)* Stop setting exp on client DPoP proofs by default ([#205](https://github.com/huskarl-rs/huskarl/pull/205))
+- *(oidc)* Guard ID-token auth_time overflow and default clock leeway ([#189](https://github.com/huskarl-rs/huskarl/pull/189))
+- *(core)* Don't reject future-iat tokens via the max_token_age check ([#140](https://github.com/huskarl-rs/huskarl/pull/140))
+- *(core)* Skip malformed JWKS entries instead of failing the whole set ([#139](https://github.com/huskarl-rs/huskarl/pull/139))
+- *(core)* Enforce refresh policy under the single-flight lock ([#138](https://github.com/huskarl-rs/huskarl/pull/138))
+- *(core)* Remove fuzz Cargo.lock
+- *(core)* Bound metrics alg label to registered JWS algorithms ([#125](https://github.com/huskarl-rs/huskarl/pull/125))
+
+### Other
+
+- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
+- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
+- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
+- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
+- [**breaking**] Normalize DPoP capitalization across types. ([#182](https://github.com/huskarl-rs/huskarl/pull/182))
+- [**breaking**] Make authentication_params a builder struct, rename authentication_context ([#181](https://github.com/huskarl-rs/huskarl/pull/181))
+- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
+- Align the preludes on a call-side-traits principle ([#173](https://github.com/huskarl-rs/huskarl/pull/173))
+- *(core)* Serialize EndpointUrl without an intermediate allocation ([#170](https://github.com/huskarl-rs/huskarl/pull/170))
+- Extract common max-age handling to a shared function ([#161](https://github.com/huskarl-rs/huskarl/pull/161))
+- Document that a particular AES-GCM key shoud be used at most 2^32 times ([#158](https://github.com/huskarl-rs/huskarl/pull/158))
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- *(core)* [**breaking**] Remove dead UnsealError::AuthenticationFailed variant ([#128](https://github.com/huskarl-rs/huskarl/pull/128))
+- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
+- Limit body size of responses (default 1Mb) ([#123](https://github.com/huskarl-rs/huskarl/pull/123))
+
 ## [0.7.1] - 2026-06-29
 
 ### Changes

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-native/CHANGELOG.md
+++ b/huskarl-crypto-native/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.8.5...huskarl-crypto-native-v0.9.0) - 2026-07-08
+
+### Added
+
+- Add supported_signature_algorithms to JwsVerifierPlatform. ([#196](https://github.com/huskarl-rs/huskarl/pull/196))
+- *(crypto-native)* Bump p256, p384, ed25519-dalek to non-RC releases ([#194](https://github.com/huskarl-rs/huskarl/pull/194))
+- *(crypto)* [**breaking**] Load private keys through JWKs ([#184](https://github.com/huskarl-rs/huskarl/pull/184))
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Fixed
+
+- *(crypto-native)* Validate RSA modulus by bit length with an upper bound ([#200](https://github.com/huskarl-rs/huskarl/pull/200))
+- *(crypto-native)* Return an error instead of panicking on fallible signing ([#137](https://github.com/huskarl-rs/huskarl/pull/137))
+
+### Other
+
+- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
+- RsaPublicKey::new already enforces 8192-bit max keys, remove check ([#202](https://github.com/huskarl-rs/huskarl/pull/202))
+- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
+- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
+- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
+- Add extra docs on loading keys ([#187](https://github.com/huskarl-rs/huskarl/pull/187))
+- *(crypto)* [**breaking**] Unify from_jwk on the core Error type ([#186](https://github.com/huskarl-rs/huskarl/pull/186))
+- *(crypto)* [**breaking**] Add Pkcs8Pem and remove the legacy key loaders ([#185](https://github.com/huskarl-rs/huskarl/pull/185))
+- [**breaking**] Disambiguate crypto-native key-load error enums ([#183](https://github.com/huskarl-rs/huskarl/pull/183))
+- Extract common max-age handling to a shared function ([#161](https://github.com/huskarl-rs/huskarl/pull/161))
+- Document that a particular AES-GCM key shoud be used at most 2^32 times ([#158](https://github.com/huskarl-rs/huskarl/pull/158))
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+
 ## [0.8.5] - 2026-06-30
 
 ### Changes

--- a/huskarl-crypto-native/Cargo.toml
+++ b/huskarl-crypto-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-native"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Native crypto for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-webcrypto/CHANGELOG.md
+++ b/huskarl-crypto-webcrypto/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.8.0...huskarl-crypto-webcrypto-v0.9.0) - 2026-07-08
+
+### Added
+
+- Add supported_signature_algorithms to JwsVerifierPlatform. ([#196](https://github.com/huskarl-rs/huskarl/pull/196))
+- *(core)* Add ProvidedSecret for when you have a live secret to pass to secret API. ([#180](https://github.com/huskarl-rs/huskarl/pull/180))
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Fixed
+
+- *(resource-server)* Escape the DPoP algs challenge value ([#203](https://github.com/huskarl-rs/huskarl/pull/203))
+- *(crypto-webcrypto)* Validate RSA modulus by bit length with an upper bound ([#201](https://github.com/huskarl-rs/huskarl/pull/201))
+- *(crypto-webcrypto)* Surface JS error details instead of an empty string ([#149](https://github.com/huskarl-rs/huskarl/pull/149))
+- *(crypto-webcrypto)* Reject kid-mismatched tokens in verify() ([#148](https://github.com/huskarl-rs/huskarl/pull/148))
+
+### Other
+
+- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
+- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
+- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
+- *(crypto)* [**breaking**] Add Pkcs8Pem and remove the legacy key loaders ([#185](https://github.com/huskarl-rs/huskarl/pull/185))
+- [**breaking**] Disambiguate crypto-native key-load error enums ([#183](https://github.com/huskarl-rs/huskarl/pull/183))
+- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
+- Document that a particular AES-GCM key shoud be used at most 2^32 times ([#158](https://github.com/huskarl-rs/huskarl/pull/158))
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- Require RSA keys to be 2024 bits or more for webcrypto. ([#120](https://github.com/huskarl-rs/huskarl/pull/120))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+
  - Require RSA keys to be at least 2048 bits.
 
 ## [0.8.0] - 2026-06-15

--- a/huskarl-crypto-webcrypto/Cargo.toml
+++ b/huskarl-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-webcrypto"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "WebCrypto support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-macros/CHANGELOG.md
+++ b/huskarl-macros/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.3.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.0...huskarl-macros-v0.3.1) - 2026-07-08
+
+### Added
+
+- *(macros)* Handle metadata fields that are keywords ([#160](https://github.com/huskarl-rs/huskarl/pull/160))
+
+### Other
+
+- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+
 ### Removed
 
 - `#[try_builder]` and its `#[try_setter(Trait::method)]` field attribute.

--- a/huskarl-macros/Cargo.toml
+++ b/huskarl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Procedural macros for the huskarl OAuth2 client library."

--- a/huskarl-reqwest/Cargo.toml
+++ b/huskarl-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-reqwest"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.92"
 description = "reqwest support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.8.0...huskarl-resource-server-v0.9.0) - 2026-07-08
+
+### Added
+
+- *(core)* Let ClaimCheck fields accept plain strings ([#178](https://github.com/huskarl-rs/huskarl/pull/178))
+- *(resource-server)* [**breaking**] Derive the RFC 9728 document from validator metadata ([#175](https://github.com/huskarl-rs/huskarl/pull/175))
+- *(core)* Add RFC 9728 protected resource metadata URL derivation ([#172](https://github.com/huskarl-rs/huskarl/pull/172))
+- *(resource-server)* Point WWW-Authenticate challenges at RFC 9728 resource metadata ([#167](https://github.com/huskarl-rs/huskarl/pull/167))
+- *(resource-server)* Advertise mTLS-bound token support in validator metadata ([#166](https://github.com/huskarl-rs/huskarl/pull/166))
+- *(resource-server)* Carry the required scope on InsufficientScope ([#164](https://github.com/huskarl-rs/huskarl/pull/164))
+- *(resource-server)* Let validators carry the challenge realm ([#163](https://github.com/huskarl-rs/huskarl/pull/163))
+- *(resource-server)* Helper to turn resource server validation failures into a response ([#162](https://github.com/huskarl-rs/huskarl/pull/162))
+- *(resource-server)* Require that DPoP htu is an absolute URL ([#157](https://github.com/huskarl-rs/huskarl/pull/157))
+- *(resource-server)* Refuse to validate DPoP keys that have a private component. ([#155](https://github.com/huskarl-rs/huskarl/pull/155))
+- *(resource-server)* Add clock-skew leeway to all temporal checks ([#147](https://github.com/huskarl-rs/huskarl/pull/147))
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Fixed
+
+- *(resource-server)* Escape the DPoP algs challenge value ([#203](https://github.com/huskarl-rs/huskarl/pull/203))
+- *(resource-server)* Reject requests carrying more than one DPoP header ([#199](https://github.com/huskarl-rs/huskarl/pull/199))
+- *(resource-server)* Preserve the rotated DPoP nonce when a later binding check fails ([#197](https://github.com/huskarl-rs/huskarl/pull/197))
+- *(resource-server)* Make sure introspection can't panic from timestamp in server response ([#190](https://github.com/huskarl-rs/huskarl/pull/190))
+- *(resource-server)* [**breaking**] Advertise DPoP challenge when DPoP is accepted but unrestricted ([#135](https://github.com/huskarl-rs/huskarl/pull/135))
+
+### Other
+
+- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
+- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
+- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
+- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
+- [**breaking**] Normalize DPoP capitalization across types. ([#182](https://github.com/huskarl-rs/huskarl/pull/182))
+- [**breaking**] Make authentication_params a builder struct, rename authentication_context ([#181](https://github.com/huskarl-rs/huskarl/pull/181))
+- Align the preludes on a call-side-traits principle ([#173](https://github.com/huskarl-rs/huskarl/pull/173))
+- Add DPoP and client authentication how-to guides ([#165](https://github.com/huskarl-rs/huskarl/pull/165))
+- Update README
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- Reduce version numbers to init release-plz without publishing.
+- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
+- Strip control chars from www-authenticate parameters ([#122](https://github.com/huskarl-rs/huskarl/pull/122))
+- Add MultiIssuerValidator, box futures in AccessTokenValidator to make them dyn compatible. ([#121](https://github.com/huskarl-rs/huskarl/pull/121))
+- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
+- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
+- Build the RFC 7662 introspection request via oauth_form ([#100](https://github.com/huskarl-rs/huskarl/pull/100))
+- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
+- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+- Simplify some code
+
  - Breaking: Make AccessTokenValidator dyn-compatible (with boxed futures).
  - Add MultiIssuerValidator which can route validator by iss value.
  - Add `non_exhaustive` to various error types.

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "OAuth2 resource server (JWT validation) support for the huskarl ecosystem."

--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.8.0...huskarl-v0.9.0) - 2026-07-08
+
+### Added
+
+- *(client)* [**breaking**] Rename `scopes` builder to `scope` and make `Vec<String>` for consistency. ([#207](https://github.com/huskarl-rs/huskarl/pull/207))
+- *(client)* Auth-code StartOutput carries an absolute PAR expiry ([#177](https://github.com/huskarl-rs/huskarl/pull/177))
+- *(cache)* Require an explicit grant-parameters choice on GrantTokenSource ([#176](https://github.com/huskarl-rs/huskarl/pull/176))
+- *(core)* Give EndpointUrl Display and Uri conversions ([#168](https://github.com/huskarl-rs/huskarl/pull/168))
+- *(resource-server)* Helper to turn resource server validation failures into a response ([#162](https://github.com/huskarl-rs/huskarl/pull/162))
+- *(client)* When require PAR is set, don't downgrade ([#159](https://github.com/huskarl-rs/huskarl/pull/159))
+- *(client)* Support expires_in as fractions, be more lenient for device authorization. ([#156](https://github.com/huskarl-rs/huskarl/pull/156))
+- *(client)* Accept RFC 8693 token_type N_A in token-exchange responses ([#144](https://github.com/huskarl-rs/huskarl/pull/144))
+- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
+
+### Fixed
+
+- *(client)* Keep the refresh token when a 5xx response carries an OAuth error code ([#198](https://github.com/huskarl-rs/huskarl/pull/198))
+- *(client)* [**breaking**] Remove `sub` from ID token claims (already in base token claims) ([#192](https://github.com/huskarl-rs/huskarl/pull/192))
+- *(client)* Don't validate azp, but check audience is client id or another trusted audience ([#191](https://github.com/huskarl-rs/huskarl/pull/191))
+- *(oidc)* Guard ID-token auth_time overflow and default clock leeway ([#189](https://github.com/huskarl-rs/huskarl/pull/189))
+- *(client)* Don't abort the loopback login on a single connection's read error ([#146](https://github.com/huskarl-rs/huskarl/pull/146))
+- Classify registration 5xx responses as retryable transport errors ([#145](https://github.com/huskarl-rs/huskarl/pull/145))
+- *(client)* [**breaking**] Only validate the ID-token nonce when a nonce was sent ([#143](https://github.com/huskarl-rs/huskarl/pull/143))
+- *(client)* [**breaking**] Require audience on IdTokenValidator ([#142](https://github.com/huskarl-rs/huskarl/pull/142))
+- *(client)* Don't reject future auth_time in the max_age check ([#141](https://github.com/huskarl-rs/huskarl/pull/141))
+- *(client)* Serialize authorization-request max_age as seconds ([#133](https://github.com/huskarl-rs/huskarl/pull/133))
+
+### Other
+
+- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
+- *(client)* Make the PKCE verifier tests exercise real output ([#204](https://github.com/huskarl-rs/huskarl/pull/204))
+- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
+- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
+- *(crypto)* [**breaking**] Add Pkcs8Pem and remove the legacy key loaders ([#185](https://github.com/huskarl-rs/huskarl/pull/185))
+- [**breaking**] Disambiguate crypto-native key-load error enums ([#183](https://github.com/huskarl-rs/huskarl/pull/183))
+- [**breaking**] Normalize DPoP capitalization across types. ([#182](https://github.com/huskarl-rs/huskarl/pull/182))
+- [**breaking**] Make authentication_params a builder struct, rename authentication_context ([#181](https://github.com/huskarl-rs/huskarl/pull/181))
+- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
+- Align the preludes on a call-side-traits principle ([#173](https://github.com/huskarl-rs/huskarl/pull/173))
+- Use ? instead of unwrap in doc examples ([#171](https://github.com/huskarl-rs/huskarl/pull/171))
+- Add DPoP and client authentication how-to guides ([#165](https://github.com/huskarl-rs/huskarl/pull/165))
+- Extract common max-age handling to a shared function ([#161](https://github.com/huskarl-rs/huskarl/pull/161))
+- *(client)* Redact device_code from Debug output of device auth grant pending state. ([#154](https://github.com/huskarl-rs/huskarl/pull/154))
+- *(client)* Fix clippy errors ([#152](https://github.com/huskarl-rs/huskarl/pull/152))
+- Update README
+- *(client)* Fix clippy ([#150](https://github.com/huskarl-rs/huskarl/pull/150))
+- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
+- Reduce version numbers to init release-plz without publishing.
+- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
+- Update integration tests to support keycloak/dex/node-oidc-provider/Okta. ([#119](https://github.com/huskarl-rs/huskarl/pull/119))
+- Prefer form over basic client credentials auth (aligning with OAuth 2.1). ([#117](https://github.com/huskarl-rs/huskarl/pull/117))
+- Add DCR fields from OIDC DCR. ([#116](https://github.com/huskarl-rs/huskarl/pull/116))
+- Add Dynamic Client Registration (RFC 7591) ([#115](https://github.com/huskarl-rs/huskarl/pull/115))
+- Tighten documentation across grants, cache, and authorizer ([#113](https://github.com/huskarl-rs/huskarl/pull/113))
+- Add cache state reporting, refresh jitter, and shared-store-safe refresh. ([#112](https://github.com/huskarl-rs/huskarl/pull/112))
+- Implement PartialEq/Eq for RefreshToken ([#111](https://github.com/huskarl-rs/huskarl/pull/111))
+- Include client_id in the PAR request body (RFC 9126) ([#110](https://github.com/huskarl-rs/huskarl/pull/110))
+- Some API visibility updates ([#109](https://github.com/huskarl-rs/huskarl/pull/109))
+- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
+- Add TokenResponse::get_extra for non-standard token fields ([#106](https://github.com/huskarl-rs/huskarl/pull/106))
+- Gate the OIDC nonce parameter on the openid scope ([#105](https://github.com/huskarl-rs/huskarl/pull/105))
+- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
+- Read granted authorization_details from the token response ([#102](https://github.com/huskarl-rs/huskarl/pull/102))
+- Add RFC 9396 Rich Authorization Requests on the request side ([#101](https://github.com/huskarl-rs/huskarl/pull/101))
+- Replace serde_html_form with oauth_form across the client ([#99](https://github.com/huskarl-rs/huskarl/pull/99))
+- Remove raw data from some debug implementations. ([#96](https://github.com/huskarl-rs/huskarl/pull/96))
+- Harden www-authenticate parsing. ([#95](https://github.com/huskarl-rs/huskarl/pull/95))
+- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
+- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
+- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
+- New HttpAuthorizer approach - adds GrantTokenSource. ([#91](https://github.com/huskarl-rs/huskarl/pull/91))
+- Simplify some code
+
 ### Changes
 
  - Breaking: Update HttpAuthorizer to accept a GrantTokenSource which is capable

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = '''


### PR DESCRIPTION



## 🤖 New release

* `huskarl-core`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)
* `huskarl-macros`: 0.3.0 -> 0.3.1
* `huskarl-crypto-webcrypto`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `huskarl-crypto-native`: 0.8.5 -> 0.9.0 (⚠ API breaking changes)
* `huskarl`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `huskarl-resource-server`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `huskarl-reqwest`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

### ⚠ `huskarl-core` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ErrorKind::Dpop, previously in file /tmp/.tmplAL2pu/huskarl-core/src/error.rs:111
  variant ErrorKind::Dpop, previously in file /tmp/.tmplAL2pu/huskarl-core/src/error.rs:111
  variant UnsealError::AuthenticationFailed, previously in file /tmp/.tmplAL2pu/huskarl-core/src/crypto/cipher/error.rs:53

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ScheduledRefreshSigner::try_refresh, previously in file /tmp/.tmplAL2pu/huskarl-core/src/crypto/signer/scheduled.rs:67
  PrivateJwk::builder, previously in file /tmp/.tmplAL2pu/huskarl-core/src/jwk/mod.rs:137
  PrivateJwk::public_jwk, previously in file /tmp/.tmplAL2pu/huskarl-core/src/jwk/mod.rs:164
  PrivateJwk::thumbprint, previously in file /tmp/.tmplAL2pu/huskarl-core/src/jwk/mod.rs:177

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct KeyMatch in /tmp/.tmpBYp9rQ/huskarl/huskarl-core/src/crypto/verifier/trait.rs:21

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl_core::jwk::PrivateJwkBuilder, previously in file /tmp/.tmplAL2pu/huskarl-core/src/jwk/mod.rs:137
  struct huskarl_core::secrets::encodings::BinaryEncoding, previously in file /tmp/.tmplAL2pu/huskarl-core/src/secrets/encodings/binary.rs:10
  struct huskarl_core::crypto::verifier::RefreshingVerifier, previously in file /tmp/.tmplAL2pu/huskarl-core/src/crypto/verifier/refreshing.rs:19

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct huskarl_core::jwk::PrivateJwk became enum in file /tmp/.tmpBYp9rQ/huskarl/huskarl-core/src/jwk/mod.rs:255

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait huskarl_core::crypto::cipher::AeadCipherSelector gained Debug in file /tmp/.tmpBYp9rQ/huskarl/huskarl-core/src/crypto/cipher/mod.rs:193

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method authentication_params of trait ClientAuthentication, previously in file /tmp/.tmplAL2pu/huskarl-core/src/client_auth/mod.rs:62

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait huskarl_core::secrets::encodings::SecretDecoder, previously in file /tmp/.tmplAL2pu/huskarl-core/src/secrets/encodings/mod.rs:18
  trait huskarl_core::secrets::SecretDecoder, previously in file /tmp/.tmplAL2pu/huskarl-core/src/secrets/encodings/mod.rs:18

--- failure trait_newly_sealed: pub trait became sealed ---

Description:
A publicly-visible trait became sealed, so downstream crates are no longer able to implement it
        ref: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_newly_sealed.ron

Failed in:
  trait huskarl_core::crypto::cipher::AeadCipherSelector in file /tmp/.tmpBYp9rQ/huskarl/huskarl-core/src/crypto/cipher/mod.rs:193
  trait huskarl_core::crypto::signer::AsymmetricJwsSignerSelector in file /tmp/.tmpBYp9rQ/huskarl/huskarl-core/src/crypto/signer/asymmetric/mod.rs:23
  trait huskarl_core::crypto::signer::JwsSignerSelector in file /tmp/.tmpBYp9rQ/huskarl/huskarl-core/src/crypto/signer/symmetric/mod.rs:21
```

### ⚠ `huskarl-crypto-webcrypto` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum huskarl_crypto_webcrypto::aead::LoadKeyError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-webcrypto/src/aead.rs:74

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  huskarl_crypto_webcrypto::aead::AesGcmKey::from_secret takes 2 parameters in /tmp/.tmplAL2pu/huskarl-crypto-webcrypto/src/aead.rs:172, but now takes 1 parameters in /tmp/.tmpBYp9rQ/huskarl/huskarl-crypto-webcrypto/src/aead.rs:252
```

### ⚠ `huskarl-crypto-native` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum huskarl_crypto_native::asymmetric::signer::JwkLoadError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:62
  enum huskarl_crypto_native::symmetric::KeyLoadError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/symmetric.rs:71
  enum huskarl_crypto_native::asymmetric::signer::JwkError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:44
  enum huskarl_crypto_native::symmetric::JwkLoadError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/symmetric.rs:112
  enum huskarl_crypto_native::symmetric::JwkError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/symmetric.rs:89
  enum huskarl_crypto_native::asymmetric::signer::KeyLoadError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:28
  enum huskarl_crypto_native::aead::LoadKeyError, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/aead.rs:66

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  PrivateKey::load_pkcs8_der, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:592
  PrivateKey::load_pkcs8_pem, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:670
  PrivateKey::load_jwk, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:791
  SymmetricKey::load_bytes, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/symmetric.rs:137
  SymmetricKey::load_jwk, previously in file /tmp/.tmplAL2pu/huskarl-crypto-native/src/symmetric.rs:219

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  huskarl_crypto_native::aead::AesGcmKey::from_secret takes 2 parameters in /tmp/.tmplAL2pu/huskarl-crypto-native/src/aead.rs:84, but now takes 1 parameters in /tmp/.tmpBYp9rQ/huskarl/huskarl-crypto-native/src/aead.rs:172
  huskarl_crypto_native::asymmetric::signer::PrivateKey::as_private_jwk takes 1 parameters in /tmp/.tmplAL2pu/huskarl-crypto-native/src/asymmetric/signer.rs:746, but now takes 0 parameters in /tmp/.tmpBYp9rQ/huskarl/huskarl-crypto-native/src/asymmetric/signer.rs:560
```

### ⚠ `huskarl` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum UserInfoBuildError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/userinfo.rs:378
  enum LoopbackError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/loopback.rs:30
  enum ErrorContext in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/loopback.rs:101
  enum UserInfoError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/userinfo.rs:393
  enum InvalidTokenResponse in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/core/token_response.rs:226
  enum PollError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/device_authorization/grant.rs:422
  enum BuildError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/error.rs:50
  enum GetTokenError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/cache/mod.rs:100
  enum IdTokenValidationError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/id_token.rs:320
  enum CompleteError in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/error.rs:13

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant IdTokenValidationError::AcrMissing 7 -> 6 in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/id_token.rs:347
  variant IdTokenValidationError::AcrMismatch 8 -> 7 in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/id_token.rs:349
  variant LoopbackError::MissingParameter 4 -> 5 in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/loopback.rs:66
  variant LoopbackError::Complete 5 -> 6 in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/loopback.rs:72
  variant GetTokenError::NoTokenSource 2 -> 3 in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/cache/mod.rs:132

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AccessToken:DPoP in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/access_token.rs:41
  variant AccessToken:NotAccessToken in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/access_token.rs:49

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant IdTokenValidationError::AzpMissing, previously in file /tmp/.tmplAL2pu/huskarl/src/token/id_token.rs:332
  variant IdTokenValidationError::AzpMismatch, previously in file /tmp/.tmplAL2pu/huskarl/src/token/id_token.rs:334
  variant AccessToken::Dpop, previously in file /tmp/.tmplAL2pu/huskarl/src/token/access_token.rs:32
  variant InvalidTokenResponse::NoDpopThumbprint, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/core/token_response.rs:189

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature keycloak-tests in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ClientCredentialsGrantParametersBuilder::scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/client_credentials.rs:281
  ClientCredentialsGrantParametersBuilder::maybe_scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/client_credentials.rs:281
  HttpAuthorizer::prime, previously in file /tmp/.tmplAL2pu/huskarl/src/authorizer/mod.rs:193
  RefreshGrantParametersBuilder::scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/refresh.rs:272
  RefreshGrantParametersBuilder::maybe_scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/refresh.rs:272
  InMemoryTokenCacheBuilder::grant, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:26
  InMemoryTokenCacheBuilder::grant_parameters, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:37
  InMemoryTokenCacheBuilder::maybe_grant_parameters, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:37
  InMemoryTokenCacheBuilder::refresh_store, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:38
  StartInput::scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/authorization_code/types.rs:114
  InMemoryTokenCache::grant, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:186
  InMemoryTokenCache::has_grant_parameters, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:195
  InMemoryTokenCache::has_refresh_token_cached, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:207
  InMemoryTokenCache::has_refresh_token, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/in_memory.rs:218
  TokenExchangeGrantParametersBuilder::scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/token_exchange.rs:301
  TokenExchangeGrantParametersBuilder::maybe_scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/token_exchange.rs:301
  JwtBearerGrantParametersBuilder::scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/jwt_bearer.rs:355
  JwtBearerGrantParametersBuilder::maybe_scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/jwt_bearer.rs:355
  StartInput::scopes, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/device_authorization/grant.rs:414
  IdTokenValidatorBuilder::maybe_audience, previously in file /tmp/.tmplAL2pu/huskarl/src/token/id_token.rs:185
  IdTokenValidatorBuilder::expected_azp, previously in file /tmp/.tmplAL2pu/huskarl/src/token/id_token.rs:193
  IdTokenValidatorBuilder::maybe_expected_azp, previously in file /tmp/.tmplAL2pu/huskarl/src/token/id_token.rs:193

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct UserInfo in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/userinfo.rs:358
  struct StartOutput in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/types.rs:157
  struct StandardOidcAddressClaims in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/id_token.rs:168
  struct PendingState in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/types.rs:187
  struct PendingState in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/device_authorization/grant.rs:397
  struct StartOutput in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/device_authorization/grant.rs:380
  struct IdTokenClaims in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/id_token.rs:60
  struct StandardOidcProfileClaims in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/token/id_token.rs:101

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl::token::DpopAccessToken, previously in file /tmp/.tmplAL2pu/huskarl/src/token/access_token.rs:106

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field dpop_jkt of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/authorization_code/grant.rs:274
  field code of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/authorization_code/grant.rs:277
  field pkce_verifier of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/authorization_code/grant.rs:280
  field resource of struct AuthorizationCodeGrantParameters, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/authorization_code/grant.rs:282
  field expires_in of struct StartOutput, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/authorization_code/types.rs:130
  field sub of struct IdTokenClaims, previously in file /tmp/.tmplAL2pu/huskarl/src/token/id_token.rs:62
  field device_code of struct DeviceAuthorizationGrantParameters, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/device_authorization/grant.rs:236
  field resource of struct DeviceAuthorizationGrantParameters, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/device_authorization/grant.rs:238

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field AuthorizationCodeGrantParameters.dpop_jkt in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/grant.rs:311
  field AuthorizationCodeGrantParameters.code in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/grant.rs:311
  field AuthorizationCodeGrantParameters.pkce_verifier in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/grant.rs:311
  field AuthorizationCodeGrantParameters.resource in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/authorization_code/grant.rs:311
  field DeviceAuthorizationGrantParameters.device_code in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/device_authorization/grant.rs:253
  field DeviceAuthorizationGrantParameters.resource in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/grant/device_authorization/grant.rs:253

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait huskarl::cache::TokenCache gained TokenSource in file /tmp/.tmpBYp9rQ/huskarl/huskarl/src/cache/mod.rs:81

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method reusable_parameters of trait OAuth2ExchangeGrant, previously in file /tmp/.tmplAL2pu/huskarl/src/grant/core/grant.rs:42
  method get_token_response of trait TokenCache, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/mod.rs:40
  method resource_server_dpop of trait TokenCache, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/mod.rs:45
  method prime of trait TokenCache, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/mod.rs:53
  method invalidate of trait TokenCache, previously in file /tmp/.tmplAL2pu/huskarl/src/cache/mod.rs:56

--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct InMemoryTokenCacheBuilder allows 3 -> 2 generic types in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/cache/in_memory.rs:50
  Struct InMemoryTokenCache allows 2 -> 1 generic types in /tmp/.tmpBYp9rQ/huskarl/huskarl/src/cache/in_memory.rs:51
```

### ⚠ `huskarl-resource-server` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum ValidateHeadersError in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/error.rs:119
  enum IntrospectionCallError in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/introspection.rs:441
  enum TokenExtractError in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/extract.rs:67
  enum TokenErrorCode in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/error.rs:128
  enum TokenBindingError in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/error.rs:25
  enum IntrospectionValidateError in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/introspection/error.rs:16
  enum IntrospectionValidateError in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/introspection/error.rs:16

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum huskarl_resource_server::validator::dpop_proof::DpopProofError, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/dpop_proof.rs:214

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant TokenBindingError::UnsupportedCnfMethod 4 -> 5 in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/error.rs:57
  variant TokenBindingError::DPoPBinding 5 -> 6 in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/error.rs:62
  variant TokenBindingError::MtlsBinding 6 -> 7 in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/error.rs:67

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant TokenBindingError::DpopRequiredForBoundToken, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/error.rs:41
  variant TokenBindingError::DpopRequired, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/error.rs:45

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  huskarl_resource_server::validator::rfc9068::Rfc9068Validator::new takes 15 parameters in /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/rfc9068/mod.rs:171, but now takes 18 parameters in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/rfc9068/mod.rs:76
  huskarl_resource_server::validator::introspection::IntrospectionValidator::new takes 19 parameters in /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/introspection/mod.rs:214, but now takes 22 parameters in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/introspection/mod.rs:92
  huskarl_resource_server::validator::custom::CustomValidator::new takes 15 parameters in /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/custom/mod.rs:174, but now takes 18 parameters in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/custom/mod.rs:71

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct ValidatorMetadata in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/validator/metadata.rs:17

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl_resource_server::validator::dpop_proof::ValidatedDpopProof, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/dpop_proof.rs:28
  struct huskarl_resource_server::validator::dpop_proof::DpopProofValidator, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/dpop_proof.rs:70
  struct huskarl_resource_server::validator::dpop_proof::DpopProofValidatorBuilder, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/dpop_proof.rs:69

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait huskarl_resource_server::error::ToRfc6750Error gained Debug in file /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/error.rs:256

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait huskarl_resource_server::validator::dpop_nonce::DpopNonceChecker, previously in file /tmp/.tmplAL2pu/huskarl-resource-server/src/validator/dpop_nonce.rs:33

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct InsufficientScope in /tmp/.tmpBYp9rQ/huskarl/huskarl-resource-server/src/error.rs:181
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl-core`

<blockquote>

## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.7.1...huskarl-core-v0.8.0) - 2026-07-08

### Added

- Add supported_signature_algorithms to JwsVerifierPlatform. ([#196](https://github.com/huskarl-rs/huskarl/pull/196))
- *(crypto)* [**breaking**] Load private keys through JWKs ([#184](https://github.com/huskarl-rs/huskarl/pull/184))
- *(core)* Add ProvidedSecret for when you have a live secret to pass to secret API. ([#180](https://github.com/huskarl-rs/huskarl/pull/180))
- *(core)* Let ClaimCheck fields accept plain strings ([#178](https://github.com/huskarl-rs/huskarl/pull/178))
- *(core)* Add the RFC 9728 ProtectedResourceMetadata document ([#174](https://github.com/huskarl-rs/huskarl/pull/174))
- *(core)* Add RFC 9728 protected resource metadata URL derivation ([#172](https://github.com/huskarl-rs/huskarl/pull/172))
- *(core)* Reject non-http(s) schemes and userinfo in EndpointUrl ([#169](https://github.com/huskarl-rs/huskarl/pull/169))
- *(core)* Give EndpointUrl Display and Uri conversions ([#168](https://github.com/huskarl-rs/huskarl/pull/168))
- *(resource-server)* Refuse to validate DPoP keys that have a private component. ([#155](https://github.com/huskarl-rs/huskarl/pull/155))
- *(core)* [**breaking**] Enable mapping of secret output, make b64/hex more forgiving. ([#153](https://github.com/huskarl-rs/huskarl/pull/153))
- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))
- *(core)* Add configurable TTL to JwksSource ([#129](https://github.com/huskarl-rs/huskarl/pull/129))

### Fixed

- *(dpop)* Stop setting exp on client DPoP proofs by default ([#205](https://github.com/huskarl-rs/huskarl/pull/205))
- *(oidc)* Guard ID-token auth_time overflow and default clock leeway ([#189](https://github.com/huskarl-rs/huskarl/pull/189))
- *(core)* Don't reject future-iat tokens via the max_token_age check ([#140](https://github.com/huskarl-rs/huskarl/pull/140))
- *(core)* Skip malformed JWKS entries instead of failing the whole set ([#139](https://github.com/huskarl-rs/huskarl/pull/139))
- *(core)* Enforce refresh policy under the single-flight lock ([#138](https://github.com/huskarl-rs/huskarl/pull/138))
- *(core)* Remove fuzz Cargo.lock
- *(core)* Bound metrics alg label to registered JWS algorithms ([#125](https://github.com/huskarl-rs/huskarl/pull/125))

### Other

- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
- [**breaking**] Normalize DPoP capitalization across types. ([#182](https://github.com/huskarl-rs/huskarl/pull/182))
- [**breaking**] Make authentication_params a builder struct, rename authentication_context ([#181](https://github.com/huskarl-rs/huskarl/pull/181))
- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
- Align the preludes on a call-side-traits principle ([#173](https://github.com/huskarl-rs/huskarl/pull/173))
- *(core)* Serialize EndpointUrl without an intermediate allocation ([#170](https://github.com/huskarl-rs/huskarl/pull/170))
- Extract common max-age handling to a shared function ([#161](https://github.com/huskarl-rs/huskarl/pull/161))
- Document that a particular AES-GCM key shoud be used at most 2^32 times ([#158](https://github.com/huskarl-rs/huskarl/pull/158))
- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- *(core)* [**breaking**] Remove dead UnsealError::AuthenticationFailed variant ([#128](https://github.com/huskarl-rs/huskarl/pull/128))
- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
- Limit body size of responses (default 1Mb) ([#123](https://github.com/huskarl-rs/huskarl/pull/123))
</blockquote>

## `huskarl-macros`

<blockquote>

## [0.3.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.0...huskarl-macros-v0.3.1) - 2026-07-08

### Added

- *(macros)* Handle metadata fields that are keywords ([#160](https://github.com/huskarl-rs/huskarl/pull/160))

### Other

- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))

### Removed

- `#[try_builder]` and its `#[try_setter(Trait::method)]` field attribute.
  Superseded by bon's native fallible `with` closures —
  `#[builder(with = |value: impl Trait| -> Result<_, huskarl_core::Error> { … })]` —
  which became expressible once the converter traits returned the concrete
  `huskarl_core::Error` instead of a per-impl associated error type.

### Changed

- `#[from_metadata]` no longer routes converted fields through hidden
  `{field}_internal` setters. Metadata values now go through the public
  setter; when that setter is a fallible `with` closure, the generated
  `builder_from_metadata` unwraps the `Result` — metadata fields already have
  the target type, so the conversion must be an infallible identity case.
</blockquote>

## `huskarl-crypto-webcrypto`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.8.0...huskarl-crypto-webcrypto-v0.9.0) - 2026-07-08

### Added

- Add supported_signature_algorithms to JwsVerifierPlatform. ([#196](https://github.com/huskarl-rs/huskarl/pull/196))
- *(core)* Add ProvidedSecret for when you have a live secret to pass to secret API. ([#180](https://github.com/huskarl-rs/huskarl/pull/180))
- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Fixed

- *(resource-server)* Escape the DPoP algs challenge value ([#203](https://github.com/huskarl-rs/huskarl/pull/203))
- *(crypto-webcrypto)* Validate RSA modulus by bit length with an upper bound ([#201](https://github.com/huskarl-rs/huskarl/pull/201))
- *(crypto-webcrypto)* Surface JS error details instead of an empty string ([#149](https://github.com/huskarl-rs/huskarl/pull/149))
- *(crypto-webcrypto)* Reject kid-mismatched tokens in verify() ([#148](https://github.com/huskarl-rs/huskarl/pull/148))

### Other

- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
- *(crypto)* [**breaking**] Add Pkcs8Pem and remove the legacy key loaders ([#185](https://github.com/huskarl-rs/huskarl/pull/185))
- [**breaking**] Disambiguate crypto-native key-load error enums ([#183](https://github.com/huskarl-rs/huskarl/pull/183))
- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
- Document that a particular AES-GCM key shoud be used at most 2^32 times ([#158](https://github.com/huskarl-rs/huskarl/pull/158))
- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- Require RSA keys to be 2024 bits or more for webcrypto. ([#120](https://github.com/huskarl-rs/huskarl/pull/120))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))

 - Require RSA keys to be at least 2048 bits.
</blockquote>

## `huskarl-crypto-native`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.8.5...huskarl-crypto-native-v0.9.0) - 2026-07-08

### Added

- Add supported_signature_algorithms to JwsVerifierPlatform. ([#196](https://github.com/huskarl-rs/huskarl/pull/196))
- *(crypto-native)* Bump p256, p384, ed25519-dalek to non-RC releases ([#194](https://github.com/huskarl-rs/huskarl/pull/194))
- *(crypto)* [**breaking**] Load private keys through JWKs ([#184](https://github.com/huskarl-rs/huskarl/pull/184))
- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Fixed

- *(crypto-native)* Validate RSA modulus by bit length with an upper bound ([#200](https://github.com/huskarl-rs/huskarl/pull/200))
- *(crypto-native)* Return an error instead of panicking on fallible signing ([#137](https://github.com/huskarl-rs/huskarl/pull/137))

### Other

- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
- RsaPublicKey::new already enforces 8192-bit max keys, remove check ([#202](https://github.com/huskarl-rs/huskarl/pull/202))
- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
- Add extra docs on loading keys ([#187](https://github.com/huskarl-rs/huskarl/pull/187))
- *(crypto)* [**breaking**] Unify from_jwk on the core Error type ([#186](https://github.com/huskarl-rs/huskarl/pull/186))
- *(crypto)* [**breaking**] Add Pkcs8Pem and remove the legacy key loaders ([#185](https://github.com/huskarl-rs/huskarl/pull/185))
- [**breaking**] Disambiguate crypto-native key-load error enums ([#183](https://github.com/huskarl-rs/huskarl/pull/183))
- Extract common max-age handling to a shared function ([#161](https://github.com/huskarl-rs/huskarl/pull/161))
- Document that a particular AES-GCM key shoud be used at most 2^32 times ([#158](https://github.com/huskarl-rs/huskarl/pull/158))
- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
</blockquote>

## `huskarl`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.8.0...huskarl-v0.9.0) - 2026-07-08

### Added

- *(client)* [**breaking**] Rename `scopes` builder to `scope` and make `Vec<String>` for consistency. ([#207](https://github.com/huskarl-rs/huskarl/pull/207))
- *(client)* Auth-code StartOutput carries an absolute PAR expiry ([#177](https://github.com/huskarl-rs/huskarl/pull/177))
- *(cache)* Require an explicit grant-parameters choice on GrantTokenSource ([#176](https://github.com/huskarl-rs/huskarl/pull/176))
- *(core)* Give EndpointUrl Display and Uri conversions ([#168](https://github.com/huskarl-rs/huskarl/pull/168))
- *(resource-server)* Helper to turn resource server validation failures into a response ([#162](https://github.com/huskarl-rs/huskarl/pull/162))
- *(client)* When require PAR is set, don't downgrade ([#159](https://github.com/huskarl-rs/huskarl/pull/159))
- *(client)* Support expires_in as fractions, be more lenient for device authorization. ([#156](https://github.com/huskarl-rs/huskarl/pull/156))
- *(client)* Accept RFC 8693 token_type N_A in token-exchange responses ([#144](https://github.com/huskarl-rs/huskarl/pull/144))
- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Fixed

- *(client)* Keep the refresh token when a 5xx response carries an OAuth error code ([#198](https://github.com/huskarl-rs/huskarl/pull/198))
- *(client)* [**breaking**] Remove `sub` from ID token claims (already in base token claims) ([#192](https://github.com/huskarl-rs/huskarl/pull/192))
- *(client)* Don't validate azp, but check audience is client id or another trusted audience ([#191](https://github.com/huskarl-rs/huskarl/pull/191))
- *(oidc)* Guard ID-token auth_time overflow and default clock leeway ([#189](https://github.com/huskarl-rs/huskarl/pull/189))
- *(client)* Don't abort the loopback login on a single connection's read error ([#146](https://github.com/huskarl-rs/huskarl/pull/146))
- Classify registration 5xx responses as retryable transport errors ([#145](https://github.com/huskarl-rs/huskarl/pull/145))
- *(client)* [**breaking**] Only validate the ID-token nonce when a nonce was sent ([#143](https://github.com/huskarl-rs/huskarl/pull/143))
- *(client)* [**breaking**] Require audience on IdTokenValidator ([#142](https://github.com/huskarl-rs/huskarl/pull/142))
- *(client)* Don't reject future auth_time in the max_age check ([#141](https://github.com/huskarl-rs/huskarl/pull/141))
- *(client)* Serialize authorization-request max_age as seconds ([#133](https://github.com/huskarl-rs/huskarl/pull/133))

### Other

- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
- *(client)* Make the PKCE verifier tests exercise real output ([#204](https://github.com/huskarl-rs/huskarl/pull/204))
- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
- *(crypto)* [**breaking**] Add Pkcs8Pem and remove the legacy key loaders ([#185](https://github.com/huskarl-rs/huskarl/pull/185))
- [**breaking**] Disambiguate crypto-native key-load error enums ([#183](https://github.com/huskarl-rs/huskarl/pull/183))
- [**breaking**] Normalize DPoP capitalization across types. ([#182](https://github.com/huskarl-rs/huskarl/pull/182))
- [**breaking**] Make authentication_params a builder struct, rename authentication_context ([#181](https://github.com/huskarl-rs/huskarl/pull/181))
- Pay down the usability-review docs debt ([#179](https://github.com/huskarl-rs/huskarl/pull/179))
- Align the preludes on a call-side-traits principle ([#173](https://github.com/huskarl-rs/huskarl/pull/173))
- Use ? instead of unwrap in doc examples ([#171](https://github.com/huskarl-rs/huskarl/pull/171))
- Add DPoP and client authentication how-to guides ([#165](https://github.com/huskarl-rs/huskarl/pull/165))
- Extract common max-age handling to a shared function ([#161](https://github.com/huskarl-rs/huskarl/pull/161))
- *(client)* Redact device_code from Debug output of device auth grant pending state. ([#154](https://github.com/huskarl-rs/huskarl/pull/154))
- *(client)* Fix clippy errors ([#152](https://github.com/huskarl-rs/huskarl/pull/152))
- Update README
- *(client)* Fix clippy ([#150](https://github.com/huskarl-rs/huskarl/pull/150))
- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- Reduce version numbers to init release-plz without publishing.
- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
- Update integration tests to support keycloak/dex/node-oidc-provider/Okta. ([#119](https://github.com/huskarl-rs/huskarl/pull/119))
- Prefer form over basic client credentials auth (aligning with OAuth 2.1). ([#117](https://github.com/huskarl-rs/huskarl/pull/117))
- Add DCR fields from OIDC DCR. ([#116](https://github.com/huskarl-rs/huskarl/pull/116))
- Add Dynamic Client Registration (RFC 7591) ([#115](https://github.com/huskarl-rs/huskarl/pull/115))
- Tighten documentation across grants, cache, and authorizer ([#113](https://github.com/huskarl-rs/huskarl/pull/113))
- Add cache state reporting, refresh jitter, and shared-store-safe refresh. ([#112](https://github.com/huskarl-rs/huskarl/pull/112))
- Implement PartialEq/Eq for RefreshToken ([#111](https://github.com/huskarl-rs/huskarl/pull/111))
- Include client_id in the PAR request body (RFC 9126) ([#110](https://github.com/huskarl-rs/huskarl/pull/110))
- Some API visibility updates ([#109](https://github.com/huskarl-rs/huskarl/pull/109))
- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
- Add TokenResponse::get_extra for non-standard token fields ([#106](https://github.com/huskarl-rs/huskarl/pull/106))
- Gate the OIDC nonce parameter on the openid scope ([#105](https://github.com/huskarl-rs/huskarl/pull/105))
- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
- Read granted authorization_details from the token response ([#102](https://github.com/huskarl-rs/huskarl/pull/102))
- Add RFC 9396 Rich Authorization Requests on the request side ([#101](https://github.com/huskarl-rs/huskarl/pull/101))
- Replace serde_html_form with oauth_form across the client ([#99](https://github.com/huskarl-rs/huskarl/pull/99))
- Remove raw data from some debug implementations. ([#96](https://github.com/huskarl-rs/huskarl/pull/96))
- Harden www-authenticate parsing. ([#95](https://github.com/huskarl-rs/huskarl/pull/95))
- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
- New HttpAuthorizer approach - adds GrantTokenSource. ([#91](https://github.com/huskarl-rs/huskarl/pull/91))
- Simplify some code

### Changes

 - Breaking: Update HttpAuthorizer to accept a GrantTokenSource which is capable
   of regenerating grant parameters (e.g. useful for JWT bearer grant). Also this
   unifies with the idea of priming the token source.
 - Allow token cache to refresh before the token actually expires, while all but
   one request use the existing still valid token.
 - Save RAR `authorization_details` as an extra field in token response.
 - Read allowed ID tokens algorithms from AS metadata.
 - Only send `nonce` value in authorization request for openid scope (overrideable).
 - Always include `client_id` parameter in PAR requests.
 - Add Dynamic Client Registration client (RFC 7591).
</blockquote>

## `huskarl-resource-server`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.8.0...huskarl-resource-server-v0.9.0) - 2026-07-08

### Added

- *(core)* Let ClaimCheck fields accept plain strings ([#178](https://github.com/huskarl-rs/huskarl/pull/178))
- *(resource-server)* [**breaking**] Derive the RFC 9728 document from validator metadata ([#175](https://github.com/huskarl-rs/huskarl/pull/175))
- *(core)* Add RFC 9728 protected resource metadata URL derivation ([#172](https://github.com/huskarl-rs/huskarl/pull/172))
- *(resource-server)* Point WWW-Authenticate challenges at RFC 9728 resource metadata ([#167](https://github.com/huskarl-rs/huskarl/pull/167))
- *(resource-server)* Advertise mTLS-bound token support in validator metadata ([#166](https://github.com/huskarl-rs/huskarl/pull/166))
- *(resource-server)* Carry the required scope on InsufficientScope ([#164](https://github.com/huskarl-rs/huskarl/pull/164))
- *(resource-server)* Let validators carry the challenge realm ([#163](https://github.com/huskarl-rs/huskarl/pull/163))
- *(resource-server)* Helper to turn resource server validation failures into a response ([#162](https://github.com/huskarl-rs/huskarl/pull/162))
- *(resource-server)* Require that DPoP htu is an absolute URL ([#157](https://github.com/huskarl-rs/huskarl/pull/157))
- *(resource-server)* Refuse to validate DPoP keys that have a private component. ([#155](https://github.com/huskarl-rs/huskarl/pull/155))
- *(resource-server)* Add clock-skew leeway to all temporal checks ([#147](https://github.com/huskarl-rs/huskarl/pull/147))
- [**breaking**] Make key selection async and split refresh into miss/TTL paths ([#130](https://github.com/huskarl-rs/huskarl/pull/130))

### Fixed

- *(resource-server)* Escape the DPoP algs challenge value ([#203](https://github.com/huskarl-rs/huskarl/pull/203))
- *(resource-server)* Reject requests carrying more than one DPoP header ([#199](https://github.com/huskarl-rs/huskarl/pull/199))
- *(resource-server)* Preserve the rotated DPoP nonce when a later binding check fails ([#197](https://github.com/huskarl-rs/huskarl/pull/197))
- *(resource-server)* Make sure introspection can't panic from timestamp in server response ([#190](https://github.com/huskarl-rs/huskarl/pull/190))
- *(resource-server)* [**breaking**] Advertise DPoP challenge when DPoP is accepted but unrestricted ([#135](https://github.com/huskarl-rs/huskarl/pull/135))

### Other

- Update documentation ([#206](https://github.com/huskarl-rs/huskarl/pull/206))
- Update documentation ([#195](https://github.com/huskarl-rs/huskarl/pull/195))
- Update documentation ([#193](https://github.com/huskarl-rs/huskarl/pull/193))
- *(crypto)* [**breaking**] Make PrivateJwk a sum type and route symmetric keys through the JWK funnel ([#188](https://github.com/huskarl-rs/huskarl/pull/188))
- [**breaking**] Normalize DPoP capitalization across types. ([#182](https://github.com/huskarl-rs/huskarl/pull/182))
- [**breaking**] Make authentication_params a builder struct, rename authentication_context ([#181](https://github.com/huskarl-rs/huskarl/pull/181))
- Align the preludes on a call-side-traits principle ([#173](https://github.com/huskarl-rs/huskarl/pull/173))
- Add DPoP and client authentication how-to guides ([#165](https://github.com/huskarl-rs/huskarl/pull/165))
- Update README
- Document crypto strategies, JWT verification config, and revocation TTL ([#131](https://github.com/huskarl-rs/huskarl/pull/131))
- Reduce version numbers to init release-plz without publishing.
- Update docs ([#124](https://github.com/huskarl-rs/huskarl/pull/124))
- Strip control chars from www-authenticate parameters ([#122](https://github.com/huskarl-rs/huskarl/pull/122))
- Add MultiIssuerValidator, box futures in AccessTokenValidator to make them dyn compatible. ([#121](https://github.com/huskarl-rs/huskarl/pull/121))
- Add non_exhaustive to more enums ([#107](https://github.com/huskarl-rs/huskarl/pull/107))
- Read allowed ID token signing algorithms from AS metadata. ([#104](https://github.com/huskarl-rs/huskarl/pull/104))
- Build the RFC 7662 introspection request via oauth_form ([#100](https://github.com/huskarl-rs/huskarl/pull/100))
- Add ability to refresh token cache ahead of expiry. ([#94](https://github.com/huskarl-rs/huskarl/pull/94))
- Split up some large files ([#93](https://github.com/huskarl-rs/huskarl/pull/93))
- Docs update ([#92](https://github.com/huskarl-rs/huskarl/pull/92))
- Simplify some code

 - Breaking: Make AccessTokenValidator dyn-compatible (with boxed futures).
 - Add MultiIssuerValidator which can route validator by iss value.
 - Add `non_exhaustive` to various error types.
 - Breaking: Add Debug bound to ToRfc6750Error.
 - Strip control chars from www-authenticate parameters.
</blockquote>

## `huskarl-reqwest`

<blockquote>

## [0.7.1] - 2026-06-30

### Changes

 - Add max_response_bytes builder parameter (defaults to 1024 x 1024).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).