### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-redis"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bon",
  "hex",

--- a/huskarl-redis/CHANGELOG.md
+++ b/huskarl-redis/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.1.0...huskarl-redis-v0.1.1) - 2026-07-16
+
+### Other
+
+- *(huskarl-resource-server)* release v0.9.1 ([#216](https://github.com/huskarl-rs/huskarl/pull/216))
+
 ## [0.1.0](https://github.com/huskarl-rs/huskarl/releases/tag/huskarl-redis-v0.1.0) - 2026-07-10
 
 ### Added

--- a/huskarl-redis/Cargo.toml
+++ b/huskarl-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-redis"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Redis-backed replay prevention for the huskarl (OAuth2) ecosystem."

--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.1...huskarl-v0.9.2) - 2026-07-16
+
+### Fixed
+
+- *(client)* Set authentication headers (Authorization/DPoP) as sensitive. ([#221](https://github.com/huskarl-rs/huskarl/pull/221))
+- *(client)* Make sure the same DPoP key thumbprint is used in PAR body. ([#220](https://github.com/huskarl-rs/huskarl/pull/220))
+
 ## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.0...huskarl-v0.9.1) - 2026-07-08
 
 ### Other

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 rust-version = "1.92"
 description = '''


### PR DESCRIPTION



## 🤖 New release

* `huskarl`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `huskarl-redis`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl`

<blockquote>

## [0.9.2](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.1...huskarl-v0.9.2) - 2026-07-16

### Fixed

- *(client)* Set authentication headers (Authorization/DPoP) as sensitive. ([#221](https://github.com/huskarl-rs/huskarl/pull/221))
- *(client)* Make sure the same DPoP key thumbprint is used in PAR body. ([#220](https://github.com/huskarl-rs/huskarl/pull/220))
</blockquote>

## `huskarl-redis`

<blockquote>

## [0.1.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.1.0...huskarl-redis-v0.1.1) - 2026-07-16

### Other

- *(huskarl-resource-server)* release v0.9.1 ([#216](https://github.com/huskarl-rs/huskarl/pull/216))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).