### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-native"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-webcrypto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64",
  "huskarl-core",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-redis"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bon",
  "hex",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-reqwest"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bon",
  "bytes",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-resource-server"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,14 @@ default-members = [
 exclude = ["huskarl-core/fuzz"]
 
 [workspace.dependencies]
-huskarl = { version = "0.9", path = "./huskarl" }
-huskarl-core = { version = "0.8", path = "./huskarl-core" }
+huskarl = { version = "0.10", path = "./huskarl" }
+huskarl-core = { version = "0.9", path = "./huskarl-core" }
 huskarl-macros = { version = "0.3", path = "./huskarl-macros" }
-huskarl-redis = { version = "0.1", path = "./huskarl-redis" }
-huskarl-reqwest = { version = "0.7", path = "./huskarl-reqwest" }
-huskarl-crypto-native = { version = "0.9", path = "./huskarl-crypto-native" }
-huskarl-crypto-webcrypto = { version = "0.9", path = "./huskarl-crypto-webcrypto" }
-huskarl-resource-server = { version = "0.9", path = "./huskarl-resource-server" }
+huskarl-redis = { version = "0.2", path = "./huskarl-redis" }
+huskarl-reqwest = { version = "0.8", path = "./huskarl-reqwest" }
+huskarl-crypto-native = { version = "0.10", path = "./huskarl-crypto-native" }
+huskarl-crypto-webcrypto = { version = "0.10", path = "./huskarl-crypto-webcrypto" }
+huskarl-resource-server = { version = "0.10", path = "./huskarl-resource-server" }
 
 bon = { version = "3.9", default-features = false, features = [
   "alloc",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.8.1...huskarl-core-v0.9.0) - 2026-07-19
+
+### Added
+
+- *(dpop)* [**breaking**] Support per-session DPoP keys via grant-level binding. ([#248](https://github.com/huskarl-rs/huskarl/pull/248))
+- *(core)* [**breaking**] Move server-side DPoP nonce checking into core ([#245](https://github.com/huskarl-rs/huskarl/pull/245))
+- *(crypto)* [**breaking**] Add back kid (optional string) for seal kid matching. ([#241](https://github.com/huskarl-rs/huskarl/pull/241))
+- *(core)* Add metrics decorator for encryption. ([#240](https://github.com/huskarl-rs/huskarl/pull/240))
+- *(crypto-native)* Add XChaCha20-Poly1305 AEAD cipher ([#238](https://github.com/huskarl-rs/huskarl/pull/238))
+- *(auth)* Loosen lifetime requirements of oauth2 form keys. ([#235](https://github.com/huskarl-rs/huskarl/pull/235))
+- *(crypto)* [**breaking**] Return diagnostic errors from AsymmetricPublicKey::from_jwk ([#234](https://github.com/huskarl-rs/huskarl/pull/234))
+- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))
+
+### Other
+
+- Add a few more references to XChaCha20-Poly1305. ([#246](https://github.com/huskarl-rs/huskarl/pull/246))
+- *(crypto)* Move base signer/verifier traits into the base module. ([#231](https://github.com/huskarl-rs/huskarl/pull/231))
+- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
+
 ## [0.8.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.8.0...huskarl-core-v0.8.1) - 2026-07-10
 
 ### Added

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-native/CHANGELOG.md
+++ b/huskarl-crypto-native/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.9.0...huskarl-crypto-native-v0.10.0) - 2026-07-19
+
+### Added
+
+- *(crypto-native)* Add alg-dispatching AEAD constructors ([#239](https://github.com/huskarl-rs/huskarl/pull/239))
+- *(crypto-native)* Add XChaCha20-Poly1305 AEAD cipher ([#238](https://github.com/huskarl-rs/huskarl/pull/238))
+- *(crypto)* [**breaking**] Return diagnostic errors from AsymmetricPublicKey::from_jwk ([#234](https://github.com/huskarl-rs/huskarl/pull/234))
+- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
+- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))
+
+### Other
+
+- Add a few more references to XChaCha20-Poly1305. ([#246](https://github.com/huskarl-rs/huskarl/pull/246))
+- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
+
 ## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.8.5...huskarl-crypto-native-v0.9.0) - 2026-07-08
 
 ### Added

--- a/huskarl-crypto-native/Cargo.toml
+++ b/huskarl-crypto-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-native"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Native crypto for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-webcrypto/CHANGELOG.md
+++ b/huskarl-crypto-webcrypto/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.9.0...huskarl-crypto-webcrypto-v0.10.0) - 2026-07-19
+
+### Added
+
+- *(crypto)* [**breaking**] Return diagnostic errors from AsymmetricPublicKey::from_jwk ([#234](https://github.com/huskarl-rs/huskarl/pull/234))
+- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
+- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))
+
+### Other
+
+- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
+
 ## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.8.0...huskarl-crypto-webcrypto-v0.9.0) - 2026-07-08
 
 ### Added

--- a/huskarl-crypto-webcrypto/Cargo.toml
+++ b/huskarl-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-webcrypto"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.92"
 description = "WebCrypto support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-redis/CHANGELOG.md
+++ b/huskarl-redis/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.1.1...huskarl-redis-v0.2.0) - 2026-07-19
+
+### Added
+
+- *(redis)* [**breaking**] Make key prefix mandatory to avoid accidental cross-context reuse. ([#242](https://github.com/huskarl-rs/huskarl/pull/242))
+
 ## [0.1.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.1.0...huskarl-redis-v0.1.1) - 2026-07-16
 
 ### Other

--- a/huskarl-redis/Cargo.toml
+++ b/huskarl-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-redis"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Redis-backed replay prevention for the huskarl (OAuth2) ecosystem."

--- a/huskarl-reqwest/CHANGELOG.md
+++ b/huskarl-reqwest/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-reqwest-v0.7.1...huskarl-reqwest-v0.8.0) - 2026-07-19
+
+### Added
+
+- *(reqwest)* [**breaking**] Rename MtlsApplyOutput as ConfiguredBuilder, make a builder. ([#243](https://github.com/huskarl-rs/huskarl/pull/243))
+
 ## [0.7.1] - 2026-06-30
 
 ### Changes

--- a/huskarl-reqwest/Cargo.toml
+++ b/huskarl-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-reqwest"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 description = "reqwest support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.9.1...huskarl-resource-server-v0.10.0) - 2026-07-19
+
+### Added
+
+- *(core)* [**breaking**] Move server-side DPoP nonce checking into core ([#245](https://github.com/huskarl-rs/huskarl/pull/245))
+- *(crypto)* [**breaking**] Add back kid (optional string) for seal kid matching. ([#241](https://github.com/huskarl-rs/huskarl/pull/241))
+- *(crypto-native)* Add XChaCha20-Poly1305 AEAD cipher ([#238](https://github.com/huskarl-rs/huskarl/pull/238))
+- *(resource-server)* [**breaking**] Make validator metrics a decorator. ([#232](https://github.com/huskarl-rs/huskarl/pull/232))
+- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
+- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))
+
+### Other
+
+- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
+
 ## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.9.0...huskarl-resource-server-v0.9.1) - 2026-07-10
 
 ### Fixed

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.92"
 description = "OAuth2 resource server (JWT validation) support for the huskarl ecosystem."

--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.2...huskarl-v0.10.0) - 2026-07-19
+
+### Added
+
+- *(dpop)* [**breaking**] Support per-session DPoP keys via grant-level binding. ([#248](https://github.com/huskarl-rs/huskarl/pull/248))
+- *(client)* [**breaking**] Require ID token when openid scope requested. ([#244](https://github.com/huskarl-rs/huskarl/pull/244))
+- *(client)* Add function to make client decision on DPoP nonce. ([#236](https://github.com/huskarl-rs/huskarl/pull/236))
+- *(client)* Extract callback query parsing into `CompleteInput`. ([#233](https://github.com/huskarl-rs/huskarl/pull/233))
+- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
+
+### Other
+
+- *(client)* Collapse dpop_nonce_action into a dpop_resend_advised predicate. ([#237](https://github.com/huskarl-rs/huskarl/pull/237))
+- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
+
 ## [0.9.2](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.1...huskarl-v0.9.2) - 2026-07-16
 
 ### Fixed

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.92"
 description = '''


### PR DESCRIPTION



## 🤖 New release

* `huskarl-core`: 0.8.1 -> 0.9.0 (⚠ API breaking changes)
* `huskarl-crypto-webcrypto`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `huskarl-crypto-native`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `huskarl`: 0.9.2 -> 0.10.0 (✓ API compatible changes)
* `huskarl-resource-server`: 0.9.1 -> 0.10.0 (⚠ API breaking changes)
* `huskarl-reqwest`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)
* `huskarl-redis`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `huskarl-core` breaking changes

```text
--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant CreateVerifierError::UnsupportedKey in /tmp/.tmpibzWPD/huskarl/huskarl-core/src/crypto/verifier/error.rs:54

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ValidatedJwtBuilder::issuer, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:16
  ValidatedJwtBuilder::maybe_issuer, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:16
  ValidatedJwtBuilder::subject, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:18
  ValidatedJwtBuilder::maybe_subject, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:18
  ValidatedJwtBuilder::audience, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:20
  ValidatedJwtBuilder::issued_at, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:24
  ValidatedJwtBuilder::maybe_issued_at, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:24
  ValidatedJwtBuilder::expiration, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:26
  ValidatedJwtBuilder::maybe_expiration, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:26
  JwtBuilder::issuer, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:41
  JwtBuilder::maybe_issuer, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:41
  JwtBuilder::subject, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:44
  JwtBuilder::maybe_subject, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:44
  JwtBuilder::audiences, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:47
  JwtBuilder::maybe_audiences, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:47
  JwtBuilder::issued_at, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:49
  JwtBuilder::maybe_issued_at, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:49
  JwtBuilder::expiration, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:51
  JwtBuilder::maybe_expiration, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:51
  JwtBuilder::not_before, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:53
  JwtBuilder::maybe_not_before, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:53

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl_core::crypto::cipher::StaticAeadCipher, previously in file /tmp/.tmpOknBxV/huskarl-core/src/crypto/cipher/mod.rs:593

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field issuer of struct ValidatedJwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:16
  field subject of struct ValidatedJwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:18
  field audience of struct ValidatedJwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:20
  field issued_at of struct ValidatedJwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:24
  field expiration of struct ValidatedJwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/validator/validated_jwt.rs:26
  field issuer of struct Jwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:41
  field subject of struct Jwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:44
  field audiences of struct Jwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:47
  field issued_at of struct Jwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:49
  field expiration of struct Jwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:51
  field not_before of struct Jwt, previously in file /tmp/.tmpOknBxV/huskarl-core/src/jwt/builder.rs:53

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait huskarl_core::crypto::cipher::SealedAeadCipher, previously in file /tmp/.tmpOknBxV/huskarl-core/src/crypto/cipher/mod.rs:243
  trait huskarl_core::crypto::cipher::SealedAeadCipherSelector, previously in file /tmp/.tmpOknBxV/huskarl-core/src/crypto/cipher/mod.rs:283
  trait huskarl_core::crypto::cipher::AeadCipherSelector, previously in file /tmp/.tmpOknBxV/huskarl-core/src/crypto/cipher/mod.rs:193
  trait huskarl_core::crypto::cipher::AeadSealerSelector, previously in file /tmp/.tmpOknBxV/huskarl-core/src/crypto/cipher/mod.rs:264

--- failure trait_removed_supertrait: supertrait removed or renamed ---

Description:
A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.
        ref: https://doc.rust-lang.org/reference/items/traits.html#supertraits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_removed_supertrait.ron

Failed in:
  supertrait huskarl_core::crypto::cipher::AeadDecryptor of trait AeadUnsealer in file /tmp/.tmpibzWPD/huskarl/huskarl-core/src/crypto/cipher/mod.rs:287
  supertrait huskarl_core::crypto::cipher::AeadEncryptor of trait AeadSealer in file /tmp/.tmpibzWPD/huskarl/huskarl-core/src/crypto/cipher/mod.rs:267
  supertrait huskarl_core::crypto::cipher::AeadEncryptor of trait AeadCipher in file /tmp/.tmpibzWPD/huskarl/huskarl-core/src/crypto/cipher/mod.rs:222
```

### ⚠ `huskarl-crypto-native` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum huskarl_crypto_native::aead::AesGcmError, previously in file /tmp/.tmpOknBxV/huskarl-crypto-native/src/aead.rs:184
```

### ⚠ `huskarl-resource-server` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ValidatedRequest.iss in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/mod.rs:105
  field ValidatedRequest.sub in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/mod.rs:107
  field ValidatedRequest.aud in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/mod.rs:109
  field ValidatedRequest.iat in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/mod.rs:113
  field ValidatedRequest.exp in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/mod.rs:115

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum huskarl_resource_server::validator::dpop_nonce::NonceCheck, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/dpop_nonce.rs:21

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ValidationOutcome::BindingError 4 -> 5 in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/observe.rs:48
  variant ValidationOutcome::CallError 5 -> 7 in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/observe.rs:59

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field issuer of variant MultiIssuerError::Validation in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/multi_issuer/error.rs:48
  field issuer of variant MultiIssuerError::Validation in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/multi_issuer/error.rs:48

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant MultiIssuerError::UnrecognizedIssuer in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/multi_issuer/error.rs:37
  variant MultiIssuerError::UnrecognizedIssuer in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/multi_issuer/error.rs:37

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Rfc9068ValidatorBuilder::on_validate, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/rfc9068/mod.rs:152
  Rfc9068ValidatorBuilder::maybe_on_validate, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/rfc9068/mod.rs:152
  IntrospectionValidatorBuilder::audience, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/introspection/mod.rs:122
  IntrospectionValidatorBuilder::on_validate, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/introspection/mod.rs:209
  IntrospectionValidatorBuilder::maybe_on_validate, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/introspection/mod.rs:209
  CustomValidatorBuilder::on_validate, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:146
  CustomValidatorBuilder::maybe_on_validate, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:146
  CustomValidatorBuilder::token_type, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:236
  CustomValidatorBuilder::issuer, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:242
  CustomValidatorBuilder::audience, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:248
  CustomValidatorBuilder::subject, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:266

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  huskarl_resource_server::validator::custom::CustomValidator::new takes 18 parameters in /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/custom/mod.rs:71, but now takes 17 parameters in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/custom/mod.rs:69
  huskarl_resource_server::validator::introspection::IntrospectionValidator::new takes 22 parameters in /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/introspection/mod.rs:92, but now takes 21 parameters in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/introspection/mod.rs:90
  huskarl_resource_server::validator::rfc9068::Rfc9068Validator::new takes 18 parameters in /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/rfc9068/mod.rs:76, but now takes 17 parameters in /tmp/.tmpibzWPD/huskarl/huskarl-resource-server/src/validator/rfc9068/mod.rs:74

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod huskarl_resource_server::validator::dpop_nonce, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/dpop_nonce.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl_resource_server::validator::dpop_nonce::SealedTimestampNonce, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/dpop_nonce.rs:83
  struct huskarl_resource_server::validator::dpop_nonce::SealedTimestampNonceBuilder, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/dpop_nonce.rs:82

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field issuer of struct ValidatedRequest, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/mod.rs:105
  field subject of struct ValidatedRequest, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/mod.rs:107
  field audience of struct ValidatedRequest, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/mod.rs:109
  field issued_at of struct ValidatedRequest, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/mod.rs:113
  field expiration of struct ValidatedRequest, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/mod.rs:115

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait huskarl_resource_server::validator::dpop_nonce::DPoPNonceChecker, previously in file /tmp/.tmpOknBxV/huskarl-resource-server/src/validator/dpop_nonce.rs:39
```

### ⚠ `huskarl-reqwest` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct huskarl_reqwest::mtls::MtlsApplyOutput, previously in file /tmp/.tmpOknBxV/huskarl-reqwest/src/mtls.rs:21
```

### ⚠ `huskarl-redis` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  RedisJtiUniquenessCheckerBuilder::maybe_key_prefix, previously in file /tmp/.tmpOknBxV/huskarl-redis/src/jti.rs:39
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl-core`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.8.1...huskarl-core-v0.9.0) - 2026-07-19

### Added

- *(dpop)* [**breaking**] Support per-session DPoP keys via grant-level binding. ([#248](https://github.com/huskarl-rs/huskarl/pull/248))
- *(core)* [**breaking**] Move server-side DPoP nonce checking into core ([#245](https://github.com/huskarl-rs/huskarl/pull/245))
- *(crypto)* [**breaking**] Add back kid (optional string) for seal kid matching. ([#241](https://github.com/huskarl-rs/huskarl/pull/241))
- *(core)* Add metrics decorator for encryption. ([#240](https://github.com/huskarl-rs/huskarl/pull/240))
- *(crypto-native)* Add XChaCha20-Poly1305 AEAD cipher ([#238](https://github.com/huskarl-rs/huskarl/pull/238))
- *(auth)* Loosen lifetime requirements of oauth2 form keys. ([#235](https://github.com/huskarl-rs/huskarl/pull/235))
- *(crypto)* [**breaking**] Return diagnostic errors from AsymmetricPublicKey::from_jwk ([#234](https://github.com/huskarl-rs/huskarl/pull/234))
- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))

### Other

- Add a few more references to XChaCha20-Poly1305. ([#246](https://github.com/huskarl-rs/huskarl/pull/246))
- *(crypto)* Move base signer/verifier traits into the base module. ([#231](https://github.com/huskarl-rs/huskarl/pull/231))
- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
</blockquote>

## `huskarl-crypto-webcrypto`

<blockquote>

## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.9.0...huskarl-crypto-webcrypto-v0.10.0) - 2026-07-19

### Added

- *(crypto)* [**breaking**] Return diagnostic errors from AsymmetricPublicKey::from_jwk ([#234](https://github.com/huskarl-rs/huskarl/pull/234))
- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))

### Other

- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
</blockquote>

## `huskarl-crypto-native`

<blockquote>

## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.9.0...huskarl-crypto-native-v0.10.0) - 2026-07-19

### Added

- *(crypto-native)* Add alg-dispatching AEAD constructors ([#239](https://github.com/huskarl-rs/huskarl/pull/239))
- *(crypto-native)* Add XChaCha20-Poly1305 AEAD cipher ([#238](https://github.com/huskarl-rs/huskarl/pull/238))
- *(crypto)* [**breaking**] Return diagnostic errors from AsymmetricPublicKey::from_jwk ([#234](https://github.com/huskarl-rs/huskarl/pull/234))
- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))

### Other

- Add a few more references to XChaCha20-Poly1305. ([#246](https://github.com/huskarl-rs/huskarl/pull/246))
- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
</blockquote>

## `huskarl`

<blockquote>

## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.2...huskarl-v0.10.0) - 2026-07-19

### Added

- *(dpop)* [**breaking**] Support per-session DPoP keys via grant-level binding. ([#248](https://github.com/huskarl-rs/huskarl/pull/248))
- *(client)* [**breaking**] Require ID token when openid scope requested. ([#244](https://github.com/huskarl-rs/huskarl/pull/244))
- *(client)* Add function to make client decision on DPoP nonce. ([#236](https://github.com/huskarl-rs/huskarl/pull/236))
- *(client)* Extract callback query parsing into `CompleteInput`. ([#233](https://github.com/huskarl-rs/huskarl/pull/233))
- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))

### Other

- *(client)* Collapse dpop_nonce_action into a dpop_resend_advised predicate. ([#237](https://github.com/huskarl-rs/huskarl/pull/237))
- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
</blockquote>

## `huskarl-resource-server`

<blockquote>

## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.9.1...huskarl-resource-server-v0.10.0) - 2026-07-19

### Added

- *(core)* [**breaking**] Move server-side DPoP nonce checking into core ([#245](https://github.com/huskarl-rs/huskarl/pull/245))
- *(crypto)* [**breaking**] Add back kid (optional string) for seal kid matching. ([#241](https://github.com/huskarl-rs/huskarl/pull/241))
- *(crypto-native)* Add XChaCha20-Poly1305 AEAD cipher ([#238](https://github.com/huskarl-rs/huskarl/pull/238))
- *(resource-server)* [**breaking**] Make validator metrics a decorator. ([#232](https://github.com/huskarl-rs/huskarl/pull/232))
- *(crypto)* [**breaking**] Separate selectors from signers for JWS signers ([#229](https://github.com/huskarl-rs/huskarl/pull/229))
- *(crypto)* [**breaking**] Implement selector for AES-GCM key, split off sealing traits. ([#225](https://github.com/huskarl-rs/huskarl/pull/225))

### Other

- *(jwt)* [**breaking**] Unify claim naming on serialized name, builders and struct fields. ([#230](https://github.com/huskarl-rs/huskarl/pull/230))
</blockquote>

## `huskarl-reqwest`

<blockquote>

## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-reqwest-v0.7.1...huskarl-reqwest-v0.8.0) - 2026-07-19

### Added

- *(reqwest)* [**breaking**] Rename MtlsApplyOutput as ConfiguredBuilder, make a builder. ([#243](https://github.com/huskarl-rs/huskarl/pull/243))
</blockquote>

## `huskarl-redis`

<blockquote>

## [0.2.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.1.1...huskarl-redis-v0.2.0) - 2026-07-19

### Added

- *(redis)* [**breaking**] Make key prefix mandatory to avoid accidental cross-context reuse. ([#242](https://github.com/huskarl-rs/huskarl/pull/242))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).