### PR TITLE
feat(crypto)!: Separate selectors from signers for JWS signers

### DIFF
--- a/huskarl-crypto-native/src/asymmetric/signer.rs
+++ b/huskarl-crypto-native/src/asymmetric/signer.rs
@@ -22,6 +22,8 @@ use rand::Rng;
 use rsa::traits::PublicKeyParts as _;
 use signature::{SignatureEncoding, Signer as _};
 
+/// The shared key material behind a `PrivateKey` — the signer snapshot the
+/// selectors hand out.
 #[derive(Debug)]
 struct PrivateKeyInner {
     signing_key: Key,
@@ -32,7 +34,8 @@ struct PrivateKeyInner {
 }
 
 /// An asymmetric private key for JWS signing (ES256/384, RS/PS 256/384/512,
-/// Ed25519), implementing [`JwsSigner`] and [`AsymmetricJwsSigner`].
+/// Ed25519): a [`JwsSignerSelector`] / [`AsymmetricJwsSignerSelector`] whose
+/// selection hands out the key's shared inner [`JwsSigner`].
 ///
 /// Generate one with [`generate`](Self::generate), or load one with
 /// [`from_jwk`](Self::from_jwk) or [`from_secret`](Self::from_secret) (composing
@@ -781,40 +784,40 @@ impl SecretMap for Pkcs8Pem {
 
 impl JwsSignerSelector for PrivateKey {
     fn select_signer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn JwsSigner>> {
-        let signer: Arc<dyn JwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { signer })
+        let snapshot: Arc<dyn JwsSigner> = self.inner.clone();
+        Box::pin(async move { snapshot })
     }
 }
 
 impl AsymmetricJwsSignerSelector for PrivateKey {
     fn select_asymmetric_signer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AsymmetricJwsSigner>> {
-        let signer: Arc<dyn AsymmetricJwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { signer })
+        let snapshot: Arc<dyn AsymmetricJwsSigner> = self.inner.clone();
+        Box::pin(async move { snapshot })
     }
 
     fn select_signer_by_thumbprint<'a>(
         &'a self,
         thumbprint: &'a str,
     ) -> MaybeSendBoxFuture<'a, Option<Arc<dyn AsymmetricJwsSigner>>> {
-        let matches = self.inner.thumbprint == thumbprint;
-        let signer: Arc<dyn AsymmetricJwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { matches.then_some(signer) })
+        let snapshot = (self.inner.thumbprint == thumbprint)
+            .then(|| self.inner.clone() as Arc<dyn AsymmetricJwsSigner>);
+        Box::pin(async move { snapshot })
     }
 }
 
-impl AsymmetricJwsSigner for PrivateKey {
+impl AsymmetricJwsSigner for PrivateKeyInner {
     fn public_key_jwk(&self) -> Cow<'_, jwk::PublicJwk> {
-        Cow::Borrowed(&self.inner.jwk)
+        Cow::Borrowed(&self.jwk)
     }
 }
 
-impl JwsSigner for PrivateKey {
+impl JwsSigner for PrivateKeyInner {
     fn jws_algorithm(&self) -> Cow<'_, str> {
-        Cow::Borrowed(self.inner.signing_key.jws_algorithm())
+        Cow::Borrowed(self.signing_key.jws_algorithm())
     }
 
     fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.inner.jwk.kid.as_deref().map(Cow::Borrowed)
+        self.jwk.kid.as_deref().map(Cow::Borrowed)
     }
 
     fn sign<'a>(&'a self, input: &'a [u8]) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
