### PR TITLE
feat(crypto): Implement selector for AES-GCM key, split off sealing traits

### DIFF
--- a/huskarl-core/docs/explanation/crypto_strategies.md
+++ b/huskarl-core/docs/explanation/crypto_strategies.md
@@ -59,8 +59,8 @@ handed a token to match; the caller chooses the current key. That choice goes
 through a *selector*:
 [`select_signer`](crate::crypto::signer::JwsSignerSelector::select_signer) hands
 out the signer to use right now, and
-[`select_cipher`](crate::crypto::cipher::AeadCipherSelector::select_cipher) the
-encryptor. [`KeyMatchStrength`](crate::crypto::KeyMatchStrength) plays no part
+[`select_encryptor`](crate::crypto::cipher::AeadEncryptorSelector::select_encryptor)
+the encryptor. [`KeyMatchStrength`](crate::crypto::KeyMatchStrength) plays no part
 here. The multi-key signer ([`MultiKeySigner`](crate::crypto::signer::MultiKeySigner))
 returns its default key, or — via
 [`select_signer_by_thumbprint`](crate::crypto::signer::AsymmetricJwsSignerSelector::select_signer_by_thumbprint)
@@ -97,8 +97,14 @@ back a frozen snapshot, and the caller runs the whole read-header-then-sign
 sequence against that one snapshot. Rotation happens *between* selections, never
 within one — which is why a selected signer should be used immediately and
 dropped, not cached across a rotation. Encryption and
-[`AeadCipherSelector`](crate::crypto::cipher::AeadCipherSelector) work the same
-way.
+[`AeadEncryptorSelector`](crate::crypto::cipher::AeadEncryptorSelector) work the
+same way.
+
+The relation is deliberately one-way: you hold a *selector* and get an
+encryptor, never the reverse. Even a fixed key is a selector — it hands out its
+shared inner [`AeadEncryptor`](crate::crypto::cipher::AeadEncryptor) — so
+there is no wrapper for lifting a bare encryptor into selection, which would
+silently freeze anything rotating beneath it.
 
 ## The wrapper families
 
@@ -141,8 +147,8 @@ relevant trait — the operation trait inbound, the selector trait outbound:
   failure backoff rate-limit the reloads. The outbound selectors work the same
   way: selection
   ([`select_signer`](crate::crypto::signer::JwsSignerSelector::select_signer) /
-  [`select_cipher`](crate::crypto::cipher::AeadCipherSelector::select_cipher)) is
-  async, so it reloads a stale key *during selection* — the outbound read path —
+  [`select_encryptor`](crate::crypto::cipher::AeadEncryptorSelector::select_encryptor))
+  is async, so it reloads a stale key *during selection* — the outbound read path —
   and hands back a fresh frozen snapshot. There the TTL bounds how quickly a
   rotated-in key is discovered rather than how quickly a removed one is dropped,
   but the mechanism is identical and the caller never has to poll.
@@ -201,40 +207,78 @@ reload on an explicit rotation event.
 Encryption has one more layer for values that must travel on their own —
 encrypted cookies, stateless tokens — where the nonce and tag have to ride along
 with the ciphertext. [`AeadSealer`](crate::crypto::cipher::AeadSealer) and
-[`AeadUnsealer`](crate::crypto::cipher::AeadUnsealer) frame an AEAD operation as
-a versioned, self-describing bundle
-(`[0x01 || nonce_len || tag_len || nonce || ciphertext || tag]`), implemented by
-[`AeadV1Cipher`](crate::crypto::cipher::AeadV1Cipher) over any inner cipher. The
-impls are capability-conditional: wrapping a cipher that does both directions
-yields a [`SealedAeadCipher`](crate::crypto::cipher::SealedAeadCipher); an
-encrypt-only key yields just a sealer; a decrypt-only key — a retired rotation
-key that can still open old bundles — yields just an unsealer.
+[`AeadUnsealer`](crate::crypto::cipher::AeadUnsealer) describe that operation:
+sealing packs one opaque byte string, unsealing re-opens it.
+[`AeadV1Cipher`](crate::crypto::cipher::AeadV1Cipher) is the local
+implementation, framing an AEAD operation as a versioned, self-describing bundle
+(`[0x01 || nonce_len || tag_len || nonce || ciphertext || tag]`) over any inner
+key stack. Its impls are capability-conditional: an
+[`AeadEncryptorSelector`](crate::crypto::cipher::AeadEncryptorSelector) inside
+yields a sealer; an [`AeadDecryptor`](crate::crypto::cipher::AeadDecryptor) — a
+retired rotation key that can still open old bundles, say — yields an unsealer;
+and an inner with both, an [`AeadCipher`](crate::crypto::cipher::AeadCipher),
+yields an [`AeadSealerUnsealer`](crate::crypto::cipher::AeadSealerUnsealer), the
+combined trait that erases to one `Arc<dyn AeadSealerUnsealer>` carrying both
+directions.
 
-Sealing is an **outbound** operation, so — like signing — it reaches its key
-through a *selector*.
-[`select_sealer`](crate::crypto::cipher::AeadSealerSelector::select_sealer) hands
-back a *frozen* [`AeadSealer`](crate::crypto::cipher::AeadSealer), and
-[`unseal`](crate::crypto::cipher::AeadUnsealer::unseal) takes the same match
-criteria as decryption, so a caller can record *which* key sealed a bundle — a
-cookie attribute, a database column — for a later unseal to select on. The frozen
-snapshot is what makes that recorded `kid` trustworthy: it collapses the separate
-"read the [`key_id`](crate::crypto::cipher::AeadEncryptor::key_id)" and
-"[`seal`](crate::crypto::cipher::AeadSealer::seal)" steps onto one key, so a
-rotation between them cannot leave the bundle carrying one key's `kid` over
-another's ciphertext — the same corruption a
-[`JwsSignerSelector`](crate::crypto::signer::JwsSignerSelector) prevents for
-read-header-then-sign. Note the hazard lives in the *caller's* out-of-band `kid`,
-not in the bundle, which carries none.
+Sealing is an **outbound** operation, but unlike signing it needs no separate
+selector trait: each [`seal`](crate::crypto::cipher::AeadSealer::seal) selects
+one frozen encryptor snapshot internally and runs the whole encrypt-then-frame
+sequence against it, so a rotation cannot land between choosing the key and
+using it — the read-header-then-sign hazard, closed off inside the one call.
+The price is opacity: a sealer exposes no `key_id`, so *which* key sealed a
+bundle cannot be observed or recorded alongside it — fitting, since the bundle
+carries no `kid` either. The inbound path leans on the AEAD tag instead: a
+multi-key unsealer tries its candidate keys, and a wrong key is a clean
+authentication failure, never a wrong plaintext.
+[`unseal`](crate::crypto::cipher::AeadUnsealer::unseal) still takes the same
+match criteria as decryption, for a caller that knows the key some other way.
 
-For a key that never rotates, wrap it in
-[`StaticAeadCipher`](crate::crypto::cipher::StaticAeadCipher) — the fixed-key base
-case, the cipher analogue of a signing key that is its own selector. For one that
-does, a [`RefreshableCipher`](crate::crypto::cipher::RefreshableCipher) or
-[`ScheduledRefreshCipher`](crate::crypto::cipher::ScheduledRefreshCipher) reloads a
-stale key during `select_sealer` exactly as it does for
-[`select_cipher`](crate::crypto::cipher::AeadCipherSelector::select_cipher),
-bounding how quickly a rotated-in key is discovered; both erase to
-`Arc<dyn SealedAeadCipherSelector>` when the key source is chosen at runtime. A
-resource server uses this to issue and check stateless `DPoP` nonces: select a
-sealer, seal the issue time into a bundle, hand it out, and unseal it later to
-verify its age without server-side storage.
+Because a raw key is already a selector, `AeadV1Cipher::new(key)` is the whole
+fixed-key story. For a rotating key, put a
+[`ScheduledRefreshCipher`](crate::crypto::cipher::ScheduledRefreshCipher) (or
+[`RefreshableCipher`](crate::crypto::cipher::RefreshableCipher)) inside instead,
+and the stale key is reloaded during each seal's internal selection, bounding
+how quickly a rotated-in key is discovered. A resource server uses this to issue
+and check stateless `DPoP` nonces: seal the issue time into a bundle, hand it
+out, and unseal it later to verify its age without server-side storage.
+
+The sealer traits are also a *boundary*, not just a framing: they are where
+encryption can be delegated wholesale to an external service. A KMS- or
+Vault-style encrypt endpoint returns one opaque, self-describing token — there
+is no nonce/ciphertext/tag decomposition to expose, so such a service cannot
+implement [`AeadEncryptor`](crate::crypto::cipher::AeadEncryptor) at all — but
+it implements [`AeadSealer`](crate::crypto::cipher::AeadSealer) /
+[`AeadUnsealer`](crate::crypto::cipher::AeadUnsealer) naturally, handling
+rotation on its own side. Consumers bound on the sealer traits accept either
+world unchanged.
+
+## The three operations, compared
+
+Everything above follows from two rules and one question. The rules: an
+**outbound** operation is compound, so it must run against one frozen key
+snapshot — reached through a selector, refreshed at selection; an **inbound**
+operation is handed its selection criteria by what arrived — matched by
+strength, where the worst a stale keyset can produce is a recoverable miss. The
+question: does the key material arrive as data (then a platform must
+materialise it) or is it handed in fully formed? Signing is the outbound rule
+alone, verification the inbound rule alone, and encryption is the one operation
+family where both rules apply to a single key — which is why it alone has a
+combined trait (`AeadCipher`) and the sealing layer on top.
+
+|                        | Signing                                     | Verification                                 | Encryption / decryption                                        |
+|------------------------|---------------------------------------------|----------------------------------------------|----------------------------------------------------------------|
+| Direction              | outbound                                    | inbound                                      | both, on one key family                                        |
+| Base trait             | `JwsSigner`                                 | `JwsVerifier`                                | `AeadEncryptor` / `AeadDecryptor`; `AeadCipher` for both       |
+| Key chosen by          | caller, via `JwsSignerSelector`             | the token, via `key_match`                   | caller via `AeadEncryptorSelector`; bundle via `cipher_match`  |
+| Hot-swap wrapper is    | the *selector*, never a `JwsSigner`         | the operation itself                         | the selector outbound; the operation inbound                   |
+| Miss reaction          | none — no outbound miss exists              | `RetryingVerifier`: refresh, retry once      | `RetryingDecryptor`: same, inbound only                        |
+| Ambiguous key match    | n/a — default key, or by thumbprint         | fails closed: wrong-key acceptance is a risk | try-all is safe: the AEAD tag self-authenticates               |
+| Materialisation seam   | none — keys are handed in                   | `JwsVerifierPlatform`, keys arrive as a JWKS | none — keys are handed in                                      |
+| Extra layer            | by-thumbprint selection (`DPoP`'s `dpop_jkt`) | —                                          | sealing: self-contained bundles, external sealers              |
+
+The columns differ only where the direction or the key's origin genuinely
+differs; where neither does, the machinery is deliberately identical — the
+refresh wrappers share one mechanism, the two match methods share
+[`KeyMatchStrength`](crate::crypto::KeyMatchStrength), and the two miss-driven
+retry wrappers share their split of work with the TTL layer.

--- a/huskarl-core/docs/guide/implementing_a_backend.md
+++ b/huskarl-core/docs/guide/implementing_a_backend.md
@@ -80,8 +80,10 @@ transient failure (KMS, HSM) as
   signatures.
 - [`JwsVerifier`](crate::crypto::verifier::JwsVerifier) — verify them, reporting
   match quality through [`key_match`](crate::crypto::verifier::JwsVerifier::key_match).
-- [`AeadEncryptor`](crate::crypto::cipher::AeadEncryptor) /
-  [`AeadDecryptor`](crate::crypto::cipher::AeadDecryptor) — content encryption.
+- [`AeadEncryptorSelector`](crate::crypto::cipher::AeadEncryptorSelector) /
+  [`AeadEncryptor`](crate::crypto::cipher::AeadEncryptor) /
+  [`AeadDecryptor`](crate::crypto::cipher::AeadDecryptor) — content encryption;
+  the key type is the selector, handing out its shared inner encryptor.
 
 You usually implement only the single-key trait; the [composable
 wrappers](crate::_docs::explanation::crypto_strategies) (multi-key, refreshable,

--- a/huskarl-core/src/crypto/cipher/mod.rs
+++ b/huskarl-core/src/crypto/cipher/mod.rs
@@ -106,6 +106,24 @@ pub trait AeadEncryptor: std::fmt::Debug + MaybeSendSync {
     ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>>;
 }
 
+impl<T: AeadEncryptor + ?Sized> AeadEncryptor for Arc<T> {
+    fn enc_algorithm(&self) -> Cow<'_, str> {
+        self.as_ref().enc_algorithm()
+    }
+
+    fn key_id(&self) -> Option<Cow<'_, str>> {
+        self.as_ref().key_id()
+    }
+
+    fn encrypt<'a>(
+        &'a self,
+        plaintext: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
+        self.as_ref().encrypt(plaintext, aad)
+    }
+}
+
 /// Trait for AEAD decryption.
 ///
 /// Exposes key selection via [`cipher_match`](Self::cipher_match) so that
