### PR TITLE
feat(client): Accept RFC 8693 token_type N_A in token-exchange responses

### DIFF
--- a/huskarl/src/authorizer/mod.rs
+++ b/huskarl/src/authorizer/mod.rs
@@ -120,6 +120,14 @@ impl HttpAuthorizer {
                         })?,
                 );
             }
+            AccessToken::NotAccessToken(_) => {
+                // RFC 8693 §2.2.1: an N_A issuance is not an access token and
+                // must never be presented as an Authorization credential.
+                return Err(Error::from(ErrorKind::Config).with_context(
+                    "the cached grant issued a non-access token (token_type N_A); \
+                     it cannot authorize resource-server requests",
+                ));
+            }
         }
 
         Ok(headers)

--- a/huskarl/src/grant/core/token_response.rs
+++ b/huskarl/src/grant/core/token_response.rs
@@ -7,7 +7,7 @@ use snafu::Snafu;
 
 use crate::{
     core::{AuthorizationDetail, platform::Duration, secrets::SecretString},
-    token::{AccessToken, BearerAccessToken, DpopAccessToken, IdToken, RefreshToken},
+    token::{AccessToken, BearerAccessToken, DpopAccessToken, IdToken, NonAccessToken, RefreshToken},
 };
 
 /// The response from the token endpoint (RFC 6749 §5.1), as received.
