### PR TITLE
fix(client)!: Only validate the ID-token nonce when a nonce was sent

### DIFF
--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -169,6 +169,10 @@ impl AuthorizationCodeGrant {
             self.deliver_direct(&payload, request_object.as_ref())?
         };
 
+        // Persist the nonce exactly when the parameter went out: the
+        // completion side skips the nonce check when none was sent.
+        let nonce_sent = payload.rest.nonce.is_some();
+
         Ok(StartOutput {
             authorization_url,
             expires_in,
@@ -176,7 +180,7 @@ impl AuthorizationCodeGrant {
                 redirect_uri: self.redirect_uri.clone(),
                 pkce_verifier: pkce.map(|p| p.verifier),
                 state: start_input.state,
-                nonce: start_input.nonce,
+                nonce: nonce_sent.then_some(start_input.nonce),
                 dpop_jkt,
             },
         })
@@ -361,7 +365,7 @@ impl AuthorizationCodeGrant {
                 .build();
 
             let verified_token = validator
-                .validate(id_token, Some(pending_state.nonce.as_str()))
+                .validate(id_token, pending_state.nonce.as_deref())
                 .await
                 .map_err(|e| {
                     Error::new(ErrorKind::Protocol, e).with_context("validating ID token")
@@ -493,6 +497,35 @@ mod tests {
         let url = start_url(&grant).await;
         assert!(url.contains("code_challenge_method=S256"), "{url}");
         assert!(url.contains("code_challenge="), "{url}");
+    }
+
+    /// The persisted nonce must track whether the parameter was actually
+    /// sent: completion skips the check when it wasn't, so an ID token
+    /// legitimately issued without a nonce claim validates.
+    #[tokio::test]
+    async fn nonce_persisted_only_when_sent() {
+        let grant = AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(NoHttp)
+            .client_auth(NoAuth)
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .redirect_uri("http://127.0.0.1/cb")
+            .build()
+            .await
+            .unwrap();
+
+        let openid = grant.start(StartInput::scopes(["openid"])).await.unwrap();
+        assert!(
+            openid.pending_state.nonce.is_some(),
+            "openid scope sends the nonce, so it must be persisted"
+        );
+
+        let plain = grant.start(StartInput::scopes(["profile"])).await.unwrap();
+        assert!(
+            plain.pending_state.nonce.is_none(),
+            "no openid scope: nonce not sent, so none persisted for completion"
+        );
     }
 
     #[tokio::test]

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -181,8 +181,10 @@ pub struct PendingState {
     /// against the value returned to the callback (CSRF protection).
     pub state: String,
     /// The `nonce` sent to the authorization endpoint, checked against the
-    /// `nonce` claim in any returned ID token.
-    pub nonce: String,
+    /// `nonce` claim in any returned ID token. `None` when no nonce parameter
+    /// was sent (non-`openid` scope, or `send_oidc_nonce` forced off) — the
+    /// completion side then skips the nonce check.
+    pub nonce: Option<String>,
     /// The thumbprint of the `DPoP` key bound to the request.
     pub dpop_jkt: Option<String>,
 }
@@ -200,7 +202,7 @@ impl std::fmt::Debug for PendingState {
                 &self.pkce_verifier.as_ref().map(|_| "[REDACTED]"),
             )
             .field("state", &"[REDACTED]")
-            .field("nonce", &"[REDACTED]")
+            .field("nonce", &self.nonce.as_ref().map(|_| "[REDACTED]"))
             .field("dpop_jkt", &self.dpop_jkt)
             .finish()
     }
@@ -251,13 +253,28 @@ mod tests {
         );
     }
 
+    /// State persisted by versions where `nonce` was a plain string must
+    /// still deserialize (in-flight flows across an upgrade).
+    #[test]
+    fn pending_state_old_format_deserializes() {
+        let old = r#"{
+            "redirect_uri": "http://127.0.0.1/cb",
+            "pkce_verifier": "v",
+            "state": "s",
+            "nonce": "n",
+            "dpop_jkt": null
+        }"#;
+        let state: PendingState = serde_json::from_str(old).unwrap();
+        assert_eq!(state.nonce.as_deref(), Some("n"));
+    }
+
     #[test]
     fn pending_state_debug_redacts_secrets() {
         let state = PendingState {
             redirect_uri: "http://127.0.0.1/cb".to_owned(),
             pkce_verifier: Some("super-secret-verifier".to_owned()),
             state: "csrf-state-value".to_owned(),
-            nonce: "id-token-nonce".to_owned(),
+            nonce: Some("id-token-nonce".to_owned()),
             dpop_jkt: Some("jkt-thumbprint".to_owned()),
         };
 


### PR DESCRIPTION
Sending the nonce parameter is scope-gated (openid, or the send_oidc_nonce override), but complete_oidc unconditionally passed the generated nonce to the validator. Any flow that legitimately produced an ID token without a nonce claim — send_oidc_nonce(Some(false)) with an openid scope, or a server returning an ID token to a non-openid request — failed 100% of the time with NonceMismatch.

PendingState.nonce is now Option<String>, populated exactly when the parameter went to the authorization endpoint; completion passes it through as-is. Previously-persisted state (a plain string) still deserializes.

BREAKING CHANGE: PendingState.nonce is Option<String>.