@@ -170,14 +188,36 @@ pub trait AeadDecryptor: std::fmt::Debug + MaybeSendSync {
     }
 }
 
-/// Combined trait for types that can both encrypt and decrypt.
+impl<T: AeadDecryptor + ?Sized> AeadDecryptor for Arc<T> {
+    fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+        self.as_ref().cipher_match(m)
+    }
+
+    fn decrypt<'a>(
+        &'a self,
+        cipher_match: Option<&'a CipherMatch<'a>>,
+        nonce: &'a [u8],
+        ciphertext: &'a [u8],
+        tag: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+        self.as_ref()
+            .decrypt(cipher_match, nonce, ciphertext, tag, aad)
+    }
+
+    fn try_refresh(&self) -> MaybeSendBoxFuture<'_, bool> {
+        self.as_ref().try_refresh()
+    }
+}
+
+/// Combined trait for types that can both select an encryptor and decrypt.
 ///
 /// Automatically implemented for any type with both capabilities. Store as
 /// `Arc<dyn AeadCipher>` when both directions must come from the same source
 /// (e.g. a symmetric AEAD key).
-pub trait AeadCipher: AeadEncryptor + AeadDecryptor {}
+pub trait AeadCipher: AeadEncryptorSelector + AeadDecryptor {}
 
-impl<T: AeadEncryptor + AeadDecryptor + ?Sized> AeadCipher for T {}
+impl<T: AeadEncryptorSelector + AeadDecryptor + ?Sized> AeadCipher for T {}
 
 /// A selector for an AEAD encryptor.
 ///
@@ -189,23 +229,34 @@ impl<T: AeadEncryptor + AeadDecryptor + ?Sized> AeadCipher for T {}
 /// operations select rather than hot-swap.
 ///
 /// This trait is dyn-capable: consumers store it as
-/// `Arc<dyn AeadCipherSelector>`.
-pub trait AeadCipherSelector: std::fmt::Debug + MaybeSendSync {
+/// `Arc<dyn AeadEncryptorSelector>`.
+pub trait AeadEncryptorSelector: std::fmt::Debug + MaybeSendSync {
     /// Selects the current encryptor to use for encryption, refreshing stale key
     /// material first where the implementation supports it.
-    fn select_cipher(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>>;
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>>;
 }
 
-/// An encryptor that produces self-contained, versioned bundles.
+impl<T: AeadEncryptorSelector + ?Sized> AeadEncryptorSelector for Arc<T> {
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+        self.as_ref().select_encryptor()
+    }
+}
+
+/// An encryptor that produces self-contained bundles.
 ///
 /// Where [`AeadEncryptor::encrypt`] returns the nonce, ciphertext, and tag as
-/// separate fields, a sealer packs them into one opaque byte string so the value
+/// separate fields, a sealer hands back one opaque byte string so the value
 /// can travel on its own — an encrypted cookie, a stateless token — and be
 /// re-opened later ([`AeadUnsealer`]) with just the bundle and the key.
-/// [`AeadV1Cipher`] is the standard implementation; see it for a worked example.
-pub trait AeadSealer: AeadEncryptor {
-    /// Encrypts `plaintext` and returns a versioned bundle:
-    /// `[0x01 || nonce_len:u8 || tag_len:u8 || nonce || ciphertext || tag]`.
+/// [`AeadV1Cipher`] is the local implementation; see it for a worked example.
+///
+/// This trait is dyn-capable: consumers store it as `Arc<dyn AeadSealer>`, or
+/// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
+pub trait AeadSealer: std::fmt::Debug + MaybeSendSync {
+    /// Encrypts `plaintext` and returns an opaque, self-describing bundle that
+    /// a matching [`AeadUnsealer`] can re-open. The layout belongs to the
+    /// implementation — an externally-managed sealer returns its service's
+    /// token verbatim.
     fn seal<'a>(
         &'a self,
         plaintext: &'a [u8],
@@ -214,12 +265,16 @@ pub trait AeadSealer: AeadEncryptor {
 }
 
 /// A decryptor that consumes self-contained bundles produced by [`AeadSealer`].
-pub trait AeadUnsealer: AeadDecryptor {
-    /// Decrypts a versioned bundle produced by [`AeadSealer::seal`].
+///
+/// This trait is dyn-capable: consumers store it as `Arc<dyn AeadUnsealer>`, or
+/// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
+pub trait AeadUnsealer: std::fmt::Debug + MaybeSendSync {
+    /// Decrypts a bundle produced by [`AeadSealer::seal`].
     ///
-    /// `cipher_match` carries optional key selection criteria from an out-of-band
-    /// source (e.g. a cookie attribute or database column). Multi-key decryptors
-    /// use this to select the correct key without trying all candidates.
+    /// `cipher_match` carries optional key selection criteria known out-of-band.
+    /// Multi-key decryptors use this to select the correct key without trying
+    /// all candidates; without it, try-all is still safe — the AEAD tag makes a
+    /// wrong key a clean failure.
     ///
     /// # Errors
     ///
@@ -234,207 +289,83 @@ pub trait AeadUnsealer: AeadDecryptor {
     ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>>;
 }
 
-/// Combined trait for types that can both seal and unseal bundles.
-///
-/// Automatically implemented for any type with both capabilities — the
-/// bundle-level analogue of [`AeadCipher`]. Store as
-/// `Arc<dyn SealedAeadCipher>` when both directions must come from the same
-/// source (e.g. [`AeadV1Cipher`] over a symmetric or KMS-backed key).
-pub trait SealedAeadCipher: AeadSealer + AeadUnsealer {}
-
-impl<T: AeadSealer + AeadUnsealer + ?Sized> SealedAeadCipher for T {}
-
-/// A selector for an [`AeadSealer`] — the bundle-level analogue of
-/// [`AeadCipherSelector`].
-///
-/// [`select_sealer`](Self::select_sealer) hands back an [`AeadSealer`] that is a
-/// **frozen snapshot** of the current key, so reading its
-/// [`key_id`](AeadEncryptor::key_id)/[`enc_algorithm`](AeadEncryptor::enc_algorithm)
-/// and then [`seal`](AeadSealer::seal)ing against it describe and use the *same*
-/// key even if a rotation lands between the two calls. That is what lets a caller
-/// emit a `kid` alongside a bundle for a later [`unseal`](AeadUnsealer::unseal) to
-/// select on. Selection is **async** so a refreshing implementation (e.g.
-/// [`ScheduledRefreshCipher`]) reloads a stale key first; hold the returned sealer
-/// briefly (for one seal) and drop it. See [the sealing section of composing
-/// crypto strategies](crate::_docs::explanation::crypto_strategies) for the
-/// rotation hazard this prevents.
-///
-/// This trait is dyn-capable: consumers store it as
-/// `Arc<dyn AeadSealerSelector>`.
-pub trait AeadSealerSelector: std::fmt::Debug + MaybeSendSync {
-    /// Selects the current sealer — a frozen key snapshot — refreshing stale key
-    /// material first where the implementation supports it.
-    fn select_sealer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadSealer>>;
-}
-
-/// Combined trait for a sealed-bundle cipher driven through the selector API: it
-/// selects a frozen [`AeadSealer`] on the outbound side and
-/// [`unseal`](AeadUnsealer::unseal)s on the inbound one.
-///
-/// The selector-side analogue of [`SealedAeadCipher`] — where that is one object
-/// that both seals and unseals a fixed key, this selects a *fresh* sealer each
-/// time (so rotation stays safe) while still unsealing directly. Implemented by
-/// the composed refresh stack ([`ScheduledRefreshCipher`], [`RefreshableCipher`])
-/// and by the fixed [`StaticAeadCipher`] base case.
+/// Combined trait for types that can both seal and unseal.
 ///
 /// Automatically implemented for any type with both capabilities. Store as
-/// `Arc<dyn SealedAeadCipherSelector>` to erase the concrete key source while
-/// keeping a single value that covers both directions.
-pub trait SealedAeadCipherSelector: AeadSealerSelector + AeadUnsealer {}
+/// `Arc<dyn AeadSealerUnsealer>` when both directions must come from the same
+/// source — an [`AeadV1Cipher`] over one key, or an externally-managed sealer
+/// (e.g. a KMS/Vault encrypt endpoint) whose tokens only it can re-open.
+pub trait AeadSealerUnsealer: AeadSealer + AeadUnsealer {}
 
-impl<T: AeadSealerSelector + AeadUnsealer + ?Sized> SealedAeadCipherSelector for T {}
+impl<T: AeadSealer + AeadUnsealer + ?Sized> AeadSealerUnsealer for T {}
 
-macro_rules! forward_aead_encryptor {
-    ($wrapper:ty) => {
-        impl<T: AeadEncryptor + ?Sized> AeadEncryptor for $wrapper {
-            fn enc_algorithm(&self) -> Cow<'_, str> {
-                (**self).enc_algorithm()
-            }
-
-            fn key_id(&self) -> Option<Cow<'_, str>> {
-                (**self).key_id()
-            }
-
-            fn encrypt<'a>(
-                &'a self,
-                plaintext: &'a [u8],
-                aad: &'a [u8],
-            ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-                (**self).encrypt(plaintext, aad)
-            }
-        }
-    };
+impl<T: AeadSealer + ?Sized> AeadSealer for Arc<T> {
+    fn seal<'a>(
+        &'a self,
+        plaintext: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
+        self.as_ref().seal(plaintext, aad)
+    }
 }
 
-forward_aead_encryptor!(&T);
-forward_aead_encryptor!(Box<T>);
-forward_aead_encryptor!(Arc<T>);
-
-macro_rules! forward_aead_decryptor {
-    ($wrapper:ty) => {
-        impl<T: AeadDecryptor + ?Sized> AeadDecryptor for $wrapper {
-            fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-                (**self).cipher_match(m)
-            }
-
-            fn decrypt<'a>(
-                &'a self,
-                cipher_match: Option<&'a CipherMatch<'a>>,
-                nonce: &'a [u8],
-                ciphertext: &'a [u8],
-                tag: &'a [u8],
-                aad: &'a [u8],
-            ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-                (**self).decrypt(cipher_match, nonce, ciphertext, tag, aad)
-            }
-
-            fn try_refresh(&self) -> MaybeSendBoxFuture<'_, bool> {
-                (**self).try_refresh()
-            }
-        }
-    };
+impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
+    fn unseal<'a>(
+        &'a self,
+        cipher_match: Option<&'a CipherMatch<'a>>,
+        bundle: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+        self.as_ref().unseal(cipher_match, bundle, aad)
+    }
 }
-
-forward_aead_decryptor!(&T);
-forward_aead_decryptor!(Box<T>);
-forward_aead_decryptor!(Arc<T>);
-
-macro_rules! forward_aead_cipher_selector {
-    ($wrapper:ty) => {
-        impl<T: AeadCipherSelector + ?Sized> AeadCipherSelector for $wrapper {
-            fn select_cipher(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-                (**self).select_cipher()
-            }
-        }
-    };
-}
-
-forward_aead_cipher_selector!(&T);
-forward_aead_cipher_selector!(Box<T>);
-forward_aead_cipher_selector!(Arc<T>);
-
-macro_rules! forward_aead_sealer {
-    ($wrapper:ty) => {
-        impl<T: AeadSealer + ?Sized> AeadSealer for $wrapper {
-            fn seal<'a>(
-                &'a self,
-                plaintext: &'a [u8],
-                aad: &'a [u8],
-            ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
-                (**self).seal(plaintext, aad)
-            }
-        }
-    };
-}
-
-forward_aead_sealer!(&T);
-forward_aead_sealer!(Box<T>);
-forward_aead_sealer!(Arc<T>);
-
-macro_rules! forward_aead_unsealer {
-    ($wrapper:ty) => {
-        impl<T: AeadUnsealer + ?Sized> AeadUnsealer for $wrapper {
-            fn unseal<'a>(
-                &'a self,
-                cipher_match: Option<&'a CipherMatch<'a>>,
-                bundle: &'a [u8],
-                aad: &'a [u8],
-            ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-                (**self).unseal(cipher_match, bundle, aad)
-            }
-        }
-    };
-}
-
-forward_aead_unsealer!(&T);
-forward_aead_unsealer!(Box<T>);
-forward_aead_unsealer!(Arc<T>);
-
-macro_rules! forward_aead_sealer_selector {
-    ($wrapper:ty) => {
-        impl<T: AeadSealerSelector + ?Sized> AeadSealerSelector for $wrapper {
-            fn select_sealer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadSealer>> {
-                (**self).select_sealer()
-            }
-        }
-    };
-}
-
-forward_aead_sealer_selector!(&T);
-forward_aead_sealer_selector!(Box<T>);
-forward_aead_sealer_selector!(Arc<T>);
 
 /// A bundle wrapper over an AEAD cipher using the v1 format:
 /// `[0x01 || nonce_len:u8 || tag_len:u8 || nonce || ciphertext || tag]`.
 ///
 /// The implementations are conditional on the inner type's capabilities:
-/// wrapping an [`AeadCipher`] (e.g. a symmetric key, or a KMS-backed cipher
-/// that handles both directions as one consistent object) yields a
-/// [`SealedAeadCipher`]; wrapping an encrypt-only [`AeadEncryptor`] yields
+/// wrapping an [`AeadCipher`] (a symmetric key, a rotating multi-key stack, or
+/// a KMS-backed cipher that handles both directions as one consistent object)
+/// yields an [`AeadSealerUnsealer`]; an [`AeadEncryptorSelector`] alone yields
 /// only an [`AeadSealer`], and a decrypt-only [`AeadDecryptor`] (e.g. a
-/// retired rotation key) only an [`AeadUnsealer`].
+/// retired rotation key) only an [`AeadUnsealer`]. Each `seal` selects a
+/// frozen encryptor snapshot internally, so a rotation landing mid-seal cannot
+/// split one bundle across two keys.
 ///
 /// # Example
 ///
 /// ```
 /// # use std::borrow::Cow;
 /// # use huskarl_core::crypto::KeyMatchStrength;
+/// # use std::sync::Arc;
 /// # use huskarl_core::crypto::cipher::{
-/// #     AeadDecryptor, AeadEncryptor, AeadOutput, AeadSealer, AeadUnsealer, AeadV1Cipher,
-/// #     CipherMatch, DecryptError,
+/// #     AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, AeadOutput, AeadSealer,
+/// #     AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError,
 /// # };
 /// # use huskarl_core::error::Error;
 /// # use huskarl_core::platform::MaybeSendBoxFuture;
-/// # // Stand-in for the AEAD cipher a crypto backend (native / WebCrypto) provides.
+/// # // Stand-in for the AEAD key a crypto backend (native / WebCrypto) provides:
+/// # // the key is a selector handing out its shared inner encryptor.
 /// # #[derive(Debug)]
-/// # struct BackendCipher;
-/// # impl AeadEncryptor for BackendCipher {
+/// # struct BackendEncryptor;
+/// # impl AeadEncryptor for BackendEncryptor {
 /// #     fn enc_algorithm(&self) -> Cow<'_, str> { "A256GCM".into() }
 /// #     fn key_id(&self) -> Option<Cow<'_, str>> { None }
 /// #     fn encrypt<'a>(&'a self, plaintext: &'a [u8], _aad: &'a [u8])
 /// #         -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
 /// #         let ciphertext = plaintext.to_vec();
 /// #         Box::pin(async move { Ok(AeadOutput { nonce: vec![7], ciphertext, tag: vec![9] }) })
+/// #     }
+/// # }
+/// # #[derive(Debug)]
+/// # struct BackendCipher { inner: Arc<BackendEncryptor> }
+/// # impl BackendCipher {
+/// #     fn new() -> Self { Self { inner: Arc::new(BackendEncryptor) } }
+/// # }
+/// # impl AeadEncryptorSelector for BackendCipher {
+/// #     fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+/// #         let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+/// #         Box::pin(async move { snapshot })
 /// #     }
 /// # }
 /// # impl AeadDecryptor for BackendCipher {
@@ -449,7 +380,7 @@ forward_aead_sealer_selector!(Arc<T>);
 /// #     }
 /// # }
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let cipher = AeadV1Cipher::new(BackendCipher);
+/// let cipher = AeadV1Cipher::new(BackendCipher::new());
 ///
 /// // `seal` packs the version byte, nonce, tag and ciphertext into one bundle...
 /// let bundle = cipher.seal(b"session-state", b"aad").await?;
@@ -469,32 +400,21 @@ impl<C> AeadV1Cipher<C> {
     }
 }
 
-impl<C: AeadEncryptor> AeadEncryptor for AeadV1Cipher<C> {
-    fn enc_algorithm(&self) -> Cow<'_, str> {
-        self.0.enc_algorithm()
-    }
-
-    fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.0.key_id()
-    }
-
-    fn encrypt<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-        self.0.encrypt(plaintext, aad)
-    }
-}
-
-impl<C: AeadEncryptor> AeadSealer for AeadV1Cipher<C> {
+impl<C: AeadEncryptorSelector> AeadSealer for AeadV1Cipher<C> {
     fn seal<'a>(
         &'a self,
         plaintext: &'a [u8],
         aad: &'a [u8],
     ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
         Box::pin(async move {
-            let output = self.encrypt(plaintext, aad).await?;
+            // One frozen snapshot per seal: under rotation, the key that seals
+            // is the key any metadata read off the same snapshot names.
+            let output = self
+                .0
+                .select_encryptor()
+                .await
+                .encrypt(plaintext, aad)
+                .await?;
 
             let nonce_len: u8 = output.nonce.len().try_into().map_err(|_| {
                 Error::new(crate::ErrorKind::Crypto, "nonce length exceeds u8::MAX")
@@ -523,27 +443,6 @@ fn invalid_bundle() -> Error {
     Error::new(ErrorKind::Crypto, UnsealError::InvalidBundle)
 }
 
-impl<C: AeadDecryptor> AeadDecryptor for AeadV1Cipher<C> {
-    fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-        self.0.cipher_match(m)
-    }
-
-    fn decrypt<'a>(
-        &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
-        nonce: &'a [u8],
-        ciphertext: &'a [u8],
-        tag: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        self.0.decrypt(cipher_match, nonce, ciphertext, tag, aad)
-    }
-
-    fn try_refresh(&self) -> MaybeSendBoxFuture<'_, bool> {
-        self.0.try_refresh()
-    }
-}
-
 impl<C: AeadDecryptor> AeadUnsealer for AeadV1Cipher<C> {
     fn unseal<'a>(
         &'a self,
@@ -567,88 +466,8 @@ impl<C: AeadDecryptor> AeadUnsealer for AeadV1Cipher<C> {
             let tag = &bundle[bundle.len() - tag_len..];
             let ciphertext = &bundle[3 + nonce_len..bundle.len() - tag_len];
 
-            self.decrypt(cipher_match, nonce, ciphertext, tag, aad)
-                .await
-        })
-    }
-}
-
-/// A fixed AEAD cipher presented through the selection API.
-///
-/// The non-rotating base case for the outbound selector traits: it holds one key
-/// and hands that same key back from
-/// [`select_cipher`](AeadCipherSelector::select_cipher) and
-/// [`select_sealer`](AeadSealerSelector::select_sealer). Reach for it where a
-/// consumer wants a selector (for example a resource server's sealed
-/// `DPoP`-nonce checker, which takes an [`AeadSealerSelector`]) but the key never
-/// rotates — the cipher analogue of a
-/// signing key that is its own
-/// [`JwsSignerSelector`](crate::crypto::signer::JwsSignerSelector). For a rotating
-/// key, use [`RefreshableCipher`]/[`ScheduledRefreshCipher`] instead; they
-/// implement the same traits.
-///
-/// It also implements [`AeadDecryptor`] and [`AeadUnsealer`] by delegating to the
-/// held key, so one value covers both directions of a sealed round-trip.
-#[derive(Debug)]
-pub struct StaticAeadCipher<C> {
-    cipher: Arc<C>,
-}
-
-impl<C> StaticAeadCipher<C> {
-    /// Wraps a fixed AEAD cipher so it can be used through the selector API.
-    pub fn new(cipher: C) -> Self {
-        Self {
-            cipher: Arc::new(cipher),
-        }
-    }
-}
-
-impl<C: AeadEncryptor + 'static> AeadCipherSelector for StaticAeadCipher<C> {
-    fn select_cipher(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-        let encryptor: Arc<dyn AeadEncryptor> = self.cipher.clone();
-        Box::pin(async move { encryptor })
-    }
-}
-
-impl<C: AeadEncryptor + 'static> AeadSealerSelector for StaticAeadCipher<C> {
-    fn select_sealer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadSealer>> {
-        let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(Arc::clone(&self.cipher)));
-        Box::pin(async move { sealer })
-    }
-}
-
-impl<C: AeadDecryptor + 'static> AeadDecryptor for StaticAeadCipher<C> {
-    fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-        self.cipher.cipher_match(m)
-    }
-
-    fn decrypt<'a>(
-        &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
-        nonce: &'a [u8],
-        ciphertext: &'a [u8],
-        tag: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        self.cipher
-            .decrypt(cipher_match, nonce, ciphertext, tag, aad)
-    }
-
-    fn try_refresh(&self) -> MaybeSendBoxFuture<'_, bool> {
-        self.cipher.try_refresh()
-    }
-}
-
-impl<C: AeadDecryptor + 'static> AeadUnsealer for StaticAeadCipher<C> {
-    fn unseal<'a>(
-        &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
-        bundle: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        Box::pin(async move {
-            AeadV1Cipher::new(Arc::clone(&self.cipher))
-                .unseal(cipher_match, bundle, aad)
+            self.0
+                .decrypt(cipher_match, nonce, ciphertext, tag, aad)
                 .await
         })
     }
@@ -685,6 +504,27 @@ mod tests {
         }
     }
 
+    /// Raw-key shape: a selector handing out its shared inner encryptor.
+    #[derive(Debug)]
+    struct MockKey {
+        inner: Arc<MockEncryptor>,
+    }
+
+    impl MockKey {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockEncryptor),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for MockKey {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
     #[derive(Debug)]
     struct MockDecryptor;
 
@@ -708,23 +548,22 @@ mod tests {
 
     /// One object with both capabilities (the symmetric-key / KMS shape).
     #[derive(Debug)]
-    struct MockCipher;
+    struct MockCipher {
+        inner: Arc<MockEncryptor>,
+    }
 
-    impl AeadEncryptor for MockCipher {
-        fn enc_algorithm(&self) -> Cow<'_, str> {
-            MockEncryptor.enc_algorithm()
+    impl MockCipher {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockEncryptor),
+            }
         }
+    }
 
-        fn key_id(&self) -> Option<Cow<'_, str>> {
-            MockEncryptor.key_id()
-        }
-
-        fn encrypt<'a>(
-            &'a self,
-            plaintext: &'a [u8],
-            aad: &'a [u8],
-        ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-            Box::pin(async move { MockEncryptor.encrypt(plaintext, aad).await })
+    impl AeadEncryptorSelector for MockCipher {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
         }
     }
 