@@ -827,7 +830,7 @@ impl JwsSigner for PrivateKey {
         }
 
         Box::pin(async move {
-            match &self.inner.signing_key {
+            match &self.signing_key {
                 Key::Es256(signing_key) => {
                     let signature: p256::ecdsa::Signature =
                         signing_key.try_sign(input).map_err(crypto_error)?;
@@ -880,7 +883,6 @@ mod tests {
 
     #[tokio::test]
     async fn pkcs8_der_yields_a_complete_signing_jwk_with_the_requested_kid() {
-        use huskarl_core::crypto::signer::{AsymmetricJwsSigner as _, JwsSigner as _};
         use p256::{ecdsa::signature::Verifier as _, elliptic_curve::Generate as _};
         use pkcs8::EncodePrivateKey as _;
 
@@ -897,21 +899,21 @@ mod tests {
         // It finalizes into a usable signer whose published kid can't diverge
         // from key_id() — single source of truth.
         let key = PrivateKey::from_jwk(private_jwk).unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("key-1"));
-        assert_eq!(key.public_key_jwk().kid.as_deref(), Some("key-1"));
+        let signer = key.select_asymmetric_signer().await;
+        assert_eq!(signer.key_id().as_deref(), Some("key-1"));
+        assert_eq!(signer.public_key_jwk().kid.as_deref(), Some("key-1"));
 
         // Gold standard: a signature from the converted key verifies under the
         // ORIGINAL key's public half, proving the DER round-tripped to the same
         // private material.
-        let signature_bytes = key.sign(b"payload").await.unwrap();
+        let signature_bytes = signer.sign(b"payload").await.unwrap();
         let signature = p256::ecdsa::Signature::from_slice(&signature_bytes).unwrap();
         let verifying_key = p256::ecdsa::VerifyingKey::from(&source);
         verifying_key.verify(b"payload", &signature).unwrap();
     }
 
-    #[test]
-    fn pkcs8_der_carries_the_fully_specified_ed25519_algorithm_into_the_jwk() {
-        use huskarl_core::crypto::signer::JwsSigner as _;
+    #[tokio::test]
+    async fn pkcs8_der_carries_the_fully_specified_ed25519_algorithm_into_the_jwk() {
         use pkcs8::EncodePrivateKey as _;
         use rand::Rng as _;
 
@@ -927,7 +929,10 @@ mod tests {
         assert_eq!(jwk.algorithm.as_deref(), Some("Ed25519"));
 
         let key = PrivateKey::from_jwk(jwk).unwrap();
-        assert_eq!(key.jws_algorithm().as_ref(), "Ed25519");
+        assert_eq!(
+            key.select_signer().await.jws_algorithm().as_ref(),
+            "Ed25519"
+        );
 
         // And the classic spelling survives the same trip.
         let classic = pkcs8_der(der.as_bytes(), AsymmetricAlgorithm::EdDsa, None).unwrap();
@@ -936,10 +941,7 @@ mod tests {
 
     #[tokio::test]
     async fn from_secret_fills_kid_from_identity_then_prefers_an_explicit_jwk_kid() {
-        use huskarl_core::{
-            crypto::signer::JwsSigner as _,
-            secrets::{ProvidedSecret, Secret as _, SecretBytes, WithIdentity},
-        };
+        use huskarl_core::secrets::{ProvidedSecret, Secret as _, SecretBytes, WithIdentity};
         use p256::elliptic_curve::Generate as _;
         use pkcs8::EncodePrivateKey as _;
 
@@ -953,19 +955,20 @@ mod tests {
         )
         .mapped(Pkcs8Der::new(AsymmetricAlgorithm::Es256));
         let key = PrivateKey::from_secret(secret).await.unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("version-42"));
+        let signer = key.select_signer().await;
+        assert_eq!(signer.key_id().as_deref(), Some("version-42"));
 
         // An explicit kid stamped onto the JWK wins over the identity.
         let secret = WithIdentity::new(ProvidedSecret::new(SecretBytes::new(der)), "version-42")
             .mapped(Pkcs8Der::new(AsymmetricAlgorithm::Es256).with_kid("explicit"));
         let key = PrivateKey::from_secret(secret).await.unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("explicit"));
+        let signer = key.select_signer().await;
+        assert_eq!(signer.key_id().as_deref(), Some("explicit"));
     }
 
     #[tokio::test]
     async fn from_secret_loads_a_jwk_json_secret_with_no_alg_or_kid_arguments() {
         use huskarl_core::{
-            crypto::signer::JwsSigner as _,
             jwk::JwkJson,
             secrets::{ProvidedSecret, Secret as _, SecretString},
         };
@@ -985,8 +988,9 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(key.key_id().as_deref(), Some("in-the-jwk"));
-        assert_eq!(key.jws_algorithm().as_ref(), "ES256");
+        let signer = key.select_signer().await;
+        assert_eq!(signer.key_id().as_deref(), Some("in-the-jwk"));
+        assert_eq!(signer.jws_algorithm().as_ref(), "ES256");
     }
 
     #[test]
@@ -1037,7 +1041,12 @@ mod tests {
             }),
         };
 
-        let error = key.sign(b"payload").await.unwrap_err();
+        let error = key
+            .select_signer()
+            .await
+            .sign(b"payload")
+            .await
+            .unwrap_err();
         assert_eq!(error.kind(), ErrorKind::Crypto);
     }
 

--- a/huskarl-crypto-native/src/asymmetric/verifier.rs
+++ b/huskarl-crypto-native/src/asymmetric/verifier.rs
@@ -310,6 +310,7 @@ mod tests {
         Error,
         crypto::signer::{
             AsymmetricJwsSigner as _, AsymmetricJwsSignerSelector as _, JwsSigner as _,
+            JwsSignerSelector as _,
         },
         jwt::{
             Jwt,
@@ -692,8 +693,8 @@ mod tests {
 
         // Both keys should produce identical signatures (ES256 uses RFC 6979)
         let data = b"cross-construction test payload";
-        let sig_pkcs8 = pkcs8_key.sign(data).await.unwrap();
-        let sig_jwk = jwk_key.sign(data).await.unwrap();
+        let sig_pkcs8 = pkcs8_key.select_signer().await.sign(data).await.unwrap();
+        let sig_jwk = jwk_key.select_signer().await.sign(data).await.unwrap();
         assert_eq!(
             sig_pkcs8, sig_jwk,
             "PKCS#8-loaded and JWK-restored keys must produce identical signatures"
@@ -765,8 +766,8 @@ mod tests {
         let restored = PrivateKey::from_jwk(private_jwk).unwrap();
 
         let data = b"deterministic signature test payload";
-        let sig_original = original.sign(data).await.unwrap();
-        let sig_restored = restored.sign(data).await.unwrap();
+        let sig_original = original.select_signer().await.sign(data).await.unwrap();
+        let sig_restored = restored.select_signer().await.sign(data).await.unwrap();
 
         assert_eq!(
             sig_original, sig_restored,
@@ -860,7 +861,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let verifier = AsymmetricPublicKey::from_jwk(rsa.public_key_jwk().into_owned()).unwrap();
+        let verifier = AsymmetricPublicKey::from_jwk(rsa.as_private_jwk().public_jwk()).unwrap();
 
         // RS256→HS256 confusion is prevented at key selection: an RSA key
         // advertises only RSA algorithms, so a token claiming `alg: HS256` finds
@@ -894,7 +895,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let rsa_pub_jwk = rsa.public_key_jwk().into_owned();
+        let rsa_pub_jwk = rsa.as_private_jwk().public_jwk();
         let verifier = AsymmetricPublicKey::from_jwk(rsa_pub_jwk.clone()).unwrap();
         let validator = JwtValidator::builder().verifier(verifier).build();
 

--- a/huskarl-crypto-native/src/symmetric.rs
+++ b/huskarl-crypto-native/src/symmetric.rs
@@ -47,6 +47,8 @@ impl SymmetricAlgorithm {
     }
 }
 
+/// The shared key material behind a `SymmetricKey` — the signer snapshot
+/// `select_signer` hands out.
 #[derive(Debug)]
 struct SymmetricKeyInner {
     key: SecretBytes,
@@ -56,9 +58,10 @@ struct SymmetricKeyInner {
 
 /// An HMAC symmetric key (HS256/384/512), used to both sign and verify JWS.
 ///
-/// Implements huskarl-core's [`JwsSigner`], [`JwsVerifier`], and
-/// [`JwsSignerSelector`]. Build one with [`from_jwk`](Self::from_jwk) or
-/// [`from_secret`](Self::from_secret); cheap to clone (`Arc`-backed).
+/// Implements huskarl-core's [`JwsSignerSelector`] (selection hands out the
+/// key's shared inner [`JwsSigner`]) and [`JwsVerifier`]. Build one with
+/// [`from_jwk`](Self::from_jwk) or [`from_secret`](Self::from_secret); cheap
+/// to clone (`Arc`-backed).
 #[derive(Debug, Clone)]
 pub struct SymmetricKey {
     inner: Arc<SymmetricKeyInner>,
@@ -148,13 +151,15 @@ impl SymmetricKey {
         let jwk = output.value.with_kid_fallback(output.identity);
         Self::from_jwk(jwk.try_into()?)
     }
+}
 
+impl SymmetricKeyInner {
     // `Hmac::new_from_slice` accepts a key of any length, so it never errors.
     #[allow(clippy::expect_used)]
     fn hmac(&self, input: &[u8]) -> Vec<u8> {
-        let key_bytes = self.inner.key.expose_secret();
+        let key_bytes = self.key.expose_secret();
 
-        match self.inner.algorithm {
+        match self.algorithm {
             SymmetricAlgorithm::Hs256 => {
                 let mut key: Hmac<sha2::Sha256> = Hmac::new_from_slice(key_bytes)
                     .expect("Key length checked at construction time");
@@ -179,18 +184,33 @@ impl SymmetricKey {
 
 impl JwsSignerSelector for SymmetricKey {
     fn select_signer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn JwsSigner>> {
-        let signer: Arc<dyn JwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { signer })
+        let snapshot: Arc<dyn JwsSigner> = self.inner.clone();
+        Box::pin(async move { snapshot })
     }
 }
 
-impl JwsSigner for SymmetricKey {
+impl JwsVerifier for SymmetricKey {
+    fn key_match(&self, key_match: &KeyMatch<'_>) -> Option<KeyMatchStrength> {
+        self.inner.key_match(key_match)
+    }
+
+    fn verify<'a>(
+        &'a self,
+        input: &'a [u8],
+        signature: &'a [u8],
+        key_match: &'a KeyMatch<'a>,
+    ) -> MaybeSendBoxFuture<'a, Result<(), VerifyError>> {
+        self.inner.verify(input, signature, key_match)
+    }
+}
+
+impl JwsSigner for SymmetricKeyInner {
     fn jws_algorithm(&self) -> Cow<'_, str> {
-        Cow::Borrowed(self.inner.algorithm.as_ref())
+        Cow::Borrowed(self.algorithm.as_ref())
     }
 
     fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.inner.key_id.as_deref().map(Cow::Borrowed)
+        self.key_id.as_deref().map(Cow::Borrowed)
     }
 
     fn sign<'a>(&'a self, input: &'a [u8]) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
@@ -198,12 +218,9 @@ impl JwsSigner for SymmetricKey {
     }
 }
 
-impl JwsVerifier for SymmetricKey {
+impl JwsVerifier for SymmetricKeyInner {
     fn key_match(&self, key_match: &KeyMatch<'_>) -> Option<KeyMatchStrength> {
-        key_match.strength_for(
-            &[self.inner.algorithm.as_ref()],
-            self.inner.key_id.as_deref(),
-        )
+        key_match.strength_for(&[self.algorithm.as_ref()], self.key_id.as_deref())
     }
 
     fn verify<'a>(
@@ -255,7 +272,7 @@ mod tests {
         let key = SymmetricKey::from_jwk(jwk).unwrap();
 
         let data = b"hello world";
-        let signature = key.sign(data).await.unwrap();
+        let signature = key.select_signer().await.sign(data).await.unwrap();
 
         let key_match = KeyMatch::builder().alg(algorithm).kid("sym-key-1").build();
         key.verify(data, &signature, &key_match).await.unwrap();
@@ -333,7 +350,10 @@ mod tests {
             .decode("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
             .unwrap();
 
-        assert_eq!(key.sign(input).await.unwrap(), expected);
+        assert_eq!(
+            key.select_signer().await.sign(input).await.unwrap(),
+            expected
+        );
 
         let key_match = KeyMatch::builder().alg("HS256").build();
         key.verify(input, &expected, &key_match).await.unwrap();
@@ -349,8 +369,9 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("sym-1"));
-        assert_eq!(key.jws_algorithm().as_ref(), "HS256");
+        let signer = key.select_signer().await;
+        assert_eq!(signer.key_id().as_deref(), Some("sym-1"));
+        assert_eq!(signer.jws_algorithm().as_ref(), "HS256");
     }
 
     #[tokio::test]
@@ -362,7 +383,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("env-key"));
+        assert_eq!(
+            key.select_signer().await.key_id().as_deref(),
+            Some("env-key")
+        );
     }
 
     #[tokio::test]
@@ -397,8 +421,8 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::Config);
     }
 
-    #[test]
-    fn oct_jwk_from_wire_yields_symmetric_variant() {
+    #[tokio::test]
+    async fn oct_jwk_from_wire_yields_symmetric_variant() {
         // The Jwk -> PrivateJwk -> SymmetricJwk path a JWKS consumer takes.
         let jwk = huskarl_core::jwk::Jwk::builder()
             .key(jwk::OctKey::builder().k(vec![1u8; 32]).build())
@@ -407,6 +431,9 @@ mod tests {
             .build();
         let private: jwk::SymmetricJwk = jwk.private_jwk().unwrap().try_into().unwrap();
         let key = SymmetricKey::from_jwk(private).unwrap();
-        assert_eq!(key.key_id().as_deref(), Some("from-set"));
+        assert_eq!(
+            key.select_signer().await.key_id().as_deref(),
+            Some("from-set")
+        );
     }
 }

--- a/huskarl-crypto-webcrypto/docs/guide/signing_a_jwt.md
+++ b/huskarl-crypto-webcrypto/docs/guide/signing_a_jwt.md
@@ -6,11 +6,11 @@ with `huskarl-core`'s [`Jwt`](huskarl_core::jwt::Jwt) builder. Every crypto call
 is `async`, and the key never leaves `SubtleCrypto`:
 
 ```rust,no_run
-use huskarl_core::jwt::Jwt;
+use huskarl_core::{crypto::signer::JwsSignerSelector as _, jwt::Jwt};
 use huskarl_crypto_webcrypto::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
 
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-let signer = PrivateKey::generate(GenerateAlgorithm::Es256, Some("key-1".to_string())).await?;
+let key = PrivateKey::generate(GenerateAlgorithm::Es256, Some("key-1".to_string())).await?;
 
 let jwt = Jwt::builder()
     .issuer("https://issuer.example")
@@ -19,8 +19,8 @@ let jwt = Jwt::builder()
     .claims(serde_json::json!({ "scope": "read write" }))
     .build();
 
-// A compact JWS string, ready for the wire.
-let compact = jwt.to_jws_compact(&signer).await?;
+// Select the signer snapshot, then produce a compact JWS string.
+let compact = jwt.to_jws_compact(&*key.select_signer().await).await?;
 # let _ = compact;
 # Ok(())
 # }

--- a/huskarl-crypto-webcrypto/src/asymmetric/signer.rs
+++ b/huskarl-crypto-webcrypto/src/asymmetric/signer.rs
@@ -41,6 +41,8 @@ use crate::{
     },
 };
 
+/// The shared key handle behind a `PrivateKey` — the signer snapshot the
+/// selectors hand out.
 #[derive(Debug)]
 struct PrivateKeyInner {
     crypto_key: CryptoKey,
@@ -49,8 +51,9 @@ struct PrivateKeyInner {
 }
 
 /// A non-exportable asymmetric private key used to create JWS signatures
-/// (ES256/384, RS/PS 256/384/512, Ed25519), implementing [`JwsSigner`] and
-/// [`AsymmetricJwsSigner`].
+/// (ES256/384, RS/PS 256/384/512, Ed25519): a [`JwsSignerSelector`] /
+/// [`AsymmetricJwsSignerSelector`] whose selection hands out the key's shared
+/// inner [`JwsSigner`].
 ///
 /// Generate one with [`generate`](Self::generate). Keys are not extractable by
 /// JavaScript; the handle is cheap to clone (`Arc`-backed).
@@ -306,40 +309,40 @@ impl From<SignError> for Error {
 
 impl JwsSignerSelector for PrivateKey {
     fn select_signer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn JwsSigner>> {
-        let signer: Arc<dyn JwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { signer })
+        let snapshot: Arc<dyn JwsSigner> = self.inner.clone();
+        Box::pin(async move { snapshot })
     }
 }
 
 impl AsymmetricJwsSignerSelector for PrivateKey {
     fn select_asymmetric_signer(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AsymmetricJwsSigner>> {
-        let signer: Arc<dyn AsymmetricJwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { signer })
+        let snapshot: Arc<dyn AsymmetricJwsSigner> = self.inner.clone();
+        Box::pin(async move { snapshot })
     }
 
     fn select_signer_by_thumbprint<'a>(
         &'a self,
         thumbprint: &'a str,
     ) -> MaybeSendBoxFuture<'a, Option<Arc<dyn AsymmetricJwsSigner>>> {
-        let matches = self.inner.public_jwk.thumbprint() == thumbprint;
-        let signer: Arc<dyn AsymmetricJwsSigner> = Arc::new(self.clone());
-        Box::pin(async move { matches.then_some(signer) })
+        let snapshot = (self.inner.public_jwk.thumbprint() == thumbprint)
+            .then(|| self.inner.clone() as Arc<dyn AsymmetricJwsSigner>);
+        Box::pin(async move { snapshot })
     }
 }
 
-impl AsymmetricJwsSigner for PrivateKey {
+impl AsymmetricJwsSigner for PrivateKeyInner {
     fn public_key_jwk(&self) -> Cow<'_, huskarl_core::jwk::PublicJwk> {
-        Cow::Borrowed(&self.inner.public_jwk)
+        Cow::Borrowed(&self.public_jwk)
     }
 }
 
-impl JwsSigner for PrivateKey {
+impl JwsSigner for PrivateKeyInner {
     fn jws_algorithm(&self) -> Cow<'_, str> {
-        Cow::Borrowed(self.inner.algorithm.name())
+        Cow::Borrowed(self.algorithm.name())
     }
 
     fn key_id(&self) -> Option<Cow<'_, str>> {
-        self.inner.public_jwk.kid.clone().map(Cow::Owned)
+        self.public_jwk.kid.clone().map(Cow::Owned)
     }
 
     fn sign<'a>(&'a self, input: &'a [u8]) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
@@ -348,8 +351,8 @@ impl JwsSigner for PrivateKey {
 
             Ok(sign_with_key(
                 &crypto.subtle(),
-                self.inner.algorithm.sign_algorithm(),
-                &self.inner.crypto_key,
+                self.algorithm.sign_algorithm(),
+                &self.crypto_key,
                 input,
             )
             .await

--- a/huskarl-crypto-webcrypto/src/asymmetric/verifier.rs
+++ b/huskarl-crypto-webcrypto/src/asymmetric/verifier.rs
@@ -432,7 +432,7 @@ impl JwsVerifier for AsymmetricPublicKey {
 #[cfg(test)]
 mod tests {
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-    use huskarl_core::crypto::signer::{AsymmetricJwsSigner, JwsSigner};
+    use huskarl_core::crypto::signer::{AsymmetricJwsSignerSelector as _, JwsSignerSelector as _};
     use wasm_bindgen_test::*;
 
     use super::*;
@@ -449,8 +449,12 @@ mod tests {
     /// The exported `key_ops`/`use` are left untouched: the generated key is
     /// verification-capable (see `exported_public_jwk_is_verification_capable`),
     /// so `from_jwk` accepts it unmodified.
-    fn verification_jwk(signer: &PrivateKey, alg: Option<&str>) -> jwk::PublicJwk {
-        let mut jwk = signer.public_key_jwk().into_owned();
+    async fn verification_jwk(signer: &PrivateKey, alg: Option<&str>) -> jwk::PublicJwk {
+        let mut jwk = signer
+            .select_asymmetric_signer()
+            .await
+            .public_key_jwk()
+            .into_owned();
         jwk.algorithm = alg.map(str::to_string);
         jwk
     }
@@ -464,7 +468,11 @@ mod tests {
         let signer = PrivateKey::generate(GenerateAlgorithm::Es256, None)
             .await
             .unwrap();
-        let jwk = signer.public_key_jwk().into_owned();
+        let jwk = signer
+            .select_asymmetric_signer()
+            .await
+            .public_key_jwk()
+            .into_owned();
 
         assert!(
             jwk.key_operations
@@ -488,14 +496,14 @@ mod tests {
         let signer = PrivateKey::generate(GenerateAlgorithm::Es256, None)
             .await
             .unwrap();
-        let mut jwk = verification_jwk(&signer, Some("ES256"));
+        let mut jwk = verification_jwk(&signer, Some("ES256")).await;
         jwk.kid = Some("key-a".to_string());
         let verifier = AsymmetricPublicKey::from_jwk(jwk)
             .await
             .expect("from_jwk should import the generated key");
 
         let input = b"kid mismatch input";
-        let signature = signer.sign(input).await.unwrap();
+        let signature = signer.select_signer().await.sign(input).await.unwrap();
         let key_match = KeyMatch::builder().alg("ES256").kid("key-b").build();
 
         let outcome = verifier.verify(input, &signature, &key_match).await;
@@ -509,12 +517,13 @@ mod tests {
     /// a real signature round-trips. Mirrors native's `roundtrip_jwk` helper.
     async fn roundtrip(algorithm: GenerateAlgorithm, jws_alg: &str) {
         let signer = PrivateKey::generate(algorithm, None).await.unwrap();
-        let verifier = AsymmetricPublicKey::from_jwk(verification_jwk(&signer, Some(jws_alg)))
-            .await
-            .expect("from_jwk should import the generated key");
+        let verifier =
+            AsymmetricPublicKey::from_jwk(verification_jwk(&signer, Some(jws_alg)).await)
+                .await
+                .expect("from_jwk should import the generated key");
 
         let input = b"webcrypto asymmetric roundtrip input";
-        let signature = signer.sign(input).await.unwrap();
+        let signature = signer.select_signer().await.sign(input).await.unwrap();
         let key_match = KeyMatch::builder().alg(jws_alg).build();
 
         let outcome = verifier.verify(input, &signature, &key_match).await;
@@ -623,7 +632,7 @@ mod tests {
         .await
         .unwrap();
 
-        let verifier = AsymmetricPublicKey::from_jwk(verification_jwk(&signer, None))
+        let verifier = AsymmetricPublicKey::from_jwk(verification_jwk(&signer, None).await)
             .await
             .expect("alg-less RSA JWK should import");
 
@@ -638,7 +647,7 @@ mod tests {
 
         // The same key really verifies a signature it produced (RS256 here).
         let input = b"alg-less rsa input";
-        let signature = signer.sign(input).await.unwrap();
+        let signature = signer.select_signer().await.sign(input).await.unwrap();
         verifier
             .verify(input, &signature, &KeyMatch::builder().alg("RS256").build())
             .await
@@ -712,7 +721,7 @@ mod tests {
         let signer = PrivateKey::generate(GenerateAlgorithm::Es256, None)
             .await
             .unwrap();
-        let jwk = verification_jwk(&signer, Some("ES384"));
+        let jwk = verification_jwk(&signer, Some("ES384")).await;
         assert!(AsymmetricPublicKey::from_jwk(jwk).await.is_none());
     }
 
@@ -727,7 +736,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let jwk = verification_jwk(&signer, Some("ES256"));
+        let jwk = verification_jwk(&signer, Some("ES256")).await;
         assert!(AsymmetricPublicKey::from_jwk(jwk).await.is_none());
     }
 
@@ -738,12 +747,13 @@ mod tests {
         let signer = PrivateKey::generate(GenerateAlgorithm::Es256, None)
             .await
             .unwrap();
-        let verifier = AsymmetricPublicKey::from_jwk(verification_jwk(&signer, Some("ES256")))
-            .await
-            .unwrap();
+        let verifier =
+            AsymmetricPublicKey::from_jwk(verification_jwk(&signer, Some("ES256")).await)
+                .await
+                .unwrap();
 
         let input = b"unsupported alg input";
-        let signature = signer.sign(input).await.unwrap();
+        let signature = signer.select_signer().await.sign(input).await.unwrap();
         assert!(matches!(
             verifier
                 .verify(input, &signature, &KeyMatch::builder().alg("ES384").build(),)

--- a/huskarl-resource-server/src/validator/binding.rs
+++ b/huskarl-resource-server/src/validator/binding.rs
@@ -433,7 +433,11 @@ mod tests {
     use super::*;
     use crate::{
         DefaultJwsVerifierPlatform,
-        core::{crypto::signer::AsymmetricJwsSigner, jwt::Jwt, platform::Duration},
+        core::{
+            crypto::signer::{AsymmetricJwsSignerSelector as _, JwsSignerSelector as _},
+            jwt::Jwt,
+            platform::Duration,
+        },
     };
 
     // The request the proof is bound to. Tests keep these fixed and vary the proof.
@@ -449,7 +453,7 @@ mod tests {
 
     /// The `cnf.jkt` value that correctly binds the token to `signer`'s key.
     fn matching_jkt(signer: &PrivateKey) -> String {
-        signer.public_key_jwk().thumbprint()
+        signer.as_private_jwk().public_jwk().thumbprint()
     }
 
     /// `DPoP` proof claims, with `None` fields omitted entirely from the JWT so
@@ -477,13 +481,14 @@ mod tests {
     }
 
     async fn sign_proof(signer: &PrivateKey, claims: ProofClaims) -> SecretString {
+        let signer = signer.select_asymmetric_signer().await;
         Jwt::builder()
             .typ("dpop+jwt")
             .issued_now_expires_after(Duration::from_mins(1))
             .jwk(signer.public_key_jwk().into_owned())
             .claims(claims)
             .build()
-            .to_jws_compact(signer)
+            .to_jws_compact(&*signer)
             .await
             .unwrap()
     }
@@ -567,14 +572,15 @@ mod tests {
     async fn proof_with_slightly_future_iat_is_accepted() {
         let signer = es256();
         let now = crate::core::platform::SystemTime::now();
+        let selected = signer.select_asymmetric_signer().await;
         let proof = Jwt::builder()
             .typ("dpop+jwt")
             .issued_at(now + Duration::from_secs(2))
             .expiration(now + Duration::from_mins(1))
-            .jwk(signer.public_key_jwk().into_owned())
+            .jwk(selected.public_key_jwk().into_owned())
             .claims(valid_claims())
             .build()
-            .to_jws_compact(&signer)
+            .to_jws_compact(&*selected)
             .await
             .unwrap();
 
@@ -805,10 +811,10 @@ mod tests {
         Jwt::builder()
             .typ("dpop+jwt")
             .issued_now_expires_after(Duration::from_mins(1))
-            .jwk(embedded.public_key_jwk().into_owned())
+            .jwk(embedded.as_private_jwk().public_jwk())
             .claims(claims)
             .build()
-            .to_jws_compact(signer)
+            .to_jws_compact(&*signer.select_signer().await)
             .await
             .unwrap()
     }

--- a/huskarl-resource-server/tests/multi_issuer.rs
+++ b/huskarl-resource-server/tests/multi_issuer.rs
@@ -12,7 +12,7 @@ use huskarl_reqwest::ReqwestClient;
 use huskarl_resource_server::{
     core::{
         EndpointUrl,
-        crypto::signer::AsymmetricJwsSigner,
+        crypto::signer::JwsSignerSelector,
         jwk::{JwksSource, PublicJwks},
         jwt::Jwt,
         platform::SystemTime,
@@ -62,7 +62,7 @@ impl MockAs {
     fn start() -> Self {
         let server = MockServer::start();
         let key = PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap();
-        let jwks = PublicJwks::new(vec![key.public_key_jwk().into_owned()]);
+        let jwks = PublicJwks::new(vec![key.as_private_jwk().public_jwk()]);
         server.mock(|when, then| {
             when.method(GET).path("/jwks.json");
             then.status(200)
@@ -93,7 +93,7 @@ impl MockAs {
             .expiration(SystemTime::now() + std::time::Duration::from_secs(3600))
             .claims(claims)
             .build();
-        jwt.to_jws_compact(&self.key)
+        jwt.to_jws_compact(&*self.key.select_signer().await)
             .await
             .unwrap()
             .expose_secret()

--- a/huskarl-resource-server/tests/rfc9068.rs
+++ b/huskarl-resource-server/tests/rfc9068.rs
@@ -8,7 +8,7 @@ use huskarl_reqwest::ReqwestClient;
 use huskarl_resource_server::{
     core::{
         EndpointUrl,
-        crypto::signer::AsymmetricJwsSigner,
+        crypto::signer::AsymmetricJwsSignerSelector,
         jwk::{JwksSource, PublicJwks},
         jwt::Jwt,
     },
@@ -21,7 +21,8 @@ async fn test_rfc9068_validator() {
 
     // 1. Generate key pair
     let private_key = PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap();
-    let public_jwk = private_key.public_key_jwk().into_owned();
+    let signer = private_key.select_asymmetric_signer().await;
+    let public_jwk = signer.public_key_jwk().into_owned();
     let jwks = PublicJwks::new(vec![public_jwk]);
 
     // 2. Mock JWKS endpoint
@@ -89,7 +90,7 @@ async fn test_rfc9068_validator() {
         })
         .build();
 
-    let token = jwt.to_jws_compact(&private_key).await.unwrap();
+    let token = jwt.to_jws_compact(&*signer).await.unwrap();
 
     // 5. Validate request
     let mut headers = http::HeaderMap::new();

--- a/huskarl/docs/guide/jwt_bearer.md
+++ b/huskarl/docs/guide/jwt_bearer.md
@@ -125,9 +125,10 @@ RFC 7523 §3 requires the assertion to be a JWT signed by an issuer the
 authorization server trusts. The claims identify the trusted issuer of the
 assertion (`iss`), the principal the token is for (`sub`), and the
 authorization server as the audience (`aud`); `exp` and `iat` bound its
-lifetime. Build and sign one with [`Jwt`](crate::core::jwt::Jwt) and any
-[`JwsSigner`](crate::core::crypto::signer::JwsSigner) (here, a freshly
-generated key — in practice load a long-lived key the server trusts):
+lifetime. Build and sign one with [`Jwt`](crate::core::jwt::Jwt) and a signer
+selected from any
+[`JwsSignerSelector`](crate::core::crypto::signer::JwsSignerSelector) (here, a
+freshly generated key — in practice load a long-lived key the server trusts):
 
 The [`SecretString`](crate::core::secrets::SecretString) returned by
 `to_jws_compact` can be passed straight to
@@ -138,7 +139,7 @@ The [`SecretString`](crate::core::secrets::SecretString) returned by
 ```rust
 use std::time::Duration;
 
-use huskarl::core::{jwt::Jwt, secrets::SecretString};
+use huskarl::core::{crypto::signer::JwsSignerSelector as _, jwt::Jwt, secrets::SecretString};
 use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
 
 # async fn make_assertion() -> Result<SecretString, Box<dyn std::error::Error>> {
@@ -152,7 +153,7 @@ let jwt = Jwt::builder()
     .claims(())
     .build();
 
-let assertion = jwt.to_jws_compact(&key).await?;
+let assertion = jwt.to_jws_compact(&*key.select_signer().await).await?;
 Ok(assertion)
 # }
 ```

--- a/huskarl/src/token/id_token.rs
+++ b/huskarl/src/token/id_token.rs
@@ -364,7 +364,7 @@ mod tests {
 
     use super::*;
     use crate::core::{
-        crypto::{signer::AsymmetricJwsSigner, verifier::JwsVerifierPlatform},
+        crypto::{signer::JwsSignerSelector, verifier::JwsVerifierPlatform},
         jwt::Jwt,
         platform::Duration,
     };
@@ -378,7 +378,7 @@ mod tests {
     async fn signer_and_verifier() -> (PrivateKey, Arc<dyn JwsVerifier>) {
         let signer = PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap();
         let verifier = NativeVerifierPlatform
-            .create_verifier_from_jwk(signer.public_key_jwk().into_owned())
+            .create_verifier_from_jwk(signer.as_private_jwk().public_jwk())
             .await
             .unwrap();
         (signer, verifier)
@@ -400,7 +400,7 @@ mod tests {
             .issued_now_expires_after(Duration::from_hours(1))
             .claims(claims)
             .build()
-            .to_jws_compact(signer)
+            .to_jws_compact(&*signer.select_signer().await)
             .await
             .unwrap();
         IdToken::from(token.expose_secret())

--- a/integration/huskarl-conformance/tests/fapi2.rs
+++ b/integration/huskarl-conformance/tests/fapi2.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use huskarl::{
     core::{
         client_auth::{Audience, JwtBearer},
-        crypto::signer::AsymmetricJwsSigner as _,
         dpop::DPoP,
         server_metadata::AuthorizationServerMetadata,
     },
@@ -53,7 +52,7 @@ async fn run_fapi2_plan<J: Jar + Clone + 'static>(
         PrivateKey::generate(GenerateAlgorithm::Es256, Some("server-key".to_string())).unwrap();
 
     // Extract the public JWK to register with the conformance suite as the client JWKS.
-    let client_public_jwk = client_key.public_key_jwk().into_owned();
+    let client_public_jwk = client_key.as_private_jwk().public_jwk();
     // Provide the full private JWK so the simulated AS can sign tokens.
     let server_private_jwk: huskarl::core::jwk::Jwk = server_key.as_private_jwk().into();
 

--- a/integration/huskarl-integration/src/suite.rs
+++ b/integration/huskarl-integration/src/suite.rs
@@ -8,7 +8,6 @@ use huskarl::{
     cache::{GrantTokenSource, InMemoryRefreshTokenStore, InMemoryTokenCache},
     core::{
         client_auth::{Audience, ClientAuthentication, ClientSecret, JwtBearer},
-        crypto::signer::AsymmetricJwsSigner as _,
         dpop::DPoP,
         jwk::JwksSource,
         secrets::{ProvidedSecret, SecretString},
@@ -143,7 +142,7 @@ pub async fn client_credentials_flow(provider: &dyn TestProvider, features: Feat
         .maybe_signing_jwk(
             client_assertion_key
                 .as_ref()
-                .map(|k| k.public_key_jwk().into_owned()),
+                .map(|k| k.as_private_jwk().public_jwk()),
         )
         .build();
     let (client, secret) = provision_with_secret(provider, spec).await;
@@ -343,7 +342,7 @@ pub async fn auth_code_flow(provider: &dyn TestProvider, features: Features) {
     let spec = ClientSpec::builder()
         .features(features)
         .redirect_uris(vec![redirect_uri.clone()])
-        .maybe_signing_jwk(jar_key.as_ref().map(|k| k.public_key_jwk().into_owned()))
+        .maybe_signing_jwk(jar_key.as_ref().map(|k| k.as_private_jwk().public_jwk()))
         .build();
     let (client, secret) = provision_with_secret(provider, spec).await;
 


### PR DESCRIPTION
Private keys no longer implement JwsSigner - they only implement JwsSignerSelector. This hands out the cloned/Arc'd inner value, which does implement JwsSigner (for native/webcrypto keys).

BREAKING CHANGE: Signing keys don't directly implement signing traits; select the key first.

Fixes #227