@@ -114,6 +114,8 @@ impl TokenResponse {
 enum ResolvedTokenType {
     DPoP { jkt: String },
     Bearer,
+    /// RFC 8693 `N_A`: the issued token is not an access token.
+    NotApplicable,
 }
 
 impl RawTokenResponse {
@@ -162,6 +164,11 @@ impl RawTokenResponse {
                 .ok_or_else(|| NoDpopThumbprintSnafu.build())
         } else if self.token_type.eq_ignore_ascii_case("bearer") {
             Ok(ResolvedTokenType::Bearer)
+        } else if self.token_type.eq_ignore_ascii_case("N_A") && self.issued_token_type.is_some() {
+            // RFC 8693 §2.2.1: N_A is mandated when the issued token is not
+            // an access token. Only exchange responses carry
+            // issued_token_type, so plain grants still reject N_A.
+            Ok(ResolvedTokenType::NotApplicable)
         } else {
             InvalidTokenTypeSnafu {
                 token_type: self.token_type.clone(),
@@ -187,6 +194,13 @@ impl RawTokenResponse {
                 received_at,
                 self.expires_in.map(Duration::from_secs),
             )),
+            ResolvedTokenType::NotApplicable => {
+                AccessToken::NotAccessToken(NonAccessToken::new(
+                    self.access_token.clone(),
+                    received_at,
+                    self.expires_in.map(Duration::from_secs),
+                ))
+            }
         }
     }
 
@@ -195,7 +209,9 @@ impl RawTokenResponse {
 
         let result = match token_type {
             ResolvedTokenType::DPoP { jkt } => RefreshToken::new(refresh_token.clone(), Some(jkt)),
-            ResolvedTokenType::Bearer => RefreshToken::new(refresh_token.clone(), None),
+            ResolvedTokenType::Bearer | ResolvedTokenType::NotApplicable => {
+                RefreshToken::new(refresh_token.clone(), None)
+            }
         };
 
         Some(result)
@@ -307,13 +323,69 @@ mod test {
         );
     }
 
+    /// N_A outside a token-exchange response (no `issued_token_type`) stays
+    /// invalid — plain grants must not accept it.
     #[test]
-    fn test_invalid_token() {
-        let token_type = "N_A".to_string();
-
+    fn test_na_without_issued_token_type_is_invalid() {
         let raw_token_response = RawTokenResponse::builder()
             .access_token(SecretString::new("2YotnFZFEjr1zCsicMWpAA"))
-            .token_type(&token_type)
+            .token_type("N_A")
+            .build();
+
+        let token_response = raw_token_response.into_token_response(
+            None,
+            SystemTime::UNIX_EPOCH
+                .checked_add(Duration::from_hours(1_000_000))
+                .unwrap(),
+        );
+
+        let err_token_response = token_response.expect_err("Token response is invalid");
+
+        assert!(matches!(
+            err_token_response,
+            InvalidTokenResponse::InvalidTokenType { token_type: _ }
+        ));
+    }
+
+    /// RFC 8693 §2.2.1: a token-exchange response for a non-access-token
+    /// `requested_token_type` carries `token_type: "N_A"` and must complete.
+    #[test]
+    fn test_na_exchange_response_resolves_to_non_access_token() {
+        let raw_token_response = RawTokenResponse::builder()
+            .access_token(SecretString::new("eyJhbGciOi...an-id-token"))
+            .token_type("N_A")
+            .issued_token_type("urn:ietf:params:oauth:token-type:id_token".to_string())
+            .expires_in(300)
+            .build();
+
+        let token_response = raw_token_response
+            .into_token_response(
+                None,
+                SystemTime::UNIX_EPOCH
+                    .checked_add(Duration::from_hours(1_000_000))
+                    .unwrap(),
+            )
+            .expect("a spec-valid N_A exchange response must complete");
+
+        let token = token_response.access_token();
+        assert!(matches!(
+            token,
+            crate::token::AccessToken::NotAccessToken(_)
+        ));
+        assert_eq!(token.token_type(), "N_A");
+        assert_eq!(token.dpop_jkt(), None);
+        assert!(
+            token.expose_header_value().is_err(),
+            "an N_A token must have no Authorization-header form"
+        );
+        assert_eq!(token.token().expose_secret(), "eyJhbGciOi...an-id-token");
+    }
+
+    #[test]
+    fn test_invalid_token() {
+        let raw_token_response = RawTokenResponse::builder()
+            .access_token(SecretString::new("2YotnFZFEjr1zCsicMWpAA"))
+            .token_type("mac")
             .build();
 
         let token_response = raw_token_response.into_token_response(

--- a/huskarl/src/token/access_token.rs
+++ b/huskarl/src/token/access_token.rs
@@ -41,6 +41,12 @@ pub enum AccessToken {
     Dpop(DpopAccessToken),
     /// A `Bearer` token.
     Bearer(BearerAccessToken),
+    /// Not an access token (RFC 8693 `token_type` `N_A`): the security token
+    /// issued by a token exchange whose `requested_token_type` was something
+    /// other than an access token (an ID token, SAML assertion, or JWT). It
+    /// cannot authorize resource-server requests — read it via
+    /// [`token`](Self::token) and use it in its own protocol context.
+    NotAccessToken(NonAccessToken),
 }
 
 impl AccessToken {
@@ -50,6 +56,7 @@ impl AccessToken {
         match self {
             AccessToken::Dpop(token) => &token.token,
             AccessToken::Bearer(token) => &token.token,
+            AccessToken::NotAccessToken(token) => &token.token,
         }
     }
 
@@ -57,11 +64,18 @@ impl AccessToken {
     ///
     /// # Errors
     ///
-    /// Returns an [`InvalidHeaderValue`] if the token cannot be represented as a valid header value.
+    /// Returns an [`InvalidHeaderValue`] if the token cannot be represented as
+    /// a valid header value — always, for a
+    /// [`NotAccessToken`](Self::NotAccessToken), which must never be presented
+    /// as an `Authorization` credential (RFC 8693 §2.2.1).
     pub fn expose_header_value(&self) -> Result<HeaderValue, InvalidHeaderValue> {
         match self {
             AccessToken::Dpop(dpop_access_token) => dpop_access_token.expose_header_value(),
             AccessToken::Bearer(bearer_access_token) => bearer_access_token.expose_header_value(),
+            // Deterministically manufacture an InvalidHeaderValue (the type
+            // has no public constructor): an N_A token has no header form.
+            AccessToken::NotAccessToken(_) => Err(HeaderValue::from_str("\n")
+                .expect_err("a control character is never a valid header value")),
         }
     }
 
@@ -70,16 +84,17 @@ impl AccessToken {
     pub fn dpop_jkt(&self) -> Option<&str> {
         match self {
             AccessToken::Dpop(token) => Some(token.jkt.as_str()),
-            AccessToken::Bearer(_) => None,
+            AccessToken::Bearer(_) | AccessToken::NotAccessToken(_) => None,
         }
     }
 
-    /// Returns the token type, either `"DPoP"` or `"Bearer"`.
+    /// Returns the token type: `"DPoP"`, `"Bearer"`, or `"N_A"`.
     #[must_use]
     pub fn token_type(&self) -> &str {
         match self {
             AccessToken::Dpop(_) => "DPoP",
             AccessToken::Bearer(_) => "Bearer",
+            AccessToken::NotAccessToken(_) => "N_A",
         }
     }
 
@@ -104,6 +119,9 @@ impl AccessToken {
             AccessToken::Bearer(bearer_access_token) => {
                 bearer_access_token.effective_expiry(default_expires_in, expires_margin)
             }
+            AccessToken::NotAccessToken(token) => {
+                token.effective_expiry(default_expires_in, expires_margin)
+            }
         }
     }
 
@@ -125,7 +143,66 @@ impl AccessToken {
             AccessToken::Bearer(bearer_access_token) => {
                 bearer_access_token.effective_lifetime(default_expires_in)
             }
+            AccessToken::NotAccessToken(token) => token.effective_lifetime(default_expires_in),
         }
+    }
+}
+
+/// The security token from an RFC 8693 token-exchange response with
+/// `token_type` `N_A` — issued in the `access_token` field but *not* an access
+/// token (an ID token, SAML assertion, or JWT, per the response's
+/// `issued_token_type`). Deliberately has no `Authorization`-header form.
+#[derive(Debug, Clone)]
+pub struct NonAccessToken {
+    /// The issued security token.
+    token: SecretString,
+    /// The time at which the token was received.
+    received_at: SystemTime,
+    /// The duration for which the token is valid.
+    expires_in: Option<Duration>,
+}
+
+impl NonAccessToken {
+    /// Creates a new [`NonAccessToken`] with the given token, received time,
+    /// and expiration duration.
+    #[must_use]
+    pub fn new(token: SecretString, received_at: SystemTime, expires_in: Option<Duration>) -> Self {
+        Self {
+            token,
+            received_at,
+            expires_in,
+        }
+    }
+
+    /// Exposes the token as a [`str`].
+    #[must_use]
+    pub fn expose_token(&self) -> &str {
+        self.token.expose_secret()
+    }
+
+    /// The token's effective expiry; see
+    /// [`AccessToken::effective_expiry`] for the parameter semantics.
+    #[must_use]
+    pub fn effective_expiry(
+        &self,
+        default_expires_in: Duration,
+        expires_margin: Duration,
+    ) -> SystemTime {
+        let expires_in = self.expires_in.unwrap_or(default_expires_in);
+        effective_expiry(self.received_at, expires_in, expires_margin)
+    }
+
+    /// Returns `true` if the underlying token has expired.
+    #[must_use]
+    pub fn is_expired(&self, default_expires_in: Duration, expires_margin: Duration) -> bool {
+        SystemTime::now() >= self.effective_expiry(default_expires_in, expires_margin)
+    }
+
+    /// The token's effective lifetime; see
+    /// [`AccessToken::effective_lifetime`].
+    #[must_use]
+    pub fn effective_lifetime(&self, default_expires_in: Duration) -> Duration {
+        self.expires_in.unwrap_or(default_expires_in)
     }
 }
 

--- a/huskarl/src/token/mod.rs
+++ b/huskarl/src/token/mod.rs
@@ -4,6 +4,6 @@ mod access_token;
 pub mod id_token;
 mod refresh_token;
 
-pub use access_token::{AccessToken, BearerAccessToken, DpopAccessToken};
+pub use access_token::{AccessToken, BearerAccessToken, DpopAccessToken, NonAccessToken};
 pub use id_token::IdToken;
 pub use refresh_token::RefreshToken;


### PR DESCRIPTION
RFC 8693 §2.2.1 mandates token_type "N_A" when the issued token is not an access token, so exchanging for an id_token, saml1/2, or jwt requested_token_type could never complete: resolve_token_type rejected the spec-required response as InvalidTokenType.

N_A now resolves to AccessToken::NotAccessToken, gated on issued_token_type being present (the RFC 8693 response marker), so plain grants still reject it. The new variant carries the issued token and its expiry bookkeeping but has no Authorization-header emission at all — presenting it to a resource server is a compile-time non-option, and the HttpAuthorizer refuses it with a clear error.