### PR TITLE
fix(crypto-webcrypto): Surface JS error details instead of an empty string

### DIFF
--- a/huskarl-crypto-webcrypto/src/error.rs
+++ b/huskarl-crypto-webcrypto/src/error.rs
@@ -1,9 +1,9 @@
 use snafu::Snafu;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast as _, JsValue};
 
 /// A JavaScript error surfaced from a `JsValue` (e.g. a rejected `WebCrypto` promise).
 #[derive(Debug, Snafu)]
-#[snafu(display("{}", error.as_string().unwrap_or_default()))]
+#[snafu(display("{}", js_error_message(error)))]
 pub struct JsError {
     error: JsValue,
 }
@@ -13,4 +13,18 @@ impl JsError {
     pub(crate) fn new(error: JsValue) -> Self {
         Self { error }
     }
+}
+
+/// Human-readable text for a JS error value: string values as-is; `Error` and
+/// `DOMException` objects — what `SubtleCrypto` rejects with — via their
+/// `message`; anything else via its `Debug` form. Never the empty string that
+/// `as_string()` alone produced for every object.
+fn js_error_message(error: &JsValue) -> String {
+    if let Some(s) = error.as_string() {
+        return s;
+    }
+    if let Some(e) = error.dyn_ref::<web_sys::js_sys::Error>() {
+        return String::from(e.message());
+    }
+    format!("{error:?}")
 }


### PR DESCRIPTION
JsError's Display used JsValue::as_string(), which is Some only when the JsValue is a JS string — but SubtleCrypto rejections are DOMException / Error objects, so every error in the crate displayed as "": operators saw "Signing failed: " with zero diagnostic content. Fall back to the object's message property, then to its Debug form.