### PR TITLE
fix(core): Don't reject future-iat tokens via the max_token_age check

### DIFF
--- a/huskarl-core/src/jwt/validator/mod.rs
+++ b/huskarl-core/src/jwt/validator/mod.rs
@@ -189,9 +189,12 @@ impl JwtValidator {
                 .iat
                 .ok_or_else(|| RequiredClaimMissingSnafu { claim: "iat" }.build())?;
 
+            // A future `iat` (AS clock ahead) is age zero here, not a
+            // rejection: `check_temporal`'s IssuedInFuture check below is the
+            // sole authority on future timestamps and applies the leeway.
+            let age = now.duration_since(issued_at).unwrap_or(Duration::ZERO);
             ensure!(
-                now.duration_since(issued_at)
-                    .is_ok_and(|d| d <= max_token_age.saturating_add(self.clock_leeway)),
+                age <= max_token_age.saturating_add(self.clock_leeway),
                 TokenTooOldSnafu {
                     issued_at,
                     max_token_age

--- a/huskarl-core/src/jwt/validator/tests.rs
+++ b/huskarl-core/src/jwt/validator/tests.rs
@@ -476,6 +476,56 @@ async fn max_token_age_missing_iat() {
     ));
 }
 
+/// Regression: an `iat` slightly in the future (AS clock ahead, within the
+/// configured leeway) must not be rejected by the `max_token_age` check — it
+/// used to fail as `TokenTooOld` before the leeway-aware `IssuedInFuture`
+/// check could run.
+#[tokio::test]
+async fn max_token_age_allows_future_iat_within_leeway() {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let validator = JwtValidator::builder()
+        .verifier(MockVerifier)
+        .max_token_age(Duration::from_mins(5))
+        .clock_leeway(Duration::from_mins(1))
+        .build();
+    let parsed = make_parsed_jws(
+        serde_json::json!({"alg": "RS256"}),
+        serde_json::json!({"iat": now + 2}),
+    );
+    let result = validator
+        .validate_parsed_jws::<serde_json::Value>(parsed)
+        .await;
+    assert!(result.is_ok(), "fresh token with 2s skew: {result:?}");
+}
+
+/// An `iat` beyond the leeway still fails — as `IssuedInFuture`, the check
+/// that owns future timestamps, not as a bogus `TokenTooOld`.
+#[tokio::test]
+async fn max_token_age_far_future_iat_is_issued_in_future() {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let validator = JwtValidator::builder()
+        .verifier(MockVerifier)
+        .max_token_age(Duration::from_mins(5))
+        .build();
+    let parsed = make_parsed_jws(
+        serde_json::json!({"alg": "RS256"}),
+        serde_json::json!({"iat": now + 999_999}),
+    );
+    let result = validator
+        .validate_parsed_jws::<serde_json::Value>(parsed)
+        .await;
+    assert!(matches!(
+        result,
+        Err(JwtValidationError::IssuedInFuture { .. })
+    ));
+}
+
 // --- Panic resistance on attacker-controlled input ---
 
 #[test]


### PR DESCRIPTION
now.duration_since(issued_at) returns Err for any iat even slightly in the future, so is_ok_and(..) failed and the token was rejected as TokenTooOld — before check_temporal could apply clock_leeway to the future-iat case, and with a misleading error variant. A token minted by an AS whose clock is seconds ahead validated fine without max_token_age and failed with it set.

A future iat now counts as age zero here; the IssuedInFuture check (which honours the leeway) remains the sole authority on future timestamps.