### PR TITLE
feat(client)!: Rename `scopes` builder to `scope` and make `Vec<String>` for consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
 name = "huskarl-conformance"
 version = "0.1.0"
 dependencies = [
+ "bon",
  "bytes",
  "http",
  "huskarl",
@@ -1285,6 +1286,7 @@ dependencies = [
 name = "huskarl-integration"
 version = "0.1.0"
 dependencies = [
+ "bon",
  "http",
  "huskarl",
  "huskarl-crypto-native",

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ async fn fetch_token() -> Result<(), huskarl::core::Error> {
     let token_response = grant
         .exchange(
             ClientCredentialsGrantParameters::builder()
-                .scopes(vec!["read"])
+                .scope(bon::vec!["read"])
                 .build(),
         )
         .await?;

--- a/huskarl/docs/guide/authorization_code.md
+++ b/huskarl/docs/guide/authorization_code.md
@@ -76,7 +76,7 @@ use huskarl::grant::authorization_code::{AuthorizationCodeGrant, StartInput};
 #     grant: &AuthorizationCodeGrant,
 # ) -> Result<(), Box<dyn std::error::Error>> {
 
-let start_output = grant.start(StartInput::scopes(["read", "write"])).await?;
+let start_output = grant.start(StartInput::scope(bon::vec!["read", "write"])).await?;
 
 // Redirect the user to this URL to authorize.
 let authorization_url = start_output.authorization_url;

--- a/huskarl/docs/guide/client_credentials.md
+++ b/huskarl/docs/guide/client_credentials.md
@@ -97,7 +97,7 @@ use huskarl::core::client_auth::ClientSecret;
 #     .client_auth(client_auth)
 #     .build();
 
-let params = ClientCredentialsGrantParameters::builder().scopes(vec!["read", "write"]).build();
+let params = ClientCredentialsGrantParameters::builder().scope(bon::vec!["read", "write"]).build();
 let response = grant.exchange(params).await?;
 let token: &AccessToken = response.access_token();
 

--- a/huskarl/docs/guide/device_authorization.md
+++ b/huskarl/docs/guide/device_authorization.md
@@ -79,7 +79,7 @@ use huskarl::{
 #     grant: &DeviceAuthorizationGrant,
 # ) -> Result<(), Box<dyn std::error::Error>> {
 
-let start_output = grant.start(StartInput::scopes(["read", "write"])).await?;
+let start_output = grant.start(StartInput::scope(bon::vec!["read", "write"])).await?;
 
 // Display to the user — they visit the URL and enter the code on another device.
 println!("Visit: {}", start_output.verification_uri);

--- a/huskarl/docs/guide/jwt_bearer.md
+++ b/huskarl/docs/guide/jwt_bearer.md
@@ -110,7 +110,7 @@ use huskarl::core::client_auth::ClientSecret;
 
 let params = JwtBearerGrantParameters::builder()
     .assertion(assertion)
-    .scopes(vec!["read", "write"])
+    .scope(bon::vec!["read", "write"])
     .build();
 let response = grant.exchange(params).await?;
 let token: &AccessToken = response.access_token();

--- a/huskarl/examples/authorization_code.rs
+++ b/huskarl/examples/authorization_code.rs
@@ -63,7 +63,7 @@ pub async fn main() -> Result<(), snafu::Whatever> {
         pending_state,
         ..
     } = grant
-        .start(StartInput::scopes(["test"]))
+        .start(StartInput::scope(bon::vec!["test"]))
         .await
         .whatever_context("Getting authorization URL failed")?;
 

--- a/huskarl/examples/basic_dpop.rs
+++ b/huskarl/examples/basic_dpop.rs
@@ -48,7 +48,7 @@ pub async fn main() -> Result<(), snafu::Whatever> {
     let token_response = grant
         .exchange(
             ClientCredentialsGrantParameters::builder()
-                .scopes(vec!["test"])
+                .scope(bon::vec!["test"])
                 .build(),
         )
         .await

--- a/huskarl/examples/client_credentials.rs
+++ b/huskarl/examples/client_credentials.rs
@@ -39,7 +39,7 @@ pub async fn main() -> Result<(), snafu::Whatever> {
     let token_response = grant
         .exchange(
             ClientCredentialsGrantParameters::builder()
-                .scopes(vec!["test"])
+                .scope(bon::vec!["test"])
                 .build(),
         )
         .await

--- a/huskarl/src/cache/mod.rs
+++ b/huskarl/src/cache/mod.rs
@@ -176,7 +176,7 @@ mod tests {
             )
             .grant_parameters(
                 ClientCredentialsGrantParameters::builder()
-                    .scopes(["read", "write"])
+                    .scope(bon::vec!["read", "write"])
                     .build(),
             )
             .refresh_store(InMemoryRefreshTokenStore::default())

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -33,7 +33,7 @@ use crate::{
                 PendingState, StartInput, StartOutput,
             },
         },
-        core::{OAuth2ExchangeGrant, TokenResponse, form::with_dpop_nonce_retry},
+        core::{OAuth2ExchangeGrant, TokenResponse, form::with_dpop_nonce_retry, join_space},
     },
     token::id_token::{IdTokenClaims, IdTokenValidator},
 };
@@ -405,7 +405,7 @@ fn build_authorization_payload<'a>(
         rest: AuthorizationPayload {
             response_type: "code",
             redirect_uri: &grant.redirect_uri,
-            scope: start_input.scopes.as_deref(),
+            scope: join_space(start_input.scope.as_deref()),
             state: &start_input.state,
             code_challenge: pkce.map(|p| p.challenge.as_ref()),
             code_challenge_method: pkce.map(|p| p.method),
@@ -416,9 +416,9 @@ fn build_authorization_payload<'a>(
             // unknown parameters do not. `send_oidc_nonce` forces either way.
             nonce: {
                 let is_oidc = start_input
-                    .scopes
+                    .scope
                     .as_deref()
-                    .is_some_and(|s| s.split(' ').any(|scope| scope == "openid"));
+                    .is_some_and(|s| s.iter().any(|scope| scope == "openid"));
                 grant
                     .send_oidc_nonce
                     .unwrap_or(is_oidc)
@@ -427,10 +427,10 @@ fn build_authorization_payload<'a>(
             display: start_input.display.as_ref(),
             prompt: start_input.prompt.as_ref(),
             max_age: start_input.max_age.map(|d| d.as_secs()),
-            ui_locales: start_input.ui_locales.as_ref().map(|l| l.join(" ")),
+            ui_locales: join_space(start_input.ui_locales.as_deref()),
             id_token_hint: start_input.id_token_hint.as_ref(),
             login_hint: start_input.login_hint.as_deref(),
-            acr_values: start_input.acr_values.as_ref().map(|l| l.join(" ")),
+            acr_values: join_space(start_input.acr_values.as_deref()),
             resource: start_input.resource.as_deref(),
             authorization_details: start_input.authorization_details.as_deref(),
         },
@@ -490,7 +490,7 @@ mod tests {
 
     async fn start_url(grant: &Grant) -> String {
         grant
-            .start(StartInput::scopes(["openid"]))
+            .start(StartInput::scope(bon::vec!["openid"]))
             .await
             .unwrap()
             .authorization_url
@@ -534,7 +534,10 @@ mod tests {
             .unwrap();
 
         let before = SystemTime::now();
-        let output = grant.start(StartInput::scopes(["openid"])).await.unwrap();
+        let output = grant
+            .start(StartInput::scope(bon::vec!["openid"]))
+            .await
+            .unwrap();
         let expires_at = output.expires_at.expect("PAR delivery sets an expiry");
 
         // The RFC 9126 `expires_in` (90s) is anchored at receipt.
@@ -559,7 +562,10 @@ mod tests {
             .await
             .unwrap();
 
-        let output = grant.start(StartInput::scopes(["openid"])).await.unwrap();
+        let output = grant
+            .start(StartInput::scope(bon::vec!["openid"]))
+            .await
+            .unwrap();
         assert_eq!(output.expires_at, None);
     }
 
@@ -636,13 +642,19 @@ mod tests {
             .await
             .unwrap();
 
-        let openid = grant.start(StartInput::scopes(["openid"])).await.unwrap();
+        let openid = grant
+            .start(StartInput::scope(bon::vec!["openid"]))
+            .await
+            .unwrap();
         assert!(
             openid.pending_state.nonce.is_some(),
             "openid scope sends the nonce, so it must be persisted"
         );
 
-        let plain = grant.start(StartInput::scopes(["profile"])).await.unwrap();
+        let plain = grant
+            .start(StartInput::scope(bon::vec!["profile"]))
+            .await
+            .unwrap();
         assert!(
             plain.pending_state.nonce.is_none(),
             "no openid scope: nonce not sent, so none persisted for completion"
@@ -665,7 +677,7 @@ mod tests {
             .unwrap();
 
         let start_input = StartInput::builder()
-            .scopes(["openid"])
+            .scope(bon::vec!["openid"])
             .authorization_details(vec![
                 AuthorizationDetail::builder("payment_initiation")
                     .with("actions", serde_json::json!(["initiate"]))
@@ -695,7 +707,7 @@ mod tests {
                 crate::core::AuthorizationDetail::builder("payment_initiation").build(),
             ])
             .build();
-        assert!(start_input.scopes.is_none());
+        assert!(start_input.scope.is_none());
         assert!(start_input.authorization_details.is_some());
     }
 
@@ -847,7 +859,7 @@ mod tests {
         let result = grant
             .start(
                 StartInput::builder()
-                    .scopes(["openid"])
+                    .scope(bon::vec!["openid"])
                     .id_token_hint(crate::token::IdToken::from("a".repeat(70 * 1024)))
                     .build(),
             )

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     core::{AuthorizationDetail, platform::Duration},
-    grant::core::mk_scopes,
     token::IdToken,
 };
 
@@ -16,7 +15,7 @@ pub struct AuthorizationPayload<'a> {
     pub(super) response_type: &'static str,
     pub(super) redirect_uri: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) scope: Option<&'a str>,
+    pub(super) scope: Option<String>,
     pub(super) state: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) code_challenge: Option<&'a str>,
@@ -62,7 +61,7 @@ pub struct AuthorizationPayloadWithClientId<'a> {
 ///
 /// The device-authorization flow has a same-named counterpart
 /// ([`device_authorization::StartInput`](crate::grant::device_authorization::StartInput))
-/// with the same [`scopes`](Self::scopes) convenience constructor; when
+/// with the same [`scope`](Self::scope) convenience constructor; when
 /// wiring both flows in one module, qualify or alias the imports.
 #[derive(Debug, Clone, Builder)]
 #[builder(finish_fn(vis = "", name = build_internal), on(String, into))]
@@ -71,8 +70,8 @@ pub struct StartInput {
     pub(super) state: String,
     #[builder(finish_fn)]
     pub(super) nonce: String,
-    #[builder(required, default, with = |scopes: impl IntoIterator<Item = impl Into<String>>| mk_scopes(scopes))]
-    pub(super) scopes: Option<String>,
+    /// The requested scope(s) for the authorization request.
+    pub(super) scope: Option<Vec<String>>,
     pub(super) resource: Option<Vec<String>>,
     /// RFC 9396 Rich Authorization Requests: fine-grained authorization
     /// requirements expressed as typed authorization-details objects.
@@ -134,8 +133,9 @@ impl StartInput {
     ///
     /// This is enough for most use cases; the builder exists as an extensible
     /// API where arbitrary extra fields may be added in future.
-    pub fn scopes(scopes: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        Self::builder().scopes(scopes).build()
+    #[must_use]
+    pub fn scope(scope: Vec<String>) -> Self {
+        Self::builder().scope(scope).build()
     }
 }
 
@@ -247,7 +247,7 @@ mod tests {
         let payload = AuthorizationPayload {
             response_type: "code",
             redirect_uri: "http://127.0.0.1/cb",
-            scope: Some("openid"),
+            scope: Some("openid".into()),
             state: "state",
             code_challenge: None,
             code_challenge_method: None,

--- a/huskarl/src/grant/client_credentials.rs
+++ b/huskarl/src/grant/client_credentials.rs
@@ -22,7 +22,7 @@ use crate::{
         platform::MaybeSendBoxFuture,
     },
     grant::{
-        core::{OAuth2ExchangeGrant, mk_scopes},
+        core::{OAuth2ExchangeGrant, join_space},
         refresh::RefreshGrant,
     },
 };
@@ -143,7 +143,7 @@ impl OAuth2ExchangeGrant for ClientCredentialsGrant {
     fn build_form(&self, params: Self::Parameters) -> Self::Form<'_> {
         ClientCredentialsGrantForm {
             grant_type: "client_credentials",
-            scope: params.scope,
+            scope: join_space(params.scope.as_deref()),
             resource: params.resource,
             authorization_details: params.authorization_details,
         }
@@ -155,8 +155,7 @@ impl OAuth2ExchangeGrant for ClientCredentialsGrant {
 #[builder(on(String, into))]
 pub struct ClientCredentialsGrantParameters {
     /// The requested scope(s) for the access token.
-    #[builder(required, default, name = "scopes", with = |scopes: impl IntoIterator<Item = impl Into<String>>| mk_scopes(scopes))]
-    scope: Option<String>,
+    scope: Option<Vec<String>>,
     /// The target resource(s) for the access token.
     resource: Option<Vec<String>>,
     /// RFC 9396 `authorization_details` requested for the issued access token.

--- a/huskarl/src/grant/core/mod.rs
+++ b/huskarl/src/grant/core/mod.rs
@@ -29,15 +29,18 @@ pub(crate) fn resolve_mtls_alias(
     }
 }
 
-/// Standard implementation for converting a sequence of scopes into a scope string.
-pub(crate) fn mk_scopes(scopes: impl IntoIterator<Item = impl Into<String>>) -> Option<String> {
-    let maybe_scopes = scopes
-        .into_iter()
-        .filter_map(|s| {
-            let s = s.into();
-            (!s.trim().is_empty()).then_some(s)
-        })
-        .collect::<Vec<_>>();
+/// Joins a list of values into the single space-delimited string that the
+/// OAuth/OIDC list parameters `scope`, `ui_locales`, and `acr_values` use on the
+/// wire (RFC 6749 §3.3, OIDC Core §3.1.2.1). Empty and whitespace-only entries
+/// are dropped; an absent or all-empty list yields `None` so the parameter is
+/// omitted entirely.
+pub(crate) fn join_space(items: Option<&[String]>) -> Option<String> {
+    let joined = items?
+        .iter()
+        .map(String::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
 
-    (!maybe_scopes.is_empty()).then(|| maybe_scopes.join(" "))
+    (!joined.is_empty()).then_some(joined)
 }

--- a/huskarl/src/grant/device_authorization/grant.rs
+++ b/huskarl/src/grant/device_authorization/grant.rs
@@ -128,7 +128,7 @@ impl DeviceAuthorizationGrant {
     /// authorization request.
     pub async fn start(&self, start_input: StartInput) -> Result<StartOutput, Error> {
         let payload = DeviceAuthorizationRequest {
-            scope: start_input.scopes.as_deref(),
+            scope: crate::grant::core::join_space(start_input.scope.as_deref()),
             resource: start_input.resource.as_deref(),
             authorization_details: start_input.authorization_details.as_deref(),
         };
@@ -368,7 +368,7 @@ pub const DEFAULT_MIN_POLL_INTERVAL_SECS: u32 = 5;
 
 #[derive(Debug, Serialize)]
 struct DeviceAuthorizationRequest<'a> {
-    scope: Option<&'a str>,
+    scope: Option<String>,
     resource: Option<&'a [String]>,
     authorization_details: Option<&'a [crate::core::AuthorizationDetail]>,
 }
@@ -443,11 +443,11 @@ pub enum PollResult {
 /// The input to start the device authorization flow.
 #[derive(Debug, Clone, Builder)]
 pub struct StartInput {
-    #[builder(required, default, with = |scopes: impl IntoIterator<Item = impl Into<String>>| crate::grant::core::mk_scopes(scopes))]
-    scopes: Option<String>,
+    /// The requested scope(s) for the device authorization request.
+    scope: Option<Vec<String>>,
     resource: Option<Vec<String>>,
     /// RFC 9396 Rich Authorization Requests, sent on the device authorization
-    /// request alongside (or instead of) `scopes`.
+    /// request alongside (or instead of) `scope`.
     authorization_details: Option<Vec<crate::core::AuthorizationDetail>>,
 }
 
@@ -457,8 +457,8 @@ impl StartInput {
     /// This is enough for most use cases; the builder exists as an extensible
     /// API where arbitrary extra fields may be added in future.
     #[must_use]
-    pub fn scopes(scopes: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        Self::builder().scopes(scopes).build()
+    pub fn scope(scope: Vec<String>) -> Self {
+        Self::builder().scope(scope).build()
     }
 }
 
@@ -553,7 +553,7 @@ mod tests {
                 .build(),
         ];
         let payload = DeviceAuthorizationRequest {
-            scope: Some("openid"),
+            scope: Some("openid".into()),
             resource: None,
             authorization_details: Some(&details),
         };
@@ -576,7 +576,7 @@ mod tests {
                 crate::core::AuthorizationDetail::builder("payment_initiation").build(),
             ])
             .build();
-        assert!(input.scopes.is_none());
+        assert!(input.scope.is_none());
         assert!(input.authorization_details.is_some());
     }
 

--- a/huskarl/src/grant/jwt_bearer.rs
+++ b/huskarl/src/grant/jwt_bearer.rs
@@ -25,7 +25,7 @@ use crate::{
         secrets::SecretString,
     },
     grant::{
-        core::{OAuth2ExchangeGrant, mk_scopes},
+        core::{OAuth2ExchangeGrant, join_space},
         refresh::RefreshGrant,
     },
 };
@@ -154,7 +154,7 @@ impl OAuth2ExchangeGrant for JwtBearerGrant {
         JwtBearerGrantForm {
             grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
             assertion: params.assertion,
-            scope: params.scope,
+            scope: join_space(params.scope.as_deref()),
             resource: params.resource,
             authorization_details: params.authorization_details,
         }
@@ -176,8 +176,7 @@ pub struct JwtBearerGrantParameters {
     #[builder(into)]
     assertion: SecretString,
     /// The requested scope(s) for the access token.
-    #[builder(required, default, name = "scopes", with = |scopes: impl IntoIterator<Item = impl Into<String>>| mk_scopes(scopes))]
-    scope: Option<String>,
+    scope: Option<Vec<String>>,
     /// The target resource(s) for the access token (RFC 8707).
     resource: Option<Vec<String>>,
     /// RFC 9396 `authorization_details` requested for the issued access token.

--- a/huskarl/src/grant/refresh.rs
+++ b/huskarl/src/grant/refresh.rs
@@ -21,7 +21,7 @@ use crate::{
         http::HttpClient,
         secrets::SecretString,
     },
-    grant::core::{OAuth2ExchangeGrant, mk_scopes},
+    grant::core::{OAuth2ExchangeGrant, join_space},
     token::RefreshToken,
 };
 
@@ -136,7 +136,7 @@ impl OAuth2ExchangeGrant for RefreshGrant {
         RefreshGrantForm {
             grant_type: "refresh_token",
             refresh_token: params.refresh_token.token().clone(),
-            scope: params.scope,
+            scope: join_space(params.scope.as_deref()),
             resource: params.resource,
             authorization_details: params.authorization_details,
         }
@@ -149,8 +149,7 @@ pub struct RefreshGrantParameters {
     /// The refresh token to use in the refresh token request.
     refresh_token: RefreshToken,
     /// Scopes for downscoping (must be previously granted scopes).
-    #[builder(required, default, name = "scopes", with = |scopes: impl IntoIterator<Item = impl Into<String>>| mk_scopes(scopes))]
-    scope: Option<String>,
+    scope: Option<Vec<String>>,
     /// The target resource(s) for the access token.
     resource: Option<Vec<String>>,
     /// RFC 9396 `authorization_details` requested for the issued access token.

--- a/huskarl/src/grant/token_exchange.rs
+++ b/huskarl/src/grant/token_exchange.rs
@@ -24,7 +24,7 @@ use crate::{
         secrets::SecretString,
     },
     grant::{
-        core::{OAuth2ExchangeGrant, mk_scopes},
+        core::{OAuth2ExchangeGrant, join_space},
         refresh::RefreshGrant,
     },
 };
@@ -153,7 +153,7 @@ impl OAuth2ExchangeGrant for TokenExchangeGrant {
             resource: params.resource,
             authorization_details: params.authorization_details,
             audience: params.audience,
-            scope: params.scope,
+            scope: join_space(params.scope.as_deref()),
             requested_token_type: params.requested_token_type,
             subject_token: params.subject.token,
             subject_token_type: params.subject.token_type,
@@ -176,8 +176,7 @@ pub struct TokenExchangeGrantParameters {
     /// The logical name of the target service or resource where the requested token will be used.
     audience: Option<String>,
     /// The requested scope(s) for the issued security token.
-    #[builder(required, default, name = "scopes", with = |scopes: impl IntoIterator<Item = impl Into<String>>| mk_scopes(scopes))]
-    scope: Option<String>,
+    scope: Option<Vec<String>>,
     /// The type of the requested security token (e.g. `urn:ietf:params:oauth:token-type:access_token`).
     requested_token_type: Option<String>,
     /// An optional security token representing the party acting on behalf of the subject.
@@ -294,7 +293,7 @@ mod tests {
                     .build(),
             )
             .audience("https://api.example")
-            .scopes(["read", "write"])
+            .scope(bon::vec!["read", "write"])
             .requested_token_type("urn:ietf:params:oauth:token-type:access_token")
             .authorization_details(vec![
                 crate::core::AuthorizationDetail::builder("payment_initiation")
@@ -329,7 +328,7 @@ mod tests {
         // Only the subject is supplied; every other field is optional.
         let params = TokenExchangeGrantParameters::builder()
             .subject(subject())
-            .scopes(Vec::<String>::new())
+            .scope(vec![])
             .build();
 
         let encoded = crate::core::oauth_form::to_string(&grant().build_form(params)).unwrap();
@@ -361,7 +360,7 @@ mod tests {
                 "https://api.example.com".to_string(),
                 "https://other.example.com".to_string(),
             ])
-            .scopes(Vec::<String>::new())
+            .scope(vec![])
             .build();
 
         let encoded = crate::core::oauth_form::to_string(&grant().build_form(params)).unwrap();

--- a/huskarl/src/registration/metadata.rs
+++ b/huskarl/src/registration/metadata.rs
@@ -65,9 +65,15 @@ pub struct ClientMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logo_uri: Option<String>,
 
-    /// Space-separated list of scope values the client can request.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scope: Option<String>,
+    /// Scope values the client can request. Modeled as a list; serialized as the
+    /// single space-delimited `scope` string RFC 7591 §2 defines.
+    #[serde(
+        default,
+        skip_serializing_if = "scope_serde::is_empty",
+        serialize_with = "scope_serde::serialize",
+        deserialize_with = "scope_serde::deserialize"
+    )]
+    pub scope: Option<Vec<String>>,
 
     /// Ways to contact people responsible for the client, typically email
     /// addresses.
@@ -279,6 +285,37 @@ mod jwks_serde {
     }
 }
 
+/// (De)serializes the RFC 7591 §2 `scope` member as the single space-delimited
+/// string the wire uses, while modeling it as a list of scope values in Rust
+/// (matching how the grant builders carry scopes).
+// `&Option<_>` signatures are required by serde's `skip_serializing_if` /
+// `serialize_with`, which hand the field by shared reference.
+#[allow(clippy::ref_option)]
+mod scope_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn is_empty(scope: &Option<Vec<String>>) -> bool {
+        scope.as_ref().is_none_or(Vec::is_empty)
+    }
+
+    pub(super) fn serialize<S: Serializer>(
+        scope: &Option<Vec<String>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match scope {
+            Some(values) => serializer.serialize_str(&values.join(" ")),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Vec<String>>, D::Error> {
+        Ok(Option::<String>::deserialize(deserializer)?
+            .map(|s| s.split_whitespace().map(str::to_owned).collect()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -376,6 +413,33 @@ mod tests {
             "typed fields must not fall into extra: {:?}",
             parsed.extra
         );
+    }
+
+    #[test]
+    fn scope_is_a_space_delimited_string_on_the_wire_and_round_trips() {
+        let metadata = ClientMetadata::builder()
+            .scope(bon::vec!["openid", "profile", "email"])
+            .build();
+
+        // RFC 7591 §2: `scope` is one space-delimited string, not a JSON array.
+        let value = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(value["scope"], "openid profile email");
+
+        // A server echo splits back into the modeled list.
+        let parsed: ClientMetadata = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            parsed.scope,
+            Some(vec![
+                "openid".to_owned(),
+                "profile".to_owned(),
+                "email".to_owned()
+            ])
+        );
+
+        // An empty scope is omitted, like the other empty collections.
+        let empty = ClientMetadata::builder().scope(vec![]).build();
+        let value = serde_json::to_value(&empty).unwrap();
+        assert!(!value.as_object().unwrap().contains_key("scope"));
     }
 
     #[test]

--- a/integration/huskarl-conformance/Cargo.toml
+++ b/integration/huskarl-conformance/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", default-features = false, features = ["rt", "sync", "ma
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+bon = { workspace = true }
 huskarl-crypto-native = { workspace = true }
 huskarl-testkit = { path = "../huskarl-testkit" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/integration/huskarl-conformance/src/lib.rs
+++ b/integration/huskarl-conformance/src/lib.rs
@@ -148,7 +148,7 @@ pub async fn run_auth_code_flow<
     client_id: &str,
     client_auth: Auth,
     dpop: D,
-    scopes: impl IntoIterator<Item = impl Into<String>>,
+    scopes: Vec<String>,
     jar: J,
 ) -> Result<(TokenResponse, HttpAuthorizer), String> {
     let listener = bind_loopback(0)
@@ -188,7 +188,7 @@ pub async fn run_auth_code_flow_with_listener<
     client_id: &str,
     client_auth: Auth,
     dpop: D,
-    scopes: impl IntoIterator<Item = impl Into<String>>,
+    scopes: Vec<String>,
     listener: &TcpListener,
     redirect_uri: &str,
     jar: J,
@@ -245,7 +245,7 @@ pub async fn run_auth_code_flow_with_listener<
         pending_state,
         ..
     } = grant
-        .start(StartInput::scopes(scopes))
+        .start(StartInput::scope(scopes))
         .await
         .map_err(|e| format!("failed to start authorization: {e}"))?;
 

--- a/integration/huskarl-conformance/tests/fapi2.rs
+++ b/integration/huskarl-conformance/tests/fapi2.rs
@@ -133,7 +133,7 @@ async fn run_fapi2_plan<J: Jar + Clone + 'static>(
             &client_id(),
             client_auth,
             dpop,
-            ["openid", "profile", "email"],
+            bon::vec!["openid", "profile", "email"],
             &listener,
             &redirect_uri,
             jar,

--- a/integration/huskarl-conformance/tests/oidc.rs
+++ b/integration/huskarl-conformance/tests/oidc.rs
@@ -119,7 +119,7 @@ async fn run_plan(plan_name: &str) -> Vec<String> {
             &client_id(),
             client_auth(),
             NoDPoP,
-            ["openid", "profile", "email"],
+            bon::vec!["openid", "profile", "email"],
             &listener,
             &redirect_uri,
             NoJar,

--- a/integration/huskarl-integration/Cargo.toml
+++ b/integration/huskarl-integration/Cargo.toml
@@ -19,6 +19,7 @@ huskarl-crypto-native = { workspace = true }
 huskarl-reqwest = { workspace = true, features = ["rustls-tls"] }
 huskarl-resource-server = { path = "../../huskarl-resource-server", default-features = true }
 huskarl-testkit = { path = "../huskarl-testkit" }
+bon = { workspace = true }
 http = "1"
 # Custom `harness = false` test harness for the per-provider `tests/*.rs`.
 libtest-mimic = "0.8"

--- a/integration/huskarl-integration/src/suite.rs
+++ b/integration/huskarl-integration/src/suite.rs
@@ -377,7 +377,7 @@ pub async fn auth_code_flow(provider: &dyn TestProvider, features: Features) {
         pending_state,
         ..
     } = grant
-        .start(StartInput::scopes(["openid"]))
+        .start(StartInput::scope(bon::vec!["openid"]))
         .await
         .expect("start auth-code flow");
 


### PR DESCRIPTION
Code shows use of bon::vec! which can call `into()` on each element, recovering most of the previous usability, while maintaining consistency.