@@ -768,7 +607,7 @@ mod tests {
         let plaintext = b"hello world";
         let aad = b"associated";
 
-        let sealer = AeadV1Cipher::new(MockEncryptor);
+        let sealer = AeadV1Cipher::new(MockKey::new());
         let bundle = sealer.seal(plaintext, aad).await.unwrap();
 
         let unsealer = AeadV1Cipher::new(MockDecryptor);
@@ -778,7 +617,7 @@ mod tests {
 
     #[tokio::test]
     async fn erased_cipher_roundtrip() {
-        let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(MockEncryptor));
+        let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(MockKey::new()));
         let bundle = sealer.seal(b"hello", b"").await.unwrap();
 
         let unsealer: Arc<dyn AeadUnsealer> = Arc::new(AeadV1Cipher::new(MockDecryptor));
@@ -786,27 +625,25 @@ mod tests {
         assert_eq!(recovered, b"hello");
     }
 
-    /// One object covering both directions (the symmetric-key / KMS shape):
-    /// `AeadV1Cipher<C: AeadCipher>` satisfies `SealedAeadCipher`, both
-    /// concretely and erased, including through generic bounds.
+    /// The erased combined type must satisfy generic `S: AeadSealerUnsealer`
+    /// bounds (e.g. `SealedTimestampNonce`) — construction, not just method calls.
     #[tokio::test]
-    async fn one_object_sealed_cipher_roundtrip() {
-        async fn roundtrip(cipher: impl AeadSealer + AeadUnsealer) {
-            let bundle = cipher.seal(b"hello", b"aad").await.unwrap();
-            let recovered = cipher.unseal(None, &bundle, b"aad").await.unwrap();
-            assert_eq!(recovered, b"hello");
+    async fn erased_sealer_unsealer_satisfies_combined_bound() {
+        fn assert_combined<S: AeadSealerUnsealer>(s: S) -> S {
+            s
         }
 
-        roundtrip(AeadV1Cipher::new(MockCipher)).await;
-
-        let erased: Arc<dyn SealedAeadCipher> = Arc::new(AeadV1Cipher::new(MockCipher));
-        roundtrip(erased).await;
+        let cipher: Arc<dyn AeadSealerUnsealer> = Arc::new(AeadV1Cipher::new(MockCipher::new()));
+        let cipher = assert_combined(cipher);
+        let bundle = cipher.seal(b"hello", b"aad").await.unwrap();
+        let recovered = cipher.unseal(None, &bundle, b"aad").await.unwrap();
+        assert_eq!(recovered, b"hello");
     }
 
     #[tokio::test]
     async fn bundle_format() {
         let plaintext = b"AB";
-        let sealer = AeadV1Cipher::new(MockEncryptor);
+        let sealer = AeadV1Cipher::new(MockKey::new());
         let bundle = sealer.seal(plaintext, b"").await.unwrap();
 
         // [0x01, nonce_len=3, tag_len=4, nonce=[1,2,3], ciphertext=[0xBE, 0xBD], tag=[4,5,6,7]]

--- a/huskarl-core/src/crypto/cipher/multi.rs
+++ b/huskarl-core/src/crypto/cipher/multi.rs
@@ -1,14 +1,13 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use futures_util::future::join_all;
 
 use crate::{
     crypto::{
         KeyMatchStrength,
-        cipher::{AeadDecryptor, AeadEncryptor, AeadOutput, CipherMatch, DecryptError},
+        cipher::{AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, CipherMatch, DecryptError},
     },
-    error::Error,
-    platform::MaybeSendBoxFuture,
+    platform::{MaybeSendBoxFuture, MaybeSendSync},
 };
 
 /// An [`AeadDecryptor`] that holds multiple keys and applies [`CipherMatch`] /
@@ -183,8 +182,8 @@ impl AeadDecryptor for MultiKeyDecryptor {
     }
 }
 
-/// An [`AeadEncryptor`] + [`AeadDecryptor`] that encrypts with a single key
-/// and decrypts with a [`MultiKeyDecryptor`].
+/// An [`AeadEncryptorSelector`] + [`AeadDecryptor`] that encrypts with a
+/// single primary key and decrypts with a [`MultiKeyDecryptor`].
 ///
 /// This allows a single value to be passed where both encryption and decryption
 /// capabilities are needed (e.g. encrypted cookies with key rotation).
@@ -204,25 +203,13 @@ impl<E> MultiKeyCipher<E> {
     }
 }
 
-impl<E: AeadEncryptor> AeadEncryptor for MultiKeyCipher<E> {
-    fn enc_algorithm(&self) -> Cow<'_, str> {
-        self.encryptor.enc_algorithm()
-    }
-
-    fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.encryptor.key_id()
-    }
-
-    fn encrypt<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-        self.encryptor.encrypt(plaintext, aad)
+impl<E: AeadEncryptorSelector> AeadEncryptorSelector for MultiKeyCipher<E> {
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+        self.encryptor.select_encryptor()
     }
 }
 
