### PR TITLE
fix(core): Skip malformed JWKS entries instead of failing the whole set

### DIFF
--- a/huskarl-core/src/jwk/mod.rs
+++ b/huskarl-core/src/jwk/mod.rs
@@ -185,7 +185,27 @@ impl From<PrivateJwk> for PublicJwk {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Jwks {
     /// List of keys.
+    ///
+    /// Deserialization is lenient per entry: an entry that is not a valid JWK
+    /// is skipped rather than failing the whole set — one malformed key in an
+    /// `IdP`'s JWKS must not take down verification for its good keys. Unknown
+    /// `kty` values are absorbed as [`Key::Unknown`]; this extends the same
+    /// policy to malformed known-`kty` entries.
+    #[serde(deserialize_with = "deserialize_keys_lenient")]
     pub keys: Vec<Jwk>,
+}
+
+/// Deserializes each `keys` entry independently, skipping invalid ones. A
+/// non-array `keys` value still fails the parse.
+fn deserialize_keys_lenient<'de, D>(deserializer: D) -> Result<Vec<Jwk>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let entries = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(entries
+        .into_iter()
+        .filter_map(|entry| serde_json::from_value(entry).ok())
+        .collect())
 }
 
 impl Jwks {

--- a/huskarl-core/src/jwk/tests.rs
+++ b/huskarl-core/src/jwk/tests.rs
@@ -70,6 +70,29 @@ fn test_jwks_with_unknown_kty_parses() {
     assert_eq!(public.keys[0].kid.as_deref(), Some("1"));
 }
 
+// A key with a *known* kty but malformed contents (padded base64 modulus, a
+// real-world AS non-compliance) must not fail the whole set either — the
+// well-formed keys must remain usable.
+#[test]
+fn test_jwks_with_malformed_known_kty_key_parses() {
+    let jwks_json = r#"{"keys":[
+            {"kty":"RSA","n":"abc+/=","e":"AQAB","kid":"bad-b64"},
+            {"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","kid":"missing-y"},
+            {"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use":"sig","kid":"good"}
+        ]}"#;
+
+    let jwks: Jwks = serde_json::from_str(jwks_json).unwrap();
+    assert_eq!(jwks.keys.len(), 1, "malformed entries are skipped");
+    assert_eq!(jwks.keys[0].kid.as_deref(), Some("good"));
+}
+
+// A `keys` value that is not an array is still a hard parse error — leniency
+// applies per entry, not to the document shape.
+#[test]
+fn test_jwks_non_array_keys_still_fails() {
+    assert!(serde_json::from_str::<Jwks>(r#"{"keys":"nope"}"#).is_err());
+}
+
 #[test]
 fn test_unknown_key_use_parses() {
     let jwk_json = r#"{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use":"attest"}"#;


### PR DESCRIPTION
Jwks deserialized its keys array all-or-nothing: Key::Unknown only absorbs unrecognized kty tags, so one key with a known kty but malformed contents (padded base64 in an RSA modulus, an EC entry missing a coordinate — both seen in real-world JWKS documents) failed the entire parse. On a JWKS refresh that takes down verification for every good key in the set, which the unknown-kty handling exists to prevent.

Each entry now deserializes independently; entries that are not valid JWKs are skipped, extending the existing unknown-kty policy to malformed known-kty entries.