### PR TITLE
fix(client): Make sure the same DPoP key thumbprint is used in PAR body.

### DIFF
--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -231,7 +231,7 @@ impl AuthorizationCodeGrant {
             None => par::ParBody::Expanded(Box::new(payload.clone())),
         };
 
-        let dpop_jkt = self.dpop.get_current_thumbprint().await;
+        let dpop_jkt = payload.rest.dpop_jkt.as_deref();
 
         let par_response = with_dpop_nonce_retry!({
             let mut auth_params = self
@@ -262,7 +262,7 @@ impl AuthorizationCodeGrant {
                 auth_params,
                 &par_body,
                 self.dpop.as_ref(),
-                dpop_jkt.as_deref(),
+                dpop_jkt,
             )
             .await
             .map_err(|e| e.with_context("making PAR request"))


### PR DESCRIPTION
There was a chance in a key rotation scenario that the thumbprint in the PAR body could be different from the one used elsewhere. This would cause the login to fail.

Low chance of occurrence, and needs user to have set up key rotation for DPoP - but awkward to debug if it happened.