### PR TITLE
feat(client): Support expires_in as fractions, be more lenient for device authorization

### DIFF
--- a/huskarl/src/grant/core/token_response.rs
+++ b/huskarl/src/grant/core/token_response.rs
@@ -325,6 +325,31 @@ mod test {
         );
     }
 
+    /// Some authorization servers emit `expires_in` as a JSON float
+    /// (e.g. `3600.0`) or as a float in a string (`"3600.0"`); fractional
+    /// values truncate toward earlier expiry.
+    #[rstest::rstest]
+    #[case::integral("3600.0", Some(3600))]
+    #[case::fractional("3599.5", Some(3599))]
+    #[case::string_float(r#""3600.0""#, Some(3600))]
+    #[case::string_fractional(r#""3599.5""#, Some(3599))]
+    fn parse_token_response_with_float_expires_in(
+        #[case] expires_in: &str,
+        #[case] expected: Option<u64>,
+    ) {
+        let token_response_str = format!(
+            r#"{{
+  "access_token":"2YotnFZFEjr1zCsicMWpAA",
+  "token_type":"example",
+  "expires_in":{expires_in}
+}}"#
+        );
+
+        let raw_token_response: RawTokenResponse =
+            serde_json::from_str(&token_response_str).expect("float expires_in parses");
+        assert_eq!(raw_token_response.expires_in, expected);
+    }
+
     /// `N_A` outside a token-exchange response (no `issued_token_type`) stays
     /// invalid — plain grants must not accept it.
     #[test]

--- a/huskarl/src/grant/device_authorization/grant.rs
+++ b/huskarl/src/grant/device_authorization/grant.rs
@@ -338,11 +338,15 @@ struct DeviceAuthorizationResponse {
     verification_uri_complete: Option<String>,
 
     /// The lifetime in seconds of the `device_code` and `user_code`.
+    #[serde(deserialize_with = "crate::serde_utils::deserialize_u32_or_string")]
     expires_in: u32,
 
     /// The minimum amount of time in seconds the client should wait between polling requests.
     /// Defaults to 5 seconds if not provided by the server.
-    #[serde(default = "default_interval")]
+    #[serde(
+        default = "default_interval",
+        deserialize_with = "crate::serde_utils::deserialize_u32_or_string"
+    )]
     interval: u32,
 }
 
@@ -509,6 +513,24 @@ mod tests {
             device_code: "dev-code".to_string(),
             interval_secs: 5,
         }
+    }
+
+    /// Same wire leniency as the token response's `expires_in`: seconds
+    /// counts may arrive as floats, number strings, or float strings.
+    #[rstest::rstest]
+    #[case::floats("1800.0", "5.5")]
+    #[case::strings(r#""1800""#, r#""5""#)]
+    #[case::float_strings(r#""1800.0""#, r#""5.5""#)]
+    fn device_authorization_response_accepts_float_and_string_seconds(
+        #[case] expires_in: &str,
+        #[case] interval: &str,
+    ) {
+        let json = format!(
+            r#"{{"device_code":"dc","user_code":"uc","verification_uri":"https://as.example/verify","expires_in":{expires_in},"interval":{interval}}}"#
+        );
+        let response: DeviceAuthorizationResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(response.expires_in, 1800);
+        assert_eq!(response.interval, 5);
     }
 
     #[test]

--- a/huskarl/src/serde_utils.rs
+++ b/huskarl/src/serde_utils.rs
@@ -1,41 +1,74 @@
 use serde::{Deserializer, de};
 
-/// Deserialize a `u64` from either a JSON number or a string containing a number.
+/// Forgiving visitor for second-count fields (`expires_in`, `interval`):
+/// servers variously emit them as integers, floats (`3600.0`), strings
+/// (`"3600"`), or float strings (`"3600.0"`). Fractional values truncate,
+/// which only ever shortens a lifetime — the safe side.
+struct U64OrString;
+
+impl de::Visitor<'_> for U64OrString {
+    type Value = Option<u64>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("a number or string containing a number")
+    }
+
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        Ok(Some(v))
+    }
+
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+        u64::try_from(v)
+            .map(Some)
+            .map_err(|_| E::custom(format!("negative seconds value: {v}")))
+    }
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {
+        if v.is_finite() && v >= 0.0 {
+            Ok(Some(v as u64)) // saturates at u64::MAX
+        } else {
+            Err(E::custom(format!("invalid seconds value: {v}")))
+        }
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        if let Ok(n) = v.parse::<u64>() {
+            return Ok(Some(n));
+        }
+        match v.parse::<f64>() {
+            // visit_f64 keeps the "inf"/"NaN" strings f64 parsing accepts out.
+            Ok(f) => self.visit_f64(f),
+            Err(e) => Err(E::custom(e)),
+        }
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+}
+
+/// Deserialize an optional `u64` seconds count from a number or a string
+/// containing a number.
 pub(crate) fn deserialize_u64_or_string<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    struct U64OrString;
-
-    impl de::Visitor<'_> for U64OrString {
-        type Value = Option<u64>;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.write_str("a number or string containing a number")
-        }
-
-        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
-            Ok(Some(v))
-        }
-
-        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
-            u64::try_from(v)
-                .map(Some)
-                .map_err(|_| E::custom(format!("negative expires_in: {v}")))
-        }
-
-        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            v.parse::<u64>().map(Some).map_err(E::custom)
-        }
-
-        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
-            Ok(None)
-        }
-
-        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-            Ok(None)
-        }
-    }
-
     deserializer.deserialize_any(U64OrString)
+}
+
+/// Deserialize a required `u32` seconds count from a number or a string
+/// containing a number.
+pub(crate) fn deserialize_u32_or_string<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match deserializer.deserialize_any(U64OrString)? {
+        Some(v) => u32::try_from(v).map_err(de::Error::custom),
+        None => Err(de::Error::custom("expected a number, got null")),
+    }
 }


### PR DESCRIPTION
In general, support fractions and strings where the result is an integral number.