### PR TITLE
feat: Add supported_signature_algorithms to JwsVerifierPlatform.

### DIFF
--- a/huskarl-core/src/crypto/verifier/trait.rs
+++ b/huskarl-core/src/crypto/verifier/trait.rs
@@ -170,6 +170,14 @@ pub trait JwsVerifierPlatform: std::fmt::Debug + MaybeSendSync {
         &self,
         jwk: PublicJwk,
     ) -> MaybeSendBoxFuture<'static, Result<Arc<dyn JwsVerifier>, CreateVerifierError>>;
+
+    /// The JWS `alg` values this platform can verify, independent of loaded keys.
+    ///
+    /// A static capability upper bound for the `*_signing_alg_values_supported`
+    /// metadata fields; operators usually advertise a policy subset. Scoped to
+    /// the JWS signing registry — JWE `alg`/`enc` are a separate concern and not
+    /// covered here.
+    fn supported_signature_algorithms(&self) -> &[&str];
 }
 
 /// Factory for constructing a [`JwsVerifier`] from a JWKS URI and a verifier platform.

--- a/huskarl-core/src/jwk/source.rs
+++ b/huskarl-core/src/jwk/source.rs
@@ -172,6 +172,10 @@ mod tests {
         {
             Box::pin(async { Err(CreateVerifierError::UnsupportedKey) })
         }
+
+        fn supported_signature_algorithms(&self) -> &[&str] {
+            &[]
+        }
     }
 
     fn jwks_with_keys(n: usize) -> String {

--- a/huskarl-crypto-native/src/asymmetric/verifier.rs
+++ b/huskarl-crypto-native/src/asymmetric/verifier.rs
@@ -30,6 +30,11 @@ enum Key {
     Ed25519(ed25519_dalek::VerifyingKey),
 }
 
+/// Union of [`Key::supported_algorithms`] across all variants.
+pub(crate) const SUPPORTED_SIGNATURE_ALGORITHMS: &[&str] = &[
+    "ES256", "ES384", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "Ed25519", "EdDSA",
+];
+
 impl Key {
     pub fn supported_algorithms(&self) -> &[&str] {
         match self {

--- a/huskarl-crypto-native/src/factory.rs
+++ b/huskarl-crypto-native/src/factory.rs
@@ -24,4 +24,8 @@ impl JwsVerifierPlatform for NativeVerifierPlatform {
             })
         })
     }
+
+    fn supported_signature_algorithms(&self) -> &[&str] {
+        crate::asymmetric::verifier::SUPPORTED_SIGNATURE_ALGORITHMS
+    }
 }

--- a/huskarl-crypto-webcrypto/src/asymmetric/verifier.rs
+++ b/huskarl-crypto-webcrypto/src/asymmetric/verifier.rs
@@ -148,6 +148,11 @@ async fn create_ec_key(
     .ok()
 }
 
+/// Union of [`Key::supported_algorithms`] across all variants.
+pub(crate) const SUPPORTED_SIGNATURE_ALGORITHMS: &[&str] = &[
+    "ES256", "ES384", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "Ed25519", "EdDSA",
+];
+
 impl Key {
     fn supported_algorithms(&self) -> &[&str] {
         match self {

--- a/huskarl-crypto-webcrypto/src/factory.rs
+++ b/huskarl-crypto-webcrypto/src/factory.rs
@@ -24,4 +24,8 @@ impl JwsVerifierPlatform for WebCryptoVerifierPlatform {
                 })
         })
     }
+
+    fn supported_signature_algorithms(&self) -> &[&str] {
+        crate::asymmetric::verifier::SUPPORTED_SIGNATURE_ALGORITHMS
+    }
 }


### PR DESCRIPTION
This allows discovery of what algorithms can be verified by the relevant platform.