### PR TITLE
feat(resource-server): Add clock-skew leeway to all temporal checks

### DIFF
--- a/huskarl-resource-server/src/introspection.rs
+++ b/huskarl-resource-server/src/introspection.rs
@@ -93,6 +93,11 @@ impl TokenIntrospection {
         #[cfg(feature = "default-jws-verifier-platform")]
         #[cfg_attr(feature = "default-jws-verifier-platform", builder(default = crate::DefaultJwsVerifierPlatform::default().into()))]
         jws_verifier_platform: Arc<dyn JwsVerifierPlatform>,
+        /// Clock-skew leeway for the RFC 9701 response JWT's temporal checks.
+        /// Defaults to
+        /// [`DEFAULT_CLOCK_LEEWAY`](crate::validator::DEFAULT_CLOCK_LEEWAY).
+        #[builder(default = crate::validator::DEFAULT_CLOCK_LEEWAY)]
+        clock_leeway: crate::core::platform::Duration,
     ) -> Result<Self, Error> {
         #[cfg(feature = "default-jws-verifier-platform")]
         let jws_verifier_platform = Some(jws_verifier_platform);
@@ -118,6 +123,7 @@ impl TokenIntrospection {
                     .require_exp(true)
                     .aud(aud_check)
                     .iss(iss_check)
+                    .clock_leeway(clock_leeway)
                     .build(),
             )
         } else {

--- a/huskarl-resource-server/src/validator/binding.rs
+++ b/huskarl-resource-server/src/validator/binding.rs
@@ -487,6 +487,40 @@ mod tests {
             .await
     }
 
+    /// Regression: a proof whose `iat` is a couple of seconds ahead of the RS
+    /// clock (routine NTP drift on the client) must validate — the default
+    /// clock leeway absorbs it, per RFC 9449 §11.1.
+    #[tokio::test]
+    async fn proof_with_slightly_future_iat_is_accepted() {
+        let signer = es256();
+        let now = crate::core::platform::SystemTime::now();
+        let proof = Jwt::builder()
+            .typ("dpop+jwt")
+            .issued_at(now + Duration::from_secs(2))
+            .expiration(now + Duration::from_mins(1))
+            .jwk(signer.public_key_jwk().into_owned())
+            .claims(valid_claims())
+            .build()
+            .to_jws_compact(&signer)
+            .await
+            .unwrap();
+
+        let confirmation = cnf(Some(matching_jkt(&signer)));
+        let result = checker(None, false)
+            .check(
+                Some(&confirmation),
+                &SecretString::new(ACCESS_TOKEN),
+                proof.expose_secret(),
+                &http::Method::POST,
+                &req_uri(),
+            )
+            .await;
+        assert!(
+            matches!(result, Ok(None)),
+            "2s future iat within default leeway must validate, got {result:?}"
+        );
+    }
+
     #[tokio::test]
     async fn valid_proof_and_binding_is_accepted() {
         let signer = es256();

--- a/huskarl-resource-server/src/validator/custom/mod.rs
+++ b/huskarl-resource-server/src/validator/custom/mod.rs
@@ -83,6 +83,11 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
         /// Maximum accepted age of a `DPoP` proof. Defaults to 1 minute.
         #[builder(default = Duration::from_mins(1))]
         max_dpop_proof_age: Duration,
+        /// Clock-skew leeway for the temporal checks on access tokens and
+        /// `DPoP` proofs (RFC 9449 §11.1). Defaults to
+        /// [`DEFAULT_CLOCK_LEEWAY`](super::DEFAULT_CLOCK_LEEWAY).
+        #[builder(default = super::DEFAULT_CLOCK_LEEWAY)]
+        clock_leeway: Duration,
         /// If `true`, Bearer tokens are rejected — all tokens must be DPoP-bound.
         ///
         /// Advertised as `dpop_bound_access_tokens_required` in RFC 9728 metadata.
@@ -140,6 +145,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
             .sub(rules.sub)
             .require_jti(rules.require_jti)
             .maybe_jti_checker(token_jti_checker)
+            .clock_leeway(clock_leeway)
             .build();
 
         Ok(Self {
@@ -150,6 +156,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
                     proof_validator: DpopProofValidator::builder()
                         .jws_verifier_platform(jws_verifier_platform)
                         .max_proof_age(max_dpop_proof_age)
+                        .clock_leeway(clock_leeway)
                         .maybe_allowed_signing_algorithms(allowed_dpop_signing_algorithms)
                         .maybe_jti_checker(dpop_jti_checker)
                         .build(),

--- a/huskarl-resource-server/src/validator/dpop_proof.rs
+++ b/huskarl-resource-server/src/validator/dpop_proof.rs
@@ -74,6 +74,10 @@ pub struct DpopProofValidator {
     /// Maximum allowed proof age based on `iat`. Default: 1 minute.
     #[builder(default = Duration::from_mins(1))]
     max_proof_age: Duration,
+    /// Clock-skew leeway for the proof's temporal checks (RFC 9449 §11.1).
+    /// Default: [`DEFAULT_CLOCK_LEEWAY`](super::DEFAULT_CLOCK_LEEWAY).
+    #[builder(default = super::DEFAULT_CLOCK_LEEWAY)]
+    clock_leeway: Duration,
     /// Allowed signing algorithms. `None` permits any asymmetric algorithm.
     allowed_signing_algorithms: Option<Vec<String>>,
     /// Optional JTI uniqueness checker for replay protection.
@@ -123,6 +127,7 @@ impl DpopProofValidator {
             .typ(ClaimCheck::required_value("dpop+jwt"))
             .maybe_allowed_algorithms(self.allowed_signing_algorithms.clone())
             .max_token_age(self.max_proof_age)
+            .clock_leeway(self.clock_leeway)
             .require_jti(self.jti_checker.is_some())
             .maybe_jti_checker(self.jti_checker.clone())
             .build();

--- a/huskarl-resource-server/src/validator/introspection/mod.rs
+++ b/huskarl-resource-server/src/validator/introspection/mod.rs
@@ -136,6 +136,11 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
         /// Maximum accepted age of a `DPoP` proof. Defaults to 1 minute.
         #[builder(default = Duration::from_mins(1))]
         max_dpop_proof_age: Duration,
+        /// Clock-skew leeway for the temporal checks on `DPoP` proofs and the
+        /// RFC 9701 introspection-response JWT (RFC 9449 §11.1). Defaults to
+        /// [`DEFAULT_CLOCK_LEEWAY`](super::DEFAULT_CLOCK_LEEWAY).
+        #[builder(default = super::DEFAULT_CLOCK_LEEWAY)]
+        clock_leeway: Duration,
         /// If `true`, Bearer tokens are rejected — all tokens must be DPoP-bound.
         ///
         /// Advertised as `dpop_bound_access_tokens_required` in RFC 9728 metadata.
@@ -196,6 +201,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
             .maybe_jwks_uri(jwks_uri)
             .jws_verifier_factory(jws_verifier_factory)
             .jws_verifier_platform(jws_verifier_platform.clone())
+            .clock_leeway(clock_leeway)
             .build()
             .await?;
 
@@ -207,6 +213,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
                 proof_validator: DpopProofValidator::builder()
                     .jws_verifier_platform(jws_verifier_platform)
                     .max_proof_age(max_dpop_proof_age)
+                    .clock_leeway(clock_leeway)
                     .maybe_allowed_signing_algorithms(allowed_dpop_signing_algorithms)
                     .maybe_jti_checker(dpop_jti_checker)
                     .build(),

--- a/huskarl-resource-server/src/validator/mod.rs
+++ b/huskarl-resource-server/src/validator/mod.rs
@@ -25,10 +25,18 @@ pub mod rfc9068;
 use crate::{
     core::{
         jwt::{ConfirmationClaim, validator::ValidatedJwt},
-        platform::{MaybeSendBoxFuture, MaybeSendSync, SystemTime},
+        platform::{Duration, MaybeSendBoxFuture, MaybeSendSync, SystemTime},
     },
     error::ToRfc6750Error,
 };
+
+/// Default clock-skew leeway applied to the temporal checks (`exp`, `nbf`,
+/// `iat`, `DPoP` proof freshness). RFC 9449 §11.1 tells servers to accept
+/// proofs in a reasonable window around the current time; the same reasoning
+/// applies to access-token validation. Ten seconds absorbs real-world NTP
+/// drift without meaningfully weakening proof freshness — override it with
+/// the `clock_leeway` builder option on each validator.
+pub const DEFAULT_CLOCK_LEEWAY: Duration = Duration::from_secs(10);
 
 /// A trait for validators that authenticate and validate access tokens from HTTP requests.
 ///

--- a/huskarl-resource-server/src/validator/rfc9068/mod.rs
+++ b/huskarl-resource-server/src/validator/rfc9068/mod.rs
@@ -91,6 +91,11 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
         /// Maximum accepted age of a `DPoP` proof. Defaults to 1 minute.
         #[builder(default = Duration::from_mins(1))]
         max_dpop_proof_age: Duration,
+        /// Clock-skew leeway for the temporal checks on access tokens and
+        /// `DPoP` proofs (RFC 9449 §11.1). Defaults to
+        /// [`DEFAULT_CLOCK_LEEWAY`](super::DEFAULT_CLOCK_LEEWAY).
+        #[builder(default = super::DEFAULT_CLOCK_LEEWAY)]
+        clock_leeway: Duration,
         /// If `true`, Bearer tokens are rejected — all tokens must be DPoP-bound.
         ///
         /// Advertised as `dpop_bound_access_tokens_required` in RFC 9728 metadata.
@@ -146,6 +151,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
             .sub(ClaimCheck::present())
             .require_jti(jti_checker.is_some())
             .maybe_jti_checker(jti_checker)
+            .clock_leeway(clock_leeway)
             .build();
 
         Ok(Self {
@@ -156,6 +162,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
                     proof_validator: DpopProofValidator::builder()
                         .jws_verifier_platform(jws_verifier_platform)
                         .max_proof_age(max_dpop_proof_age)
+                        .clock_leeway(clock_leeway)
                         .maybe_allowed_signing_algorithms(allowed_dpop_signing_algorithms)
                         .maybe_jti_checker(dpop_jti_checker)
                         .build(),


### PR DESCRIPTION
No validator applied any clock leeway: a DPoP proof whose iat was one second ahead of the RS clock (routine NTP drift) failed IssuedInFuture and every request from that client 401'd until the clocks realigned, contra RFC 9449 §11.1; the same zero-leeway applied to access-token exp/nbf/iat and the RFC 9701 introspection-response JWT.

All validator builders now take clock_leeway, threaded into the access-token validator, the DPoP proof validator, and the introspection JWT validator. The default is DEFAULT_CLOCK_LEEWAY (10 seconds) — a deliberate behavior change: small enough not to weaken proof freshness meaningfully, large enough to absorb real-world skew.