-impl<E: AeadEncryptor> AeadDecryptor for MultiKeyCipher<E> {
+impl<E: std::fmt::Debug + MaybeSendSync> AeadDecryptor for MultiKeyCipher<E> {
     fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
         self.decryptor.cipher_match(m)
     }
@@ -246,15 +233,16 @@ impl<E: AeadEncryptor> AeadDecryptor for MultiKeyCipher<E> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use rstest::rstest;
 
     use super::*;
     use crate::{
+        Error,
         crypto::{
             KeyMatchStrength::*,
-            cipher::{
-                AeadSealer, AeadSealerSelector, AeadUnsealer, AeadV1Cipher, StaticAeadCipher,
-            },
+            cipher::{AeadOutput, AeadSealer, AeadSealerUnsealer, AeadUnsealer, AeadV1Cipher},
         },
         error::ErrorKind,
     };
@@ -472,6 +460,27 @@ mod tests {
     #[derive(Debug)]
     struct FakeEncryptor;
 
+    /// Raw-key shape: a selector handing out its shared inner encryptor.
+    #[derive(Debug)]
+    struct FakeKey {
+        inner: Arc<FakeEncryptor>,
+    }
+
+    impl FakeKey {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(FakeEncryptor),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for FakeKey {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
     impl AeadEncryptor for FakeEncryptor {
         fn enc_algorithm(&self) -> Cow<'_, str> {
             "A256GCM".into()
@@ -498,14 +507,16 @@ mod tests {
     #[tokio::test]
     async fn multi_key_cipher_delegates_each_direction() {
         let cipher = MultiKeyCipher::new(
-            FakeEncryptor,
+            FakeKey::new(),
             MultiKeyDecryptor::new(vec![dec(None, Outcome::Ok(b"plaintext"))]),
         );
 
-        // Encryptor side → delegates to the inner encryptor.
-        assert_eq!(cipher.enc_algorithm().as_ref(), "A256GCM");
-        assert_eq!(cipher.key_id().as_deref(), Some("enc-kid"));
-        let out = cipher.encrypt(b"plaintext", b"aad").await.unwrap();
+        // Encryptor side → delegates to the selected encryptor.
+        let selected = cipher.select_encryptor().await;
+
+        assert_eq!(selected.enc_algorithm().as_ref(), "A256GCM");
+        assert_eq!(selected.key_id().as_deref(), Some("enc-kid"));
+        let out = selected.encrypt(b"plaintext", b"aad").await.unwrap();
         assert_eq!(out.ciphertext, b"plaintext");
 
         // Decryptor side → delegates to the MultiKeyDecryptor.
@@ -523,17 +534,11 @@ mod tests {
     /// whose tag is its own `kid`. So which key sealed a cookie is observable, and
     /// a cookie can only be unsealed by the key that sealed it.
     #[derive(Debug)]
-    struct KeyedCookieCipher {
+    struct KeyedCookieEncryptor {
         kid: &'static str,
     }
 
-    impl KeyedCookieCipher {
-        fn new(kid: &'static str) -> Self {
-            Self { kid }
-        }
-    }
-
-    impl AeadEncryptor for KeyedCookieCipher {
+    impl AeadEncryptor for KeyedCookieEncryptor {
         fn enc_algorithm(&self) -> Cow<'_, str> {
             "A256GCM".into()
         }
@@ -557,9 +562,29 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct KeyedCookieCipher {
+        inner: Arc<KeyedCookieEncryptor>,
+    }
+
+    impl KeyedCookieCipher {
+        fn new(kid: &'static str) -> Self {
+            Self {
+                inner: Arc::new(KeyedCookieEncryptor { kid }),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for KeyedCookieCipher {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
     impl AeadDecryptor for KeyedCookieCipher {
         fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-            m.strength_for("A256GCM", Some(self.kid))
+            m.strength_for("A256GCM", Some(self.inner.kid))
         }
         fn decrypt<'a>(
             &'a self,
@@ -569,7 +594,7 @@ mod tests {
             tag: &'a [u8],
             _aad: &'a [u8],
         ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-            let opens = tag == self.kid.as_bytes();
+            let opens = tag == self.inner.kid.as_bytes();
             let plaintext = ciphertext.to_vec();
             Box::pin(async move {
                 if opens {
@@ -581,12 +606,11 @@ mod tests {
         }
     }
 
-    /// The rotated-cookie-keys shape: one `StaticAeadCipher<MultiKeyCipher>` seals
+    /// The rotated-cookie-keys shape: one `AeadV1Cipher<MultiKeyCipher>` seals
     /// every new cookie with the current primary key while still unsealing cookies
     /// sealed by any key left in the decryptor set — and a key dropped from the set
-    /// can no longer open its old cookies. This is the composition the sealing docs
-    /// name; it exercises `select_sealer` (encrypt with one) and `unseal` (decrypt
-    /// against many) on the same value.
+    /// can no longer open its old cookies. Erased to `Arc<dyn AeadSealerUnsealer>`,
+    /// it is a single handle carrying both directions.
     #[tokio::test]
     async fn rotated_cookie_keys_seal_new_and_unseal_old() {
         // A cookie minted with v1 before the rotation, and one minted with a
@@ -601,21 +625,17 @@ mod tests {
             .unwrap();
 
         // After rotation: seal with v2, still decrypt v2 and v1 (v0 dropped).
-        let cookies = StaticAeadCipher::new(MultiKeyCipher::new(
-            KeyedCookieCipher::new("v2"),
-            MultiKeyDecryptor::new(vec![
-                Arc::new(KeyedCookieCipher::new("v2")) as Arc<dyn AeadDecryptor>,
-                Arc::new(KeyedCookieCipher::new("v1")) as Arc<dyn AeadDecryptor>,
-            ]),
-        ));
+        let cookies: Arc<dyn AeadSealerUnsealer> =
+            Arc::new(AeadV1Cipher::new(MultiKeyCipher::new(
+                KeyedCookieCipher::new("v2"),
+                MultiKeyDecryptor::new(vec![
+                    Arc::new(KeyedCookieCipher::new("v2")) as Arc<dyn AeadDecryptor>,
+                    Arc::new(KeyedCookieCipher::new("v1")) as Arc<dyn AeadDecryptor>,
+                ]),
+            )));
 
         // New cookies are sealed with the current primary (v2)...
-        let new_cookie = cookies
-            .select_sealer()
-            .await
-            .seal(b"session", b"aad")
-            .await
-            .unwrap();
+        let new_cookie = cookies.seal(b"session", b"aad").await.unwrap();
         assert_eq!(
             &new_cookie[new_cookie.len() - 2..],
             b"v2",

--- a/huskarl-core/src/crypto/cipher/refreshable.rs
+++ b/huskarl-core/src/crypto/cipher/refreshable.rs
@@ -1,12 +1,9 @@
-use std::{borrow::Cow, pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::Arc};
 
 use crate::{
     crypto::{
         KeyMatchStrength,
-        cipher::{
-            AeadCipherSelector, AeadDecryptor, AeadEncryptor, AeadOutput, AeadSealer,
-            AeadSealerSelector, AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError,
-        },
+        cipher::{AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, CipherMatch, DecryptError},
         refreshable::Refreshable,
     },
     error::Error,
@@ -29,13 +26,11 @@ use crate::{
 /// manager) without restarting the application.
 ///
 /// For emitting, go through the selector API
-/// ([`select_cipher`](AeadCipherSelector::select_cipher) /
-/// [`select_sealer`](AeadSealerSelector::select_sealer)), which hands back a frozen
-/// snapshot. Using the type directly as an [`AeadEncryptor`] takes a fresh snapshot
-/// per call, so reading metadata and then encrypting can straddle a rotation — the
-/// hazard the selector exists to prevent (see [composing crypto
-/// strategies](crate::_docs::explanation::crypto_strategies)); the bare impl exists
-/// only for composition and erasure.
+/// ([`select_encryptor`](AeadEncryptorSelector::select_encryptor)), which hands
+/// back a frozen snapshot. The type is deliberately *not* an [`AeadEncryptor`]:
+/// reading metadata and then encrypting on a hot-swappable handle could straddle
+/// a rotation — the hazard the selector exists to prevent (see [composing crypto
+/// strategies](crate::_docs::explanation::crypto_strategies)).
 ///
 /// All clones share the same underlying state, so a refresh performed through
 /// any clone is visible to all others — a single `RefreshableCipher` can be
@@ -94,24 +89,12 @@ impl<C: std::fmt::Debug + MaybeSendSync + 'static> RefreshableCipher<C> {
     }
 }
 
-impl<C: AeadEncryptor + 'static> AeadEncryptor for RefreshableCipher<C> {
-    fn enc_algorithm(&self) -> Cow<'_, str> {
-        Cow::Owned(self.inner.load().enc_algorithm().into_owned())
-    }
-
-    fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.inner
-            .load()
-            .key_id()
-            .map(|kid| Cow::Owned(kid.into_owned()))
-    }
-
-    fn encrypt<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-        Box::pin(async move { self.inner.load_full().encrypt(plaintext, aad).await })
+impl<C: AeadEncryptorSelector + 'static> AeadEncryptorSelector for RefreshableCipher<C> {
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+        Box::pin(async move {
+            let selector = self.inner.load_full();
+            selector.select_encryptor().await
+        })
     }
 }
 
@@ -144,53 +127,22 @@ impl<C: AeadDecryptor + 'static> AeadDecryptor for RefreshableCipher<C> {
     }
 }
 
-impl<C: AeadEncryptor + 'static> AeadCipherSelector for RefreshableCipher<C> {
-    fn select_cipher(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-        // Hand back the current key as one frozen snapshot: reading its metadata
-        // and encrypting against it then describe and use the same key, even if a
-        // rotation lands afterwards.
-        let encryptor: Arc<dyn AeadEncryptor> = self.inner.load_full();
-        Box::pin(async move { encryptor })
-    }
-}
-
-impl<C: AeadEncryptor + 'static> AeadSealerSelector for RefreshableCipher<C> {
-    fn select_sealer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadSealer>> {
-        // Frame the frozen snapshot as a v1 sealer. Because it is one fixed key,
-        // `key_id`/`enc_algorithm` and `seal` on the returned sealer agree even
-        // across a concurrent rotation.
-        let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(self.inner.load_full()));
-        Box::pin(async move { sealer })
-    }
-}
-
-impl<C: AeadDecryptor + 'static> AeadUnsealer for RefreshableCipher<C> {
-    fn unseal<'a>(
-        &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
-        bundle: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        Box::pin(async move {
-            AeadV1Cipher::new(self.inner.load_full())
-                .unseal(cipher_match, bundle, aad)
-                .await
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::{
+        borrow::Cow,
+        sync::atomic::{AtomicU32, Ordering},
+    };
 
     use super::*;
+    use crate::crypto::cipher::AeadOutput;
 
     #[derive(Debug)]
-    struct KeyedCipher {
+    struct KeyedEncryptor {
         kid: String,
     }
 
-    impl AeadEncryptor for KeyedCipher {
+    impl AeadEncryptor for KeyedEncryptor {
         fn enc_algorithm(&self) -> Cow<'_, str> {
             "mock".into()
         }
@@ -214,9 +166,29 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct KeyedCipher {
+        inner: Arc<KeyedEncryptor>,
+    }
+
+    impl KeyedCipher {
+        fn new(kid: String) -> Self {
+            Self {
+                inner: Arc::new(KeyedEncryptor { kid }),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for KeyedCipher {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
     impl AeadDecryptor for KeyedCipher {
         fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-            m.strength_for("mock", Some(&self.kid))
+            m.strength_for("mock", Some(&self.inner.kid))
         }
 
         fn decrypt<'a>(
@@ -228,7 +200,7 @@ mod tests {
             _aad: &'a [u8],
         ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
             Box::pin(async move {
-                if tag == self.kid.as_bytes() {
+                if tag == self.inner.kid.as_bytes() {
                     Ok(ciphertext.to_vec())
                 } else {
                     Err(Error::from(crate::error::ErrorKind::Crypto).into())
@@ -244,9 +216,7 @@ mod tests {
                 let counter = Arc::clone(&counter);
                 Box::pin(async move {
                     let n = counter.fetch_add(1, Ordering::SeqCst);
-                    Ok(KeyedCipher {
-                        kid: format!("v{n}"),
-                    })
+                    Ok(KeyedCipher::new(format!("v{n}")))
                 })
             };
         RefreshableCipher::builder()
@@ -261,15 +231,18 @@ mod tests {
         let cipher = versioned_cipher().await;
         let clone = cipher.clone();
 
-        assert_eq!(cipher.key_id().as_deref(), Some("v0"));
+        let encryptor = cipher.select_encryptor().await;
+        assert_eq!(encryptor.key_id().as_deref(), Some("v0"));
         assert!(cipher.refresh().await.unwrap());
-        assert_eq!(clone.key_id().as_deref(), Some("v1"));
+        let encryptor = clone.select_encryptor().await;
+        assert_eq!(encryptor.key_id().as_deref(), Some("v1"));
     }
 
     #[tokio::test]
     async fn try_refresh_swaps_through_dyn_decryptor() {
         let cipher = versioned_cipher().await;
-        let output = cipher.encrypt(b"hello", b"").await.unwrap();
+        let encryptor = cipher.select_encryptor().await;
+        let output = encryptor.encrypt(b"hello", b"").await.unwrap();
 
         let decryptor: Arc<dyn AeadDecryptor> = Arc::new(cipher);
         decryptor

--- a/huskarl-core/src/crypto/cipher/scheduled.rs
+++ b/huskarl-core/src/crypto/cipher/scheduled.rs
@@ -1,12 +1,9 @@
-use std::{borrow::Cow, pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::Arc};
 
 use crate::{
     crypto::{
         KeyMatchStrength,
-        cipher::{
-            AeadCipherSelector, AeadDecryptor, AeadEncryptor, AeadOutput, AeadSealer,
-            AeadSealerSelector, AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError,
-        },
+        cipher::{AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, CipherMatch, DecryptError},
         refreshable::ScheduledRefreshable,
     },
     error::Error,
@@ -19,15 +16,15 @@ use crate::{
 /// long a removed key lingers; key *additions* are handled by the miss-triggered
 /// [`RetryingDecryptor`](super::RetryingDecryptor) layered on top.
 ///
-/// On each [`decrypt`](AeadDecryptor::decrypt)/[`unseal`](AeadUnsealer::unseal),
-/// and inside each [`select_cipher`](AeadCipherSelector::select_cipher)/[`select_sealer`](AeadSealerSelector::select_sealer),
+/// On each [`decrypt`](AeadDecryptor::decrypt), and inside each
+/// [`select_encryptor`](AeadEncryptorSelector::select_encryptor),
 /// the first caller past the TTL reloads single-flight (non-blocking for others),
-/// then proceeds against a frozen snapshot; for the outbound selectors the TTL
+/// then proceeds against a frozen snapshot; for the outbound selector the TTL
 /// bounds how quickly a rotated-in key is discovered rather than how quickly a removed
-/// one is dropped. Using the type directly as
-/// an [`AeadEncryptor`] serves the current snapshot *without* a reload — go through
-/// the selector for the freshness guarantee. The pure swap mechanism without policy
-/// is [`RefreshableCipher`](super::RefreshableCipher).
+/// one is dropped. The type is deliberately *not* an [`AeadEncryptor`]: all
+/// outbound use goes through the selector, so there is no reload-free path to
+/// encrypt with (or read metadata off) a stale key. The pure swap mechanism
+/// without policy is [`RefreshableCipher`](super::RefreshableCipher).
 ///
 /// See [composing crypto strategies](crate::_docs::explanation::crypto_strategies)
 /// for how this layer (removals) pairs with the retrying layer (additions). All
@@ -43,6 +40,16 @@ impl<C> Clone for ScheduledRefreshCipher<C> {
         Self {
             inner: Arc::clone(&self.inner),
         }
+    }
+}
+
+impl<C: AeadEncryptorSelector + 'static> AeadEncryptorSelector for ScheduledRefreshCipher<C> {
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+        Box::pin(async move {
+            self.inner.poll_refresh_ahead().await;
+            let selector = self.inner.load_full();
+            selector.select_encryptor().await
+        })
     }
 }
 
@@ -86,11 +93,10 @@ impl<C: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshCipher<C> {
     /// Reloads the key if it has outlived its TTL and the rate-limit/backoff
     /// policy permits; a within-TTL key is left in place. Blocking.
     ///
-    /// A manual staleness poll: the selector paths
-    /// ([`select_cipher`](AeadCipherSelector::select_cipher),
-    /// [`select_sealer`](AeadSealerSelector::select_sealer)) already reload a stale
-    /// key during selection, so this only pre-warms the key ahead of a
-    /// latency-sensitive encrypt/seal. Distinct from the inbound miss path
+    /// A manual staleness poll: the selector path
+    /// ([`select_encryptor`](AeadEncryptorSelector::select_encryptor)) already
+    /// reloads a stale key during selection, so this only pre-warms the key
+    /// ahead of a latency-sensitive encrypt/seal. Distinct from the inbound miss path
     /// [`AeadDecryptor::try_refresh`], which is not TTL-gated;
     /// [`refresh`](Self::refresh) reloads unconditionally.
     ///
@@ -110,27 +116,6 @@ impl<C: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshCipher<C> {
     /// Returns an error if the factory call fails.
     pub async fn refresh(&self) -> Result<bool, Error> {
         self.inner.refresh().await
-    }
-}
-
-impl<C: AeadEncryptor + 'static> AeadEncryptor for ScheduledRefreshCipher<C> {
-    fn enc_algorithm(&self) -> Cow<'_, str> {
-        Cow::Owned(self.inner.load().enc_algorithm().into_owned())
-    }
-
-    fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.inner
-            .load()
-            .key_id()
-            .map(|kid| Cow::Owned(kid.into_owned()))
-    }
-
-    fn encrypt<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-        Box::pin(async move { self.inner.load_full().encrypt(plaintext, aad).await })
     }
 }
 
@@ -169,66 +154,28 @@ impl<C: AeadDecryptor + 'static> AeadDecryptor for ScheduledRefreshCipher<C> {
     }
 }
 
-impl<C: AeadEncryptor + 'static> AeadCipherSelector for ScheduledRefreshCipher<C> {
-    fn select_cipher(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-        Box::pin(async move {
-            // Reload a stale key during selection, then hand back the fresh key as
-            // one frozen snapshot — the caller encrypts against exactly this key.
-            self.inner.poll_refresh_ahead().await;
-            let encryptor: Arc<dyn AeadEncryptor> = self.inner.load_full();
-            encryptor
-        })
-    }
-}
-
-impl<C: AeadEncryptor + 'static> AeadSealerSelector for ScheduledRefreshCipher<C> {
-    fn select_sealer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadSealer>> {
-        Box::pin(async move {
-            // Reload on the outbound read path, then frame the frozen snapshot as a
-            // v1 sealer whose metadata and `seal` describe and use the same key.
-            self.inner.poll_refresh_ahead().await;
-            let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(self.inner.load_full()));
-            sealer
-        })
-    }
-}
-
-impl<C: AeadDecryptor + 'static> AeadUnsealer for ScheduledRefreshCipher<C> {
-    fn unseal<'a>(
-        &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
-        bundle: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        Box::pin(async move {
-            // Same read-path staleness bound as `decrypt`: reload past the TTL,
-            // then parse and open against the current snapshot.
-            self.inner.poll_refresh_ahead().await;
-            AeadV1Cipher::new(self.inner.load_full())
-                .unseal(cipher_match, bundle, aad)
-                .await
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::{
+        borrow::Cow,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     use rstest::rstest;
 
     use super::*;
+    use crate::crypto::cipher::AeadOutput;
 
     /// An identity cipher (ciphertext == plaintext) that reports a fixed `kid`
     /// and stamps that `kid` into the authentication tag, so the generation that
     /// actually performed an operation is observable in both its metadata and its
     /// output.
     #[derive(Debug)]
-    struct FakeCipher {
+    struct FakeEncryptor {
         kid: String,
     }
 
-    impl AeadEncryptor for FakeCipher {
+    impl AeadEncryptor for FakeEncryptor {
         fn enc_algorithm(&self) -> Cow<'_, str> {
             "A256GCM".into()
         }
@@ -252,6 +199,26 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct FakeCipher {
+        inner: Arc<FakeEncryptor>,
+    }
+
+    impl FakeCipher {
+        fn new(kid: String) -> Self {
+            Self {
+                inner: Arc::new(FakeEncryptor { kid }),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for FakeCipher {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
     impl AeadDecryptor for FakeCipher {
         fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
             Some(KeyMatchStrength::ByAlgorithm)
@@ -269,43 +236,50 @@ mod tests {
         }
     }
 
-    /// A generational cipher (`gen-0`, `gen-1`, …) with the given policy.
+    /// A generational cipher (`gen-0`, `gen-1`, …) with the given policy, plus
+    /// its factory-invocation counter — the reload-free way to observe refresh
+    /// behaviour (selection itself reloads a stale key).
     async fn generational_cipher(
         ttl: Duration,
         min_refresh_interval: Duration,
-    ) -> ScheduledRefreshCipher<FakeCipher> {
-        let counter = Arc::new(AtomicUsize::new(0));
-        ScheduledRefreshCipher::builder()
+    ) -> (Arc<AtomicUsize>, ScheduledRefreshCipher<FakeCipher>) {
+        let builds = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&builds);
+        let cipher = ScheduledRefreshCipher::builder()
             .factory(move || {
                 let n = counter.fetch_add(1, Ordering::SeqCst);
-                Box::pin(async move {
-                    Ok(FakeCipher {
-                        kid: format!("gen-{n}"),
-                    })
-                })
+                Box::pin(async move { Ok(FakeCipher::new(format!("gen-{n}"))) })
             })
             .ttl(ttl)
             .min_refresh_interval(min_refresh_interval)
             .build()
             .await
-            .unwrap()
+            .unwrap();
+        (builds, cipher)
     }
 
-    fn current_kid(cipher: &ScheduledRefreshCipher<FakeCipher>) -> Option<String> {
-        cipher.key_id().map(std::borrow::Cow::into_owned)
+    /// Reads the current kid through the selector — reload-free only while the
+    /// key is within its TTL.
+    async fn current_kid(cipher: &ScheduledRefreshCipher<FakeCipher>) -> Option<String> {
+        let encryptor = cipher.select_encryptor().await;
+        encryptor.key_id().map(std::borrow::Cow::into_owned)
     }
 
     #[tokio::test]
-    async fn delegates_encryptor_metadata_to_inner() {
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
-        assert_eq!(cipher.enc_algorithm().as_ref(), "A256GCM");
-        assert_eq!(current_kid(&cipher).as_deref(), Some("gen-0"));
+    async fn selected_encryptor_exposes_inner_metadata() {
+        let (_, cipher) =
+            generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
+        let encryptor = cipher.select_encryptor().await;
+        assert_eq!(encryptor.enc_algorithm().as_ref(), "A256GCM");
+        assert_eq!(encryptor.key_id().as_deref(), Some("gen-0"));
     }
 
     #[tokio::test]
     async fn encrypt_and_decrypt_delegate_to_inner() {
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
-        let out = cipher.encrypt(b"plaintext", b"aad").await.unwrap();
+        let (_, cipher) =
+            generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
+        let encryptor = cipher.select_encryptor().await;
+        let out = encryptor.encrypt(b"plaintext", b"aad").await.unwrap();
         let recovered = cipher
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"aad")
             .await
@@ -315,7 +289,8 @@ mod tests {
 
     #[tokio::test]
     async fn cipher_match_delegates_to_inner() {
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
+        let (_, cipher) =
+            generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
         let m = CipherMatch {
             enc: Some("A256GCM"),
             kid: None,
@@ -326,26 +301,28 @@ mod tests {
     #[tokio::test]
     async fn forced_refresh_bypasses_policy() {
         // A long TTL would block a policy-gated refresh, but `refresh` is forced.
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::from_mins(1)).await;
-        assert_eq!(current_kid(&cipher).as_deref(), Some("gen-0"));
+        let (_, cipher) =
+            generational_cipher(Duration::from_hours(1), Duration::from_mins(1)).await;
+        assert_eq!(current_kid(&cipher).await.as_deref(), Some("gen-0"));
         assert!(cipher.refresh().await.unwrap());
-        assert_eq!(current_kid(&cipher).as_deref(), Some("gen-1"));
+        assert_eq!(current_kid(&cipher).await.as_deref(), Some("gen-1"));
     }
 
     /// `refresh_if_stale` is gated by the TTL: a fresh value is left in place, a
-    /// stale one (zero TTL) is swapped for the next generation.
+    /// stale one (zero TTL) is swapped for the next generation. Observed via the
+    /// factory counter — with a zero TTL, selection itself would reload again.
     #[rstest]
-    #[case::blocked_while_fresh(Duration::from_hours(1), false, "gen-0")]
-    #[case::allowed_when_stale(Duration::from_secs(0), true, "gen-1")]
+    #[case::blocked_while_fresh(Duration::from_hours(1), false, 1)]
+    #[case::allowed_when_stale(Duration::from_secs(0), true, 2)]
     #[tokio::test]
     async fn refresh_if_stale_respects_ttl_policy(
         #[case] ttl: Duration,
         #[case] expected_refreshed: bool,
-        #[case] expected_kid: &str,
+        #[case] expected_builds: usize,
     ) {
-        let cipher = generational_cipher(ttl, Duration::from_secs(0)).await;
+        let (builds, cipher) = generational_cipher(ttl, Duration::from_secs(0)).await;
         assert_eq!(cipher.refresh_if_stale().await, expected_refreshed);
-        assert_eq!(current_kid(&cipher).as_deref(), Some(expected_kid));
+        assert_eq!(builds.load(Ordering::SeqCst), expected_builds);
     }
 
     /// The inbound miss path (`AeadDecryptor::try_refresh`) is **not** TTL-gated:
@@ -355,9 +332,10 @@ mod tests {
     async fn decryptor_try_refresh_is_not_ttl_gated() {
         // A large TTL — the value is nowhere near stale — yet the miss path still
         // reloads, swapping gen-0 for gen-1.
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
+        let (_, cipher) =
+            generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
         assert!(AeadDecryptor::try_refresh(&cipher).await);
-        assert_eq!(current_kid(&cipher).as_deref(), Some("gen-1"));
+        assert_eq!(current_kid(&cipher).await.as_deref(), Some("gen-1"));
     }
 
     /// A decryptor whose generation 0 decrypts (holds the key) and every later
@@ -449,46 +427,24 @@ mod tests {
         assert_eq!(builds.load(Ordering::SeqCst), 1, "no reload while fresh");
     }
 
+    /// The crux of the encryptor-selector: a selected encryptor is a *frozen*
+    /// snapshot, so a rotation landing after selection cannot make its `key_id`
+    /// and its output describe different keys. `FakeCipher` stamps its `kid` into
+    /// the tag, so the key that actually encrypted is observable in the output.
     #[tokio::test]
-    async fn select_cipher_hands_back_the_current_snapshot() {
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::from_secs(0)).await;
-        assert_eq!(
-            cipher.select_cipher().await.key_id().as_deref(),
-            Some("gen-0")
-        );
-    }
+    async fn selected_encryptor_kid_and_output_agree_across_a_rotation() {
+        let (_, cipher) = generational_cipher(Duration::from_hours(1), Duration::ZERO).await;
 
-    #[tokio::test]
-    async fn select_cipher_reloads_a_stale_key_during_selection() {
-        // Zero TTL: the outbound read path reloads before handing back the snapshot.
-        let cipher = generational_cipher(Duration::ZERO, Duration::ZERO).await;
-        assert_eq!(
-            cipher.select_cipher().await.key_id().as_deref(),
-            Some("gen-1")
-        );
-    }
+        let frozen = cipher.select_encryptor().await;
+        assert_eq!(frozen.key_id().as_deref(), Some("gen-0"));
 
-    /// The crux of the sealer-selector: a sealer is a *frozen* snapshot, so a
-    /// rotation landing after selection cannot make its `key_id` and its `seal`
-    /// describe different keys. `FakeCipher` tags every bundle with its `kid`, so
-    /// the key that actually sealed is observable in the ciphertext.
-    #[tokio::test]
-    async fn selected_sealer_kid_and_ciphertext_agree_across_a_rotation() {
-        let cipher = generational_cipher(Duration::from_hours(1), Duration::ZERO).await;
-
-        let sealer = cipher.select_sealer().await;
-        let kid = sealer.key_id().map(std::borrow::Cow::into_owned);
-        assert_eq!(kid.as_deref(), Some("gen-0"));
-
-        // Rotate the underlying key out from under the held sealer.
+        // Rotate the underlying key out from under the held encryptor.
         assert!(cipher.refresh().await.unwrap());
-        assert_eq!(current_kid(&cipher).as_deref(), Some("gen-1"));
+        assert_eq!(current_kid(&cipher).await.as_deref(), Some("gen-1"));
 
-        // The frozen sealer still seals with gen-0 — the key its `kid` named —
-        // not the freshly rotated gen-1.
-        let bundle = sealer.seal(b"payload", b"aad").await.unwrap();
-        // v1 layout: [0x01, nonce_len=0, tag_len=5, ciphertext="payload", tag="gen-0"]
-        let tag = &bundle[bundle.len() - 5..];
-        assert_eq!(tag, b"gen-0");
+        // The frozen snapshot still encrypts with gen-0 — the key its `kid`
+        // named — not the freshly rotated gen-1.
+        let out = frozen.encrypt(b"payload", b"aad").await.unwrap();
+        assert_eq!(out.tag, b"gen-0");
     }
 }

--- a/huskarl-crypto-native/src/aead.rs
+++ b/huskarl-crypto-native/src/aead.rs
@@ -1,21 +1,25 @@
 //! AES-GCM AEAD cipher, backed by `RustCrypto`'s `aes-gcm`.
 //!
-//! [`AesGcmKey`] is the user-facing cipher implementing huskarl-core's
-//! [`AeadEncryptor`] and
-//! [`AeadDecryptor`]. Build one from a JWK with [`AesGcmKey::from_jwk`], or
+//! [`AesGcmKey`] is the user-facing cipher — an
+//! [`AeadCipher`](huskarl_core::crypto::cipher::AeadCipher): an
+//! [`AeadEncryptorSelector`] handing out its shared inner [`AeadEncryptor`],
+//! plus an [`AeadDecryptor`]. Build one from a JWK with [`AesGcmKey::from_jwk`], or
 //! from a secret store with [`AesGcmKey::from_secret`] — the AES-128/192/256
 //! variant follows from the key length (16/24/32 bytes) — e.g. to back the
 //! `DPoP` nonce store. Note the per-key encryption bound in [`AesGcmKey`]'s
 //! docs when sizing key rotation.
 
-use std::{array::TryFromSliceError, borrow::Cow, fmt};
+use std::{array::TryFromSliceError, borrow::Cow, fmt, sync::Arc};
 
 use aes_gcm::{AeadInOut, KeyInit, aead::Generate};
 use huskarl_core::{
     Error, ErrorKind,
     crypto::{
         KeyMatchStrength,
-        cipher::{AeadDecryptor, AeadEncryptor, AeadOutput, CipherMatch, DecryptError},
+        cipher::{
+            AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, AeadOutput, CipherMatch,
+            DecryptError,
+        },
     },
     jwk,
     platform::MaybeSendBoxFuture,
@@ -48,8 +52,10 @@ impl NativeKey {
 ///
 /// Build one with [`from_jwk`](Self::from_jwk) or
 /// [`from_secret`](Self::from_secret); the AES-128/192/256 variant follows
-/// from the key length. Implements huskarl-core's [`AeadEncryptor`] and
-/// [`AeadDecryptor`].
+/// from the key length. Implements huskarl-core's [`AeadEncryptorSelector`]
+/// (selection hands out the key's shared inner [`AeadEncryptor`]) and
+/// [`AeadDecryptor`] — together, an
+/// [`AeadCipher`](huskarl_core::crypto::cipher::AeadCipher).
 ///
 /// # Usage bound (NIST SP 800-38D §8.3)
 ///
@@ -66,15 +72,22 @@ impl NativeKey {
 /// decrypt-only via
 /// [`MultiKeyCipher`](huskarl_core::crypto::cipher::MultiKeyCipher) /
 /// [`MultiKeyDecryptor`](huskarl_core::crypto::cipher::MultiKeyDecryptor).
+#[derive(Debug, Clone)]
 pub struct AesGcmKey {
-    inner: NativeKey,
+    inner: Arc<AesGcmKeyInner>,
+}
+
+/// The shared key material behind an `AesGcmKey` — the encryptor snapshot
+/// `select_encryptor` hands out.
+struct AesGcmKeyInner {
+    key: NativeKey,
     kid: Option<String>,
 }
 
-impl fmt::Debug for AesGcmKey {
+impl fmt::Debug for AesGcmKeyInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AesGcmKey")
-            .field("enc", &self.inner.enc_algorithm())
+        f.debug_struct("AesGcmKeyInner")
+            .field("enc", &self.key.enc_algorithm())
             .field("kid", &self.kid)
             .finish_non_exhaustive()
     }
@@ -104,7 +117,7 @@ impl AesGcmKey {
             ))
         };
         let len = jwk.key.k.len();
-        let inner = match len {
+        let key = match len {
             16 => NativeKey::Aes128(Box::new(
                 aes_gcm::Aes128Gcm::new_from_slice(&jwk.key.k).map_err(|_| bad_len(len))?,
             )),
@@ -118,17 +131,16 @@ impl AesGcmKey {
         };
 
         if let Some(alg) = jwk.algorithm.as_deref()
-            && alg != inner.enc_algorithm()
+            && alg != key.enc_algorithm()
         {
             return Err(Error::from(ErrorKind::Config).with_context(format!(
                 "JWK algorithm {alg} disagrees with the key length, which selects {}",
-                inner.enc_algorithm()
+                key.enc_algorithm()
             )));
         }
 
         Ok(AesGcmKey {
-            inner,
-            kid: jwk.kid,
+            inner: Arc::new(AesGcmKeyInner { key, kid: jwk.kid }),
         })
     }
 
@@ -216,9 +228,34 @@ impl From<AesGcmError> for DecryptError {
     }
 }
 
-impl AeadEncryptor for AesGcmKey {
+impl AeadEncryptorSelector for AesGcmKey {
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+        let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+        Box::pin(async move { snapshot })
+    }
+}
+
+impl AeadDecryptor for AesGcmKey {
+    fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+        self.inner.cipher_match(m)
+    }
+
+    fn decrypt<'a>(
+        &'a self,
+        cipher_match: Option<&'a CipherMatch<'a>>,
+        nonce: &'a [u8],
+        ciphertext: &'a [u8],
+        tag: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+        self.inner
+            .decrypt(cipher_match, nonce, ciphertext, tag, aad)
+    }
+}
+
+impl AeadEncryptor for AesGcmKeyInner {
     fn enc_algorithm(&self) -> Cow<'_, str> {
-        Cow::Borrowed(self.inner.enc_algorithm())
+        Cow::Borrowed(self.key.enc_algorithm())
     }
 
     fn key_id(&self) -> Option<Cow<'_, str>> {
@@ -234,7 +271,7 @@ impl AeadEncryptor for AesGcmKey {
             let nonce = Array::generate();
             let mut ciphertext = plaintext.to_vec();
 
-            let tag = match &self.inner {
+            let tag = match &self.key {
                 NativeKey::Aes128(aes_gcm) => {
                     aes_gcm.encrypt_inout_detached(&nonce, aad, ciphertext.as_mut_slice().into())
                 }
@@ -256,9 +293,9 @@ impl AeadEncryptor for AesGcmKey {
     }
 }
 
-impl AeadDecryptor for AesGcmKey {
+impl AeadDecryptor for AesGcmKeyInner {
     fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-        m.strength_for(self.inner.enc_algorithm(), self.kid.as_deref())
+        m.strength_for(self.key.enc_algorithm(), self.kid.as_deref())
     }
 
     fn decrypt<'a>(
@@ -274,7 +311,7 @@ impl AeadDecryptor for AesGcmKey {
             let tag = tag.try_into().context(InvalidTagSnafu)?;
             let mut plaintext = ciphertext.to_vec();
 
-            match &self.inner {
+            match &self.key {
                 NativeKey::Aes128(aes_gcm) => aes_gcm.decrypt_inout_detached(
                     &nonce,
                     aad,
@@ -356,11 +393,12 @@ mod tests {
 
     async fn roundtrip(key_bytes: Vec<u8>, expected_enc: &str) {
         let key = key_from(key_bytes, None);
-        assert_eq!(key.enc_algorithm().as_ref(), expected_enc);
+        let encryptor = key.select_encryptor().await;
+        assert_eq!(encryptor.enc_algorithm().as_ref(), expected_enc);
 
         let pt = b"the quick brown fox jumps over the lazy dog";
         let aad = b"session-context";
-        let out = key.encrypt(pt, aad).await.unwrap();
+        let out = encryptor.encrypt(pt, aad).await.unwrap();
 
         assert_eq!(out.nonce.len(), 12, "96-bit nonce");
         assert_eq!(out.tag.len(), 16, "128-bit tag");
@@ -427,7 +465,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("cookie-key-2026"));
+        let encryptor = key.select_encryptor().await;
+        assert_eq!(encryptor.key_id().as_deref(), Some("cookie-key-2026"));
     }
 
     #[tokio::test]
@@ -441,7 +480,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("explicit"));
+        let encryptor = key.select_encryptor().await;
+        assert_eq!(encryptor.key_id().as_deref(), Some("explicit"));
     }
 
     /// Mirror of the webcrypto backend's `kid_drives_cipher_match`: both
@@ -478,7 +518,8 @@ mod tests {
     #[tokio::test]
     async fn wrong_aad_fails_to_open() {
         let key = key_from(vec![5u8; 32], None);
-        let out = key.encrypt(b"payload", b"session").await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let out = encryptor.encrypt(b"payload", b"session").await.unwrap();
         let res = key
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"other")
             .await;
@@ -488,7 +529,8 @@ mod tests {
     #[tokio::test]
     async fn tampered_ciphertext_fails_to_open() {
         let key = key_from(vec![6u8; 32], None);
-        let out = key.encrypt(b"payload", b"session").await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let out = encryptor.encrypt(b"payload", b"session").await.unwrap();
         let mut ct = out.ciphertext.clone();
         ct[0] ^= 0x01;
         let res = key
@@ -503,7 +545,8 @@ mod tests {
     #[tokio::test]
     async fn wrong_length_nonce_and_tag_rejected() {
         let key = key_from(vec![7u8; 32], None);
-        let out = key.encrypt(b"payload", b"session").await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let out = encryptor.encrypt(b"payload", b"session").await.unwrap();
 
         // Nonce too short (11 bytes instead of 12).
         let res = key

--- a/huskarl-crypto-webcrypto/src/aead.rs
+++ b/huskarl-crypto-webcrypto/src/aead.rs
@@ -1,7 +1,8 @@
 //! AES-GCM AEAD over the WebCrypto/SubtleCrypto API (e.g. for cookie sealing).
 //!
 //! [`AesGcmKey`] is the AES-128/192/256-GCM cipher implementing huskarl-core's
-//! [`AeadEncryptor`]/[`AeadDecryptor`]; build one from a JWK with
+//! [`AeadEncryptorSelector`] (handing out its shared inner [`AeadEncryptor`])
+//! and [`AeadDecryptor`]; build one from a JWK with
 //! [`AesGcmKey::from_jwk`], from a secret store with
 //! [`AesGcmKey::from_secret`], or from an already-imported key with
 //! [`AesGcmKey::from_crypto_key`]. All operations are async.
@@ -12,7 +13,10 @@ use huskarl_core::{
     Error, ErrorKind,
     crypto::{
         KeyMatchStrength,
-        cipher::{AeadDecryptor, AeadEncryptor, AeadOutput, CipherMatch, DecryptError},
+        cipher::{
+            AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, AeadOutput, CipherMatch,
+            DecryptError,
+        },
     },
     jwk,
     platform::MaybeSendBoxFuture,
@@ -43,9 +47,19 @@ struct Inner {
     kid: Option<String>,
 }
 
+impl std::fmt::Debug for Inner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Inner")
+            .field("enc", &self.enc_algorithm)
+            .field("kid", &self.kid)
+            .finish_non_exhaustive()
+    }
+}
+
 /// A non-extractable AES-GCM key backed by the `WebCrypto`/Subtle API.
 ///
-/// Implements [`AeadEncryptor`] + [`AeadDecryptor`] — and therefore
+/// Implements [`AeadEncryptorSelector`] (handing out its shared inner
+/// [`AeadEncryptor`]) + [`AeadDecryptor`] — and therefore
 /// [`AeadCipher`](huskarl_core::crypto::cipher::AeadCipher) by blanket impl — so
 /// it can seal `huskarl-login`'s session and login-state cookies on platforms
 /// whose only available crypto is `WebCrypto`: Cloudflare Workers, browsers,
@@ -280,13 +294,20 @@ impl AesGcmKey {
     }
 }
 
-impl AeadEncryptor for AesGcmKey {
+impl AeadEncryptorSelector for AesGcmKey {
+    fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+        let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+        Box::pin(async move { snapshot })
+    }
+}
+
+impl AeadEncryptor for Inner {
     fn enc_algorithm(&self) -> Cow<'_, str> {
-        Cow::Borrowed(self.inner.enc_algorithm)
+        Cow::Borrowed(self.enc_algorithm)
     }
 
     fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.inner.kid.as_deref().map(Cow::Borrowed)
+        self.kid.as_deref().map(Cow::Borrowed)
     }
 
     fn encrypt<'a>(
@@ -307,7 +328,7 @@ impl AeadEncryptor for AesGcmKey {
             let result = JsFuture::from(
                 crypto
                     .subtle()
-                    .encrypt_with_object_and_u8_array(&params, &self.inner.crypto_key, plaintext)
+                    .encrypt_with_object_and_u8_array(&params, &self.crypto_key, plaintext)
                     .context(OpSnafu)?,
             )
             .await
@@ -421,7 +442,9 @@ mod tests {
         Error,
         crypto::{
             KeyMatchStrength,
-            cipher::{AeadDecryptor as _, AeadEncryptor as _, CipherMatch},
+            cipher::{
+                AeadDecryptor as _, AeadEncryptor as _, AeadEncryptorSelector as _, CipherMatch,
+            },
         },
         jwk::{OctBytes, SymmetricJwk},
         platform::MaybeSendBoxFuture,
@@ -472,7 +495,8 @@ mod tests {
         let aad = b"session";
         let pt = b"the quick brown fox jumps over the lazy dog";
 
-        let out = key.encrypt(pt, aad).await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let out = encryptor.encrypt(pt, aad).await.unwrap();
         assert_eq!(out.nonce.len(), 12, "96-bit nonce");
         assert_eq!(out.tag.len(), 16, "128-bit tag");
         assert_ne!(
@@ -491,8 +515,9 @@ mod tests {
     #[wasm_bindgen_test]
     async fn nonces_differ_across_seals() {
         let key = key_256().await;
-        let a = key.encrypt(b"x", b"aad").await.unwrap();
-        let b = key.encrypt(b"x", b"aad").await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let a = encryptor.encrypt(b"x", b"aad").await.unwrap();
+        let b = encryptor.encrypt(b"x", b"aad").await.unwrap();
         assert_ne!(a.nonce, b.nonce, "each seal must draw a fresh CSPRNG nonce");
     }
 
@@ -500,7 +525,8 @@ mod tests {
     async fn wrong_aad_fails_to_open() {
         // The AAD binding is what domain-separates session vs login-state cookies.
         let key = key_256().await;
-        let out = key.encrypt(b"payload", b"session").await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let out = encryptor.encrypt(b"payload", b"session").await.unwrap();
         let res = key
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"session_ptr")
             .await;
@@ -510,7 +536,11 @@ mod tests {
     #[wasm_bindgen_test]
     async fn tampered_ciphertext_fails_to_open() {
         let key = key_256().await;
-        let mut out = key.encrypt(b"payload data here", b"aad").await.unwrap();
+        let encryptor = key.select_encryptor().await;
+        let mut out = encryptor
+            .encrypt(b"payload data here", b"aad")
+            .await
+            .unwrap();
         out.ciphertext[0] ^= 0xff;
         let res = key
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"aad")
@@ -525,7 +555,8 @@ mod tests {
     async fn other_key_cannot_open() {
         let a = key_from(vec![7u8; 32], None).await;
         let b = key_from(vec![9u8; 32], None).await;
-        let out = a.encrypt(b"secret", b"aad").await.unwrap();
+        let encryptor = a.select_encryptor().await;
+        let out = encryptor.encrypt(b"secret", b"aad").await.unwrap();
         let res = b
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"aad")
             .await;
@@ -539,7 +570,8 @@ mod tests {
     async fn aes_128_and_192_roundtrip() {
         for len in [16usize, 24] {
             let key = key_from(vec![3u8; len], None).await;
-            let out = key.encrypt(b"data", b"aad").await.unwrap();
+            let encryptor = key.select_encryptor().await;
+            let out = encryptor.encrypt(b"data", b"aad").await.unwrap();
             let recovered = key
                 .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"aad")
                 .await
@@ -554,7 +586,12 @@ mod tests {
         // what `cipher_match` keys on, so each AES size must label itself.
         for (len, enc) in [(16usize, "A128GCM"), (24, "A192GCM"), (32, "A256GCM")] {
             let key = key_from(vec![3u8; len], None).await;
-            assert_eq!(key.enc_algorithm().as_ref(), enc, "AES key length {len}");
+            let encryptor = key.select_encryptor().await;
+            assert_eq!(
+                encryptor.enc_algorithm().as_ref(),
+                enc,
+                "AES key length {len}"
+            );
         }
     }
 
@@ -577,7 +614,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("kv-version-3"));
+        let encryptor = key.select_encryptor().await;
+        assert_eq!(encryptor.key_id().as_deref(), Some("kv-version-3"));
     }
 
     #[wasm_bindgen_test]
@@ -585,7 +623,8 @@ mod tests {
         // The kid is what lets a MultiKeyDecryptor route — and a refresh-on-miss
         // distinguish "wrong key" from "tampered". Exercise the match contract.
         let key = key_from(vec![1u8; 32], Some("v1")).await;
-        assert_eq!(key.key_id().as_deref(), Some("v1"));
+        let encryptor = key.select_encryptor().await;
+        assert_eq!(encryptor.key_id().as_deref(), Some("v1"));
 
         assert!(matches!(
             key.cipher_match(&CipherMatch::builder().kid("v1").build()),
@@ -642,12 +681,16 @@ mod tests {
         let crypto_key = import_raw_aes_crypto_key(&bytes).await;
         let key = AesGcmKey::from_crypto_key(crypto_key, 256, Some("startup".to_string()));
 
-        assert_eq!(key.enc_algorithm().as_ref(), "A256GCM");
-        assert_eq!(key.key_id().as_deref(), Some("startup"));
+        let encryptor = key.select_encryptor().await;
+        assert_eq!(encryptor.enc_algorithm().as_ref(), "A256GCM");
+        assert_eq!(encryptor.key_id().as_deref(), Some("startup"));
 
         // It seals and opens like any other key.
         let aad = b"session";
-        let out = key.encrypt(b"provisioned payload", aad).await.unwrap();
+        let out = encryptor
+            .encrypt(b"provisioned payload", aad)
+            .await
+            .unwrap();
         let recovered = key
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, aad)
             .await
@@ -680,7 +723,8 @@ mod tests {
             (9999, "A256GCM"),
         ] {
             let key = AesGcmKey::from_crypto_key(crypto_key.clone(), bits, None);
-            assert_eq!(key.enc_algorithm().as_ref(), enc, "key_bits {bits}");
+            let encryptor = key.select_encryptor().await;
+            assert_eq!(encryptor.enc_algorithm().as_ref(), enc, "key_bits {bits}");
         }
     }
 
@@ -702,7 +746,8 @@ mod tests {
         let native = native_key(bytes);
         let aad = b"session";
 
-        let out = web.encrypt(b"interop payload", aad).await.unwrap();
+        let encryptor = web.select_encryptor().await;
+        let out = encryptor.encrypt(b"interop payload", aad).await.unwrap();
         let recovered = native
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, aad)
             .await
@@ -723,7 +768,8 @@ mod tests {
 
         // Native sealing draws its nonce from getrandom — needs the wasm_js
         // backend cfg at build time (see the dev-dependency comment).
-        let out = native.encrypt(b"interop payload", aad).await.unwrap();
+        let encryptor = native.select_encryptor().await;
+        let out = encryptor.encrypt(b"interop payload", aad).await.unwrap();
         let recovered = web
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, aad)
             .await
@@ -741,7 +787,8 @@ mod tests {
         let web = key_from(bytes.clone(), None).await;
         let native = native_key(bytes);
 
-        let out = web.encrypt(b"payload", b"session").await.unwrap();
+        let encryptor = web.select_encryptor().await;
+        let out = encryptor.encrypt(b"payload", b"session").await.unwrap();
         let res = native
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, b"session_ptr")
             .await;
@@ -757,11 +804,13 @@ mod tests {
         let native = native_key(bytes);
         let aad = b"session";
 
-        assert_eq!(web.enc_algorithm().as_ref(), "A192GCM");
-        assert_eq!(native.enc_algorithm().as_ref(), "A192GCM");
+        let web_encryptor = web.select_encryptor().await;
+        let native_encryptor = native.select_encryptor().await;
+        assert_eq!(web_encryptor.enc_algorithm().as_ref(), "A192GCM");
+        assert_eq!(native_encryptor.enc_algorithm().as_ref(), "A192GCM");
 
         // WebCrypto seals → native opens.
-        let out = web.encrypt(b"aes192 payload", aad).await.unwrap();
+        let out = web_encryptor.encrypt(b"aes192 payload", aad).await.unwrap();
         let recovered = native
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, aad)
             .await
@@ -769,7 +818,10 @@ mod tests {
         assert_eq!(recovered, b"aes192 payload".to_vec());
 
         // Native seals → WebCrypto opens.
-        let out = native.encrypt(b"aes192 payload", aad).await.unwrap();
+        let out = native_encryptor
+            .encrypt(b"aes192 payload", aad)
+            .await
+            .unwrap();
         let recovered = web
             .decrypt(None, &out.nonce, &out.ciphertext, &out.tag, aad)
             .await

--- a/huskarl-resource-server/docs/guide/dpop.md
+++ b/huskarl-resource-server/docs/guide/dpop.md
@@ -78,7 +78,7 @@ the key can validate them:
 
 ```rust
 # use std::sync::Arc;
-# use huskarl_resource_server::core::crypto::cipher::StaticAeadCipher;
+# use huskarl_resource_server::core::crypto::cipher::AeadV1Cipher;
 # use huskarl_resource_server::core::jwk::{JwksSource, OctBytes};
 # use huskarl_resource_server::core::prelude::*;
 # use huskarl_resource_server::core::secrets::{EnvVarSecret, encodings::Base64Encoding};
@@ -98,7 +98,7 @@ let validator = Rfc9068Validator::builder()
     .jwks_uri("https://my-issuer/.well-known/jwks.json".parse()?)
     .dpop_nonce_checker(
         SealedTimestampNonce::builder()
-            .sealer(StaticAeadCipher::new(nonce_key))
+            .sealer(AeadV1Cipher::new(nonce_key))
             .build(),
     )
     .jws_verifier_factory(Arc::new(

--- a/huskarl-resource-server/src/validator/dpop_nonce.rs
+++ b/huskarl-resource-server/src/validator/dpop_nonce.rs
@@ -12,7 +12,7 @@ use bon::Builder;
 
 use crate::core::{
     Error,
-    crypto::cipher::{AeadSealer, AeadSealerSelector, AeadUnsealer},
+    crypto::cipher::AeadSealerUnsealer,
     platform::{Duration, MaybeSendBoxFuture, MaybeSendSync, SystemTime},
 };
 
@@ -80,17 +80,18 @@ impl<T: DPoPNonceChecker + ?Sized> DPoPNonceChecker for Arc<T> {
 /// then base64url-encoding the result (without padding). This allows stateless verification of nonce age
 /// without a database, as long as the encryption key is stable across requests.
 #[derive(Debug, Builder)]
-pub struct SealedTimestampNonce<S: AeadSealerSelector + AeadUnsealer> {
+pub struct SealedTimestampNonce {
     /// The AEAD sealer/unsealer for nonce timestamps — one object that seals on
     /// the way out and unseals on the way in.
     ///
-    /// Wrap a fixed [`AeadCipher`](crate::core::crypto::cipher::AeadCipher) (a
-    /// symmetric or KMS-backed key) in
-    /// [`StaticAeadCipher`](crate::core::crypto::cipher::StaticAeadCipher), or a
-    /// rotating key in
-    /// [`ScheduledRefreshCipher`](crate::core::crypto::cipher::ScheduledRefreshCipher);
-    /// either erases to `Arc<dyn SealedAeadCipherSelector>`.
-    sealer: S,
+    /// Wrap an [`AeadCipher`](crate::core::crypto::cipher::AeadCipher) (a key,
+    /// or a rotating stack such as
+    /// [`ScheduledRefreshCipher`](crate::core::crypto::cipher::ScheduledRefreshCipher))
+    /// in [`AeadV1Cipher`](crate::core::crypto::cipher::AeadV1Cipher); an
+    /// externally-managed sealer (e.g. a KMS encrypt endpoint) can implement
+    /// the traits directly.
+    #[builder(with = |sealer: impl AeadSealerUnsealer + 'static| Arc::new(sealer) as Arc<dyn AeadSealerUnsealer>)]
+    sealer: Arc<dyn AeadSealerUnsealer>,
     /// The maximum age of a valid nonce. Defaults to 1 hour.
     #[builder(into, default = Duration::from_hours(1))]
     nonce_lifetime: Duration,
@@ -105,7 +106,7 @@ pub struct SealedTimestampNonce<S: AeadSealerSelector + AeadUnsealer> {
     aad: Vec<u8>,
 }
 
-impl<S: AeadSealerSelector + AeadUnsealer> SealedTimestampNonce<S> {
+impl SealedTimestampNonce {
     async fn generate_nonce(&self) -> Result<String, Error> {
         use base64::prelude::*;
         let current_time = SystemTime::now()
@@ -113,10 +114,8 @@ impl<S: AeadSealerSelector + AeadUnsealer> SealedTimestampNonce<S> {
             .map_err(|e| Error::new(crate::core::ErrorKind::DPoP, e))?
             .as_secs()
             .to_be_bytes();
-        // Select a frozen sealer for this nonce: whatever key seals it is the key
-        // named by any metadata read off the same snapshot, even under rotation.
-        let sealer = self.sealer.select_sealer().await;
-        let sealed_bytes = sealer.seal(&current_time, &self.aad).await?;
+        // `seal` freezes one key snapshot per nonce, even under rotation.
+        let sealed_bytes = self.sealer.seal(&current_time, &self.aad).await?;
         Ok(BASE64_URL_SAFE_NO_PAD.encode(sealed_bytes))
     }
 
@@ -138,7 +137,7 @@ impl<S: AeadSealerSelector + AeadUnsealer> SealedTimestampNonce<S> {
     }
 }
 
-impl<S: AeadSealerSelector + AeadUnsealer> DPoPNonceChecker for SealedTimestampNonce<S> {
+impl DPoPNonceChecker for SealedTimestampNonce {
     fn check_nonce<'a>(
         &'a self,
         nonce: Option<&'a str>,
@@ -171,16 +170,30 @@ mod tests {
     use crate::core::crypto::{
         KeyMatchStrength,
         cipher::{
-            AeadOutput, CipherMatch, DecryptError, SealedAeadCipherSelector, StaticAeadCipher,
+            AeadEncryptor, AeadOutput, AeadSealer as _, AeadV1Cipher, CipherMatch, DecryptError,
         },
     };
 
-    /// XOR "cipher" with both capabilities on one object — the shape a
-    /// symmetric key or KMS-backed cipher provides.
     #[derive(Debug)]
-    struct MockCipher;
+    struct MockEncryptor;
 
-    impl crate::core::crypto::cipher::AeadEncryptor for MockCipher {
+    /// XOR "cipher" with both capabilities on one object — the shape a
+    /// symmetric key or KMS-backed cipher provides: a selector handing out its
+    /// shared inner encryptor, plus a decryptor.
+    #[derive(Debug)]
+    struct MockCipher {
+        inner: Arc<MockEncryptor>,
+    }
+
+    impl MockCipher {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockEncryptor),
+            }
+        }
+    }
+
+    impl crate::core::crypto::cipher::AeadEncryptor for MockEncryptor {
         fn enc_algorithm(&self) -> Cow<'_, str> {
             "mock".into()
         }
@@ -204,6 +217,13 @@ mod tests {
         }
     }
 
+    impl crate::core::crypto::cipher::AeadEncryptorSelector for MockCipher {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
     impl crate::core::crypto::cipher::AeadDecryptor for MockCipher {
         fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
             Some(KeyMatchStrength::ByAlgorithm)
@@ -221,17 +241,14 @@ mod tests {
         }
     }
 
-    fn checker() -> SealedTimestampNonce<StaticAeadCipher<MockCipher>> {
+    fn checker() -> SealedTimestampNonce {
         SealedTimestampNonce::builder()
-            .sealer(StaticAeadCipher::new(MockCipher))
+            .sealer(AeadV1Cipher::new(MockCipher::new()))
             .build()
     }
 
     /// Forge a nonce whose sealed timestamp lies `age_secs` in the past.
-    async fn nonce_with_age(
-        checker: &SealedTimestampNonce<StaticAeadCipher<MockCipher>>,
-        age_secs: u64,
-    ) -> String {
+    async fn nonce_with_age(checker: &SealedTimestampNonce, age_secs: u64) -> String {
         let issued_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
@@ -239,8 +256,6 @@ mod tests {
             - age_secs;
         let sealed = checker
             .sealer
-            .select_sealer()
-            .await
             .seal(&issued_at.to_be_bytes(), &checker.aad)
             .await
             .unwrap();
@@ -285,17 +300,6 @@ mod tests {
         assert!(matches!(
             checker.check_nonce(Some(&aging)).await.unwrap(),
             NonceCheck::ValidWithNewNonce(_)
-        ));
-    }
-
-    /// The erased one-object form also satisfies the bound.
-    #[tokio::test]
-    async fn erased_sealed_cipher_constructs() {
-        let cipher: Arc<dyn SealedAeadCipherSelector> = Arc::new(StaticAeadCipher::new(MockCipher));
-        let checker = SealedTimestampNonce::builder().sealer(cipher).build();
-        assert!(matches!(
-            checker.check_nonce(None).await.unwrap(),
-            NonceCheck::Invalid(_)
         ));
     }
 }


### PR DESCRIPTION
This moves traits to harder to use incorrectly. Now the raw key types hand you a selector, and you only get the encryption ability after a key is selected.

On the sealing side, this is now divorced from the encryption/decryption traits, so they can be backed by other implementations (e.g. Tink-like sealing, or Vault).

BREAKING CHANGE: Crypto traits change in how they're invoked.

Fixes #224 