### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-resource-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "bon",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.8.0...huskarl-core-v0.8.1) - 2026-07-10
+
+### Added
+
+- *(redis)* Add redis cache/set existence check in redis. ([#217](https://github.com/huskarl-rs/huskarl/pull/217))
+
 ## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.7.1...huskarl-core-v0.8.0) - 2026-07-08
 
 ### Added

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-redis/CHANGELOG.md
+++ b/huskarl-redis/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/huskarl-rs/huskarl/releases/tag/huskarl-redis-v0.1.0) - 2026-07-10
+
+### Added
+
+- *(redis)* Add redis cache/set existence check in redis. ([#217](https://github.com/huskarl-rs/huskarl/pull/217))

--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.9.0...huskarl-resource-server-v0.9.1) - 2026-07-10
+
+### Fixed
+
+- *(resource-server)* A JTI check error is not an invalid token. ([#215](https://github.com/huskarl-rs/huskarl/pull/215))
+
 ## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.8.0...huskarl-resource-server-v0.9.0) - 2026-07-08
 
 ### Added

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.92"
 description = "OAuth2 resource server (JWT validation) support for the huskarl ecosystem."


### PR DESCRIPTION



## 🤖 New release

* `huskarl-core`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `huskarl-resource-server`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `huskarl-redis`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl-core`

<blockquote>

## [0.8.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.8.0...huskarl-core-v0.8.1) - 2026-07-10

### Added

- *(redis)* Add redis cache/set existence check in redis. ([#217](https://github.com/huskarl-rs/huskarl/pull/217))
</blockquote>

## `huskarl-resource-server`

<blockquote>

## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.9.0...huskarl-resource-server-v0.9.1) - 2026-07-10

### Fixed

- *(resource-server)* A JTI check error is not an invalid token. ([#215](https://github.com/huskarl-rs/huskarl/pull/215))
</blockquote>

## `huskarl-redis`

<blockquote>

## [0.1.0](https://github.com/huskarl-rs/huskarl/releases/tag/huskarl-redis-v0.1.0) - 2026-07-10

### Added

- *(redis)* Add redis cache/set existence check in redis. ([#217](https://github.com/huskarl-rs/huskarl/pull/217))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).