### PR TITLE
feat(resource-server)!: Make validator metrics a decorator.

### DIFF
--- a/huskarl-resource-server/src/error.rs
+++ b/huskarl-resource-server/src/error.rs
@@ -11,7 +11,7 @@
 
 use std::borrow::Cow;
 
-use crate::{TokenType, core::platform::MaybeSendSync};
+use crate::{TokenType, core::platform::MaybeSendSync, validator::observe::ValidationOutcome};
 
 /// Escapes a value for safe inclusion in an HTTP quoted-string (RFC 9110 §5.6.4).
 ///
@@ -283,6 +283,41 @@ pub trait ToRfc6750Error: std::fmt::Debug + MaybeSendSync {
     /// error names the specific unmet requirement. Defaults to `None`; see
     /// [`InsufficientScope`] for the standard carrier.
     fn required_scope(&self) -> Option<String> {
+        None
+    }
+
+    /// Classifies this error into a [`ValidationOutcome`] for observation — see
+    /// [`ObservedValidator`](crate::validator::observe::ObservedValidator).
+    ///
+    /// The default derives a coarse outcome from [`token_error`](Self::token_error);
+    /// validator error types override it with a precise per-variant mapping
+    /// (which the default cannot see — e.g. expired vs otherwise-invalid, or
+    /// mTLS binding failures that classify as plain `invalid_token`).
+    fn validation_outcome(&self) -> ValidationOutcome {
+        match self.token_error() {
+            TokenValidationError::Client(TokenErrorCode::InvalidRequest) => {
+                ValidationOutcome::ExtractError
+            }
+            TokenValidationError::Client(TokenErrorCode::InvalidDPoPProof) => {
+                ValidationOutcome::BindingError
+            }
+            TokenValidationError::Client(TokenErrorCode::UseDPoPNonce) => {
+                ValidationOutcome::NonceRequired
+            }
+            TokenValidationError::Client(_) => ValidationOutcome::InvalidToken,
+            TokenValidationError::Server(_) => ValidationOutcome::CallError,
+        }
+    }
+
+    /// The issuer this validation attempt is attributed to, when the validator
+    /// knows one that is safe to use as a metrics label — e.g. the registered
+    /// issuer a [multi-issuer validator](crate::validator::multi_issuer)
+    /// routed to.
+    ///
+    /// Implementations must return only trusted, bounded values (configured or
+    /// registered issuers), never unverified token contents — an attacker could
+    /// otherwise mint unbounded label values. Defaults to `None`.
+    fn issuer(&self) -> Option<&str> {
         None
     }
 }

--- a/huskarl-resource-server/src/validator/custom/mod.rs
+++ b/huskarl-resource-server/src/validator/custom/mod.rs
@@ -37,7 +37,6 @@ use crate::{
         dpop_proof::DPoPProofValidator,
         error::ValidateHeadersError,
         metadata::{ProvideValidatorMetadata, ValidatorMetadata},
-        observe::{OnValidate, ValidationOutcome},
     },
 };
 
@@ -51,7 +50,6 @@ pub struct CustomValidator<Claims = ()> {
     authorization_server: Option<String>,
     realm: Option<String>,
     resource_metadata: Option<String>,
-    on_validate: Option<Arc<dyn OnValidate>>,
     _phantom: PhantomData<Claims>,
 }
 
@@ -140,10 +138,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
         /// [metadata](Self::validator_metadata), so clients can discover the
         /// document (RFC 9728 §5.1).
         resource_metadata: Option<String>,
-        /// Optional callback invoked after each [`validate_request`](Self::validate_request) call.
-        ///
-        /// Use this to record metrics, emit log events, or trigger alerts.
-        on_validate: Option<Arc<dyn OnValidate>>,
     ) -> Result<Self, Error> {
         let jws_verifier = jws_verifier_factory
             .build(jwks_uri.as_ref(), jws_verifier_platform.clone())
@@ -183,7 +177,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
             authorization_server,
             realm,
             resource_metadata,
-            on_validate,
             _phantom: PhantomData,
         })
     }
@@ -322,8 +315,7 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
     /// Validates the request headers, returning a [`ValidationResult`] whose
     /// [`outcome`](super::ValidationResult::outcome) is `Ok(Some(_))` for a valid
     /// token, `Ok(None)` when no authentication was presented, or `Err(_)` when a
-    /// token was present but invalid. Any configured `on_validate` callback fires
-    /// before returning.
+    /// token was present but invalid.
     ///
     /// `http_uri` must be the absolute external target URI the client
     /// addressed, not a framework request object's origin-form path — see
@@ -336,23 +328,9 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
         http_uri: &http::Uri,
         client_cert_der: Option<&[u8]>,
     ) -> ValidationResult<Claims, ValidateHeadersError> {
-        let result = self
-            .inner
+        self.inner
             .validate_request(headers, http_method, http_uri, client_cert_der)
-            .await;
-
-        if let Some(cb) = &self.on_validate {
-            let validation_outcome = match &result.outcome {
-                Ok(Some(_)) => ValidationOutcome::Success,
-                Ok(None) => ValidationOutcome::NoToken,
-                Err(ValidateHeadersError::Extract { .. }) => ValidationOutcome::ExtractError,
-                Err(ValidateHeadersError::InvalidJwt { .. }) => ValidationOutcome::InvalidToken,
-                Err(ValidateHeadersError::Binding { .. }) => ValidationOutcome::BindingError,
-            };
-            cb.on_validate(validation_outcome);
-        }
-
-        result
+            .await
     }
 }
 

--- a/huskarl-resource-server/src/validator/error.rs
+++ b/huskarl-resource-server/src/validator/error.rs
@@ -11,6 +11,7 @@ use crate::{
     validator::{
         binding::{DPoPBindingError, MtlsBindingError},
         extract::TokenExtractError,
+        observe::ValidationOutcome,
     },
 };
 
@@ -163,6 +164,28 @@ impl ToRfc6750Error for ValidateHeadersError {
             Self::Extract { source } => source.error_description(),
             Self::Binding { source, .. } => source.error_description(),
             Self::InvalidJwt { source, .. } => source.error_description(),
+        }
+    }
+
+    fn validation_outcome(&self) -> ValidationOutcome {
+        match self.token_error() {
+            // Metrics must agree with the wire: a 5xx (e.g. replay store or
+            // nonce checker down) is our failure, whichever check tripped it,
+            // and a nonce challenge is routine churn, not a binding failure.
+            TokenValidationError::Server(_) => return ValidationOutcome::CallError,
+            TokenValidationError::Client(TokenErrorCode::UseDPoPNonce) => {
+                return ValidationOutcome::NonceRequired;
+            }
+            TokenValidationError::Client(_) => {}
+        }
+        match self {
+            Self::Extract { .. } => ValidationOutcome::ExtractError,
+            Self::Binding { .. } => ValidationOutcome::BindingError,
+            Self::InvalidJwt {
+                source: JwtValidationError::Expired { .. },
+                ..
+            } => ValidationOutcome::Expired,
+            Self::InvalidJwt { .. } => ValidationOutcome::InvalidToken,
         }
     }
 }

--- a/huskarl-resource-server/src/validator/introspection/error.rs
+++ b/huskarl-resource-server/src/validator/introspection/error.rs
@@ -6,7 +6,7 @@ use crate::{
     TokenType,
     error::{ToRfc6750Error, TokenErrorCode, TokenValidationError},
     introspection::IntrospectionCallError,
-    validator::{error::TokenBindingError, extract::TokenExtractError},
+    validator::{error::TokenBindingError, extract::TokenExtractError, observe::ValidationOutcome},
 };
 
 /// Error returned by [`super::IntrospectionValidator::validate_request`].
@@ -79,6 +79,26 @@ impl ToRfc6750Error for IntrospectionValidateError {
             Self::Audience { .. } => {
                 Some("The access token is not intended for this resource".to_string())
             }
+        }
+    }
+
+    fn validation_outcome(&self) -> ValidationOutcome {
+        match self.token_error() {
+            // Metrics must agree with the wire: a 5xx (a failed endpoint call,
+            // or a nonce checker down) is our failure, whichever check tripped
+            // it, and a nonce challenge is routine churn, not a binding failure.
+            TokenValidationError::Server(_) => return ValidationOutcome::CallError,
+            TokenValidationError::Client(TokenErrorCode::UseDPoPNonce) => {
+                return ValidationOutcome::NonceRequired;
+            }
+            TokenValidationError::Client(_) => {}
+        }
+        match self {
+            Self::Extract { .. } => ValidationOutcome::ExtractError,
+            Self::Binding { .. } => ValidationOutcome::BindingError,
+            // Post-triage, the only client-classified call failure is an
+            // inactive token — a bad token, like a bad audience.
+            Self::Audience { .. } | Self::Call { .. } => ValidationOutcome::InvalidToken,
         }
     }
 }

--- a/huskarl-resource-server/src/validator/introspection/mod.rs
+++ b/huskarl-resource-server/src/validator/introspection/mod.rs
@@ -47,7 +47,6 @@ use crate::{
             },
         },
         metadata::{ProvideValidatorMetadata, ValidatorMetadata},
-        observe::{OnValidate, ValidationOutcome},
     },
 };
 
@@ -66,7 +65,6 @@ pub struct IntrospectionValidator<Claims = ()> {
     http_client: Arc<dyn HttpClient>,
     dpop_binding_checker: DPoPBindingChecker,
     token_header: HeaderName,
-    on_validate: Option<Arc<dyn OnValidate>>,
     issuer: Option<String>,
     realm: Option<String>,
     resource_metadata: Option<String>,
@@ -203,10 +201,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
         /// [metadata](Self::validator_metadata), so clients can discover the
         /// document (RFC 9728 §5.1).
         resource_metadata: Option<String>,
-        /// Optional callback invoked after each [`validate_request`](Self::validate_request) call.
-        ///
-        /// Use this to record metrics, emit log events, or trigger alerts.
-        on_validate: Option<Arc<dyn OnValidate>>,
     ) -> Result<Self, Error> {
         let token_introspection = TokenIntrospection::builder()
             .client_id(client_id.clone())
@@ -237,7 +231,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
                 required: require_dpop,
             },
             token_header,
-            on_validate,
             issuer,
             realm,
             resource_metadata,
@@ -341,25 +334,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
         let (dpop_nonce, outcome) = self
             .validate_inner(headers, http_method, http_uri, client_cert_der)
             .await;
-
-        if let Some(cb) = &self.on_validate {
-            use crate::introspection::IntrospectionCallError;
-            let validation_outcome = match &outcome {
-                Ok(Some(_)) => ValidationOutcome::Success,
-                Ok(None) => ValidationOutcome::NoToken,
-                Err(IntrospectionValidateError::Extract { .. }) => ValidationOutcome::ExtractError,
-                Err(IntrospectionValidateError::Binding { .. }) => ValidationOutcome::BindingError,
-                Err(IntrospectionValidateError::Audience { .. }) => ValidationOutcome::InvalidToken,
-                Err(IntrospectionValidateError::Call { source, .. }) => {
-                    if matches!(source, IntrospectionCallError::TokenInactive) {
-                        ValidationOutcome::InvalidToken
-                    } else {
-                        ValidationOutcome::CallError
-                    }
-                }
-            };
-            cb.on_validate(validation_outcome);
-        }
 
         ValidationResult {
             outcome,

--- a/huskarl-resource-server/src/validator/mod.rs
+++ b/huskarl-resource-server/src/validator/mod.rs
@@ -8,6 +8,7 @@
 //! [`custom::CustomValidator`] for an authorization server that follows neither.
 //! See [choosing a validator](crate::_docs::explanation::choosing_a_validator)
 //! for the trade-offs, and [`multi_issuer`] to accept more than one issuer.
+//! Wrap any validator in an [`observe::ObservedValidator`] to record metrics.
 
 mod binding;
 mod common;

--- a/huskarl-resource-server/src/validator/multi_issuer/error.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/error.rs
@@ -5,7 +5,7 @@ use snafu::Snafu;
 use crate::{
     TokenType,
     error::{ChallengeParam, ToRfc6750Error, TokenErrorCode, TokenValidationError},
-    validator::extract::TokenExtractError,
+    validator::{extract::TokenExtractError, observe::ValidationOutcome},
 };
 
 /// A failure of a [`MultiIssuerValidator`](super::MultiIssuerValidator).
@@ -28,12 +28,24 @@ pub enum MultiIssuerError {
     },
     /// A token was present, but its `iss` claim was missing, unparseable, or did
     /// not match any registered issuer. Treated as `invalid_token`.
-    #[snafu(display("unrecognized token issuer"))]
-    UnrecognizedIssuer,
+    // Debug-quoted: the peeked value is attacker-controlled, so escape any
+    // control characters before it reaches a log line.
+    #[snafu(display(
+        "unrecognized token issuer{}",
+        iss.as_ref().map_or_else(String::new, |i| format!(": {i:?}"))
+    ))]
+    UnrecognizedIssuer {
+        /// The token's `iss` claim as peeked from the **unverified** payload,
+        /// when one could be read. Diagnostic only — an attacker controls it,
+        /// so never use it as a metrics label.
+        iss: Option<String>,
+    },
     /// The validator selected for the token's issuer rejected it; its RFC 6750
     /// classification is forwarded unchanged.
-    #[snafu(display("token validation error"))]
+    #[snafu(display("token validation error (issuer {issuer})"))]
     Validation {
+        /// The registered issuer the token routed to.
+        issuer: String,
         /// The inner validator's error. Not named `source` because it is a
         /// [`ToRfc6750Error`], not a [`std::error::Error`], so it does not chain.
         error: Box<dyn ToRfc6750Error>,
@@ -44,32 +56,51 @@ impl ToRfc6750Error for MultiIssuerError {
     fn attempted_scheme(&self) -> Option<TokenType> {
         match self {
             Self::Extract { source } => source.attempted_scheme(),
-            Self::UnrecognizedIssuer => None,
-            Self::Validation { error } => error.attempted_scheme(),
+            Self::UnrecognizedIssuer { .. } => None,
+            Self::Validation { error, .. } => error.attempted_scheme(),
         }
     }
 
     fn token_error(&self) -> TokenValidationError {
         match self {
             Self::Extract { source } => source.token_error(),
-            Self::UnrecognizedIssuer => TokenValidationError::Client(TokenErrorCode::InvalidToken),
-            Self::Validation { error } => error.token_error(),
+            Self::UnrecognizedIssuer { .. } => {
+                TokenValidationError::Client(TokenErrorCode::InvalidToken)
+            }
+            Self::Validation { error, .. } => error.token_error(),
         }
     }
 
     fn error_description(&self) -> Option<String> {
         match self {
             Self::Extract { source } => source.error_description(),
-            Self::UnrecognizedIssuer => Some("unrecognized token issuer".to_owned()),
-            Self::Validation { error } => error.error_description(),
+            Self::UnrecognizedIssuer { .. } => Some("unrecognized token issuer".to_owned()),
+            Self::Validation { error, .. } => error.error_description(),
         }
     }
 
     fn extra_params(&self) -> Vec<ChallengeParam> {
         match self {
             Self::Extract { source } => source.extra_params(),
-            Self::UnrecognizedIssuer => Vec::new(),
-            Self::Validation { error } => error.extra_params(),
+            Self::UnrecognizedIssuer { .. } => Vec::new(),
+            Self::Validation { error, .. } => error.extra_params(),
+        }
+    }
+
+    fn validation_outcome(&self) -> ValidationOutcome {
+        match self {
+            Self::Extract { .. } => ValidationOutcome::ExtractError,
+            Self::UnrecognizedIssuer { .. } => ValidationOutcome::UnrecognizedIssuer,
+            Self::Validation { error, .. } => error.validation_outcome(),
+        }
+    }
+
+    fn issuer(&self) -> Option<&str> {
+        match self {
+            // Only the registered issuer is a trusted, bounded label; the
+            // peeked `iss` of an unrecognized issuer is attacker-controlled.
+            Self::Validation { issuer, .. } => Some(issuer),
+            Self::Extract { .. } | Self::UnrecognizedIssuer { .. } => None,
         }
     }
 }

--- a/huskarl-resource-server/src/validator/multi_issuer/mod.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/mod.rs
@@ -11,6 +11,10 @@
 //! explanation](crate::_docs::explanation::multi_issuer_routing); for a worked
 //! two-issuer example, see the [multi-issuer
 //! guide](crate::_docs::guide::multi_issuer).
+//!
+//! One [`ObservedValidator`](crate::validator::observe::ObservedValidator)
+//! around the composite observes the whole deployment per issuer — sources do
+//! not need their own wrappers.
 
 pub mod error;
 mod map;
@@ -32,7 +36,7 @@ use crate::{
         ValidationResult,
         extract::extract_token,
         metadata::{ProvideValidatorMetadata, ValidatorMetadata},
-        multi_issuer::source::{FoldError, SourceValidator},
+        multi_issuer::source::{RegisteredSource, SourceValidator},
     },
 };
 
@@ -88,8 +92,14 @@ impl<C: MaybeSendSync + 'static, S: multi_issuer_validator_builder::State>
         V: AccessTokenValidator<Claims = C> + ProvideValidatorMetadata + 'static,
         V::Error: ToRfc6750Error + 'static,
     {
-        self.sources
-            .push((issuer.into(), Box::new(FoldError(validator))));
+        let issuer = issuer.into();
+        self.sources.push((
+            issuer.clone(),
+            Box::new(RegisteredSource {
+                issuer,
+                inner: validator,
+            }),
+        ));
         self
     }
 }
@@ -127,11 +137,10 @@ impl<C: MaybeSendSync + 'static> AccessTokenValidator for MultiIssuerValidator<C
             // Route on the unverified issuer; the selected validator does all
             // real verification. A missing/unparseable/unregistered issuer is
             // rejected.
-            let Some(validator) =
-                peek_issuer(token.expose_secret()).and_then(|iss| self.by_issuer.get(&iss))
-            else {
+            let iss = peek_issuer(token.expose_secret());
+            let Some(validator) = iss.as_ref().and_then(|iss| self.by_issuer.get(iss)) else {
                 return ValidationResult {
-                    outcome: Err(MultiIssuerError::UnrecognizedIssuer),
+                    outcome: Err(MultiIssuerError::UnrecognizedIssuer { iss }),
                     dpop_nonce: None,
                 };
             };

--- a/huskarl-resource-server/src/validator/multi_issuer/source.rs
+++ b/huskarl-resource-server/src/validator/multi_issuer/source.rs
@@ -1,5 +1,5 @@
 //! What a registered source is, internally: the [`SourceValidator`] trait object
-//! the composite stores per issuer, and the [`FoldError`] wrapper that turns an
+//! the composite stores per issuer, and the [`RegisteredSource`] wrapper that turns an
 //! arbitrary validator into one.
 //!
 //! Since [`AccessTokenValidator`] is object-safe, the only adaptation a source
@@ -21,7 +21,7 @@ use crate::{
 /// A per-issuer entry: an access token validator producing `Claims = C` with its
 /// error folded to [`MultiIssuerError`], plus its RFC 9728 metadata.
 ///
-/// Implemented for any [`FoldError`]-wrapped source; stored as
+/// Implemented for any [`RegisteredSource`]-wrapped source; stored as
 /// `Box<dyn SourceValidator<C>>`.
 pub(super) trait SourceValidator<C>:
     AccessTokenValidator<Claims = C, Error = MultiIssuerError> + ProvideValidatorMetadata
@@ -33,11 +33,18 @@ impl<C, T> SourceValidator<C> for T where
 {
 }
 
-/// Wraps a validator, folding its error into [`MultiIssuerError::Validation`] so
-/// heterogeneous sources present one error type to the composite.
-pub(super) struct FoldError<V>(pub(super) V);
+/// Adapts a validator into a per-issuer source: folds its error into
+/// [`MultiIssuerError::Validation`] so heterogeneous sources present one error
+/// type to the composite, and carries the registered issuer to keep both
+/// outcomes attributable — folded errors name it, and successes missing the
+/// optional `iss` claim get it filled in (routing peeked exactly this value
+/// from the token's payload).
+pub(super) struct RegisteredSource<V> {
+    pub(super) issuer: String,
+    pub(super) inner: V,
+}
 
-impl<V, C> AccessTokenValidator for FoldError<V>
+impl<V, C> AccessTokenValidator for RegisteredSource<V>
 where
     V: AccessTokenValidator<Claims = C>,
     V::Error: 'static,
@@ -55,21 +62,29 @@ where
     ) -> MaybeSendBoxFuture<'a, ValidationResult<C, MultiIssuerError>> {
         Box::pin(async move {
             let result = self
-                .0
+                .inner
                 .validate_request(headers, method, uri, client_cert_der)
                 .await;
             ValidationResult {
-                outcome: result
-                    .outcome
-                    .map_err(|e| MultiIssuerError::Validation { error: Box::new(e) }),
+                outcome: match result.outcome {
+                    Ok(Some(mut validated)) => {
+                        validated.iss.get_or_insert_with(|| self.issuer.clone());
+                        Ok(Some(validated))
+                    }
+                    Ok(None) => Ok(None),
+                    Err(e) => Err(MultiIssuerError::Validation {
+                        issuer: self.issuer.clone(),
+                        error: Box::new(e),
+                    }),
+                },
                 dpop_nonce: result.dpop_nonce,
             }
         })
     }
 }
 
-impl<V: ProvideValidatorMetadata> ProvideValidatorMetadata for FoldError<V> {
+impl<V: ProvideValidatorMetadata> ProvideValidatorMetadata for RegisteredSource<V> {
     fn validator_metadata(&self, resource: Option<&str>) -> ValidatorMetadata {
-        self.0.validator_metadata(resource)
+        self.inner.validator_metadata(resource)
     }
 }

--- a/huskarl-resource-server/src/validator/observe.rs
+++ b/huskarl-resource-server/src/validator/observe.rs
@@ -1,12 +1,28 @@
 //! Token validation observation hooks.
+//!
+//! Wrap any [`AccessTokenValidator`] in an [`ObservedValidator`] to record
+//! metrics, emit structured log events, or trigger alerts on each validation
+//! attempt without touching the validator itself.
 
-use crate::core::platform::MaybeSendSync;
+use std::sync::Arc;
 
-/// The outcome of a token validation attempt.
+use crate::{
+    core::platform::{MaybeSendBoxFuture, MaybeSendSync},
+    error::ToRfc6750Error,
+    validator::{
+        AccessTokenValidator, ValidationResult,
+        metadata::{ProvideValidatorMetadata, ValidatorMetadata},
+    },
+};
+
+/// The outcome of a token validation attempt, as a low-cardinality label
+/// suitable for a metrics tag.
 ///
-/// Passed to the [`OnValidate`] callback registered on a validator. Which
-/// variants can occur depends on the validator — e.g. `CallError` arises only
-/// from introspection, never from the self-contained RFC 9068 path.
+/// Carried on the [`ValidationEvent`] passed to an [`ObservedValidator`]'s
+/// callback, alongside the underlying rejection for detail beyond the label.
+/// Which variants can occur depends on the wrapped validator — e.g. `Expired`
+/// arises only from local JWT validation, and `UnrecognizedIssuer` only from
+/// multi-issuer routing.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr, strum::AsRefStr)]
 #[strum(serialize_all = "snake_case")]
@@ -17,12 +33,35 @@ pub enum ValidationOutcome {
     NoToken,
     /// Token could not be extracted or parsed from the request headers.
     ExtractError,
-    /// Token was invalid — bad signature, expired, wrong issuer, or inactive.
+    /// Token was invalid — bad signature, wrong issuer or audience, or inactive.
     InvalidToken,
-    /// Sender-constraint binding check failed (`DPoP` or mTLS).
+    /// Token was expired (`exp` in the past).
+    ///
+    /// Split from [`InvalidToken`](Self::InvalidToken) because late-refreshing
+    /// clients make expiry the highest-volume benign rejection; folding it in
+    /// would mask signature-failure spikes (the classic broken-key-rotation
+    /// signal). Local JWT validation only — introspection reports inactive
+    /// tokens as `InvalidToken` (RFC 7662 `active` does not say why).
+    Expired,
+    /// Sender-constraint binding check failed (`DPoP` or mTLS) — the
+    /// possible-stolen-token bucket (RFC 9449 §7.1).
     BindingError,
-    /// Introspection endpoint call failed (infrastructure error, not a bad token).
+    /// A `DPoP` nonce is required; the client retries with the supplied nonce
+    /// (RFC 9449 §8).
+    ///
+    /// Routine protocol churn under server-side nonce enforcement, not a
+    /// failure — kept out of [`BindingError`](Self::BindingError) so that
+    /// bucket stays an alertable security signal.
+    NonceRequired,
+    /// The resource server itself failed — a backing call broke (introspection
+    /// endpoint, replay store, nonce checker) or the deployment is
+    /// misintegrated. The token was never judged; mirrors the 5xx response.
     CallError,
+    /// A token was presented but its `iss` claim was missing, unparseable, or
+    /// not registered with the
+    /// [`MultiIssuerValidator`](crate::validator::multi_issuer::MultiIssuerValidator)
+    /// (a misconfigured client, or probing).
+    UnrecognizedIssuer,
 }
 
 impl ValidationOutcome {
@@ -33,35 +72,440 @@ impl ValidationOutcome {
     }
 }
 
+/// A single observed validation attempt, passed to [`OnValidate`].
+///
+/// Marked non-exhaustive so future observation dimensions are additive.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct ValidationEvent<'a> {
+    /// The outcome label.
+    pub outcome: ValidationOutcome,
+    /// The validator's rejection, when a token was presented but refused — its
+    /// [`error_description`](ToRfc6750Error::error_description),
+    /// [`token_error`](ToRfc6750Error::token_error), and `Debug` output give
+    /// more detail than the outcome label alone.
+    pub error: Option<&'a dyn ToRfc6750Error>,
+    /// The token's issuer, when known and trustworthy as a metrics label: the
+    /// validated `iss` claim on success, or the registered issuer a
+    /// [multi-issuer validator](crate::validator::multi_issuer) routed to on
+    /// failure ([`ToRfc6750Error::issuer`]). A multi-issuer success whose
+    /// source dropped the optional `iss` falls back to the routed issuer.
+    ///
+    /// `None` when the rejection carries no trusted issuer — including
+    /// unrecognized-issuer rejections, whose unverified `iss` would let
+    /// clients mint arbitrary label values.
+    pub iss: Option<&'a str>,
+}
+
 /// A callback invoked after each token validation attempt.
 ///
-/// Implement this trait (or use a closure) to observe validation outcomes — for
-/// example to record metrics, emit structured log events, or trigger alerts.
+/// Implement this trait (or use a closure) and wrap a validator in an
+/// [`ObservedValidator`] to observe validation outcomes — for example to
+/// record metrics, emit structured log events, or trigger alerts.
 ///
 /// Any context needed to identify the validator (resource name, machine ID, etc.)
 /// should be captured by the implementation itself.
+pub trait OnValidate: MaybeSendSync {
+    /// Called after each call to `validate_request`.
+    fn on_validate(&self, event: &ValidationEvent<'_>);
+}
+
+impl<F: Fn(&ValidationEvent<'_>) + MaybeSendSync> OnValidate for F {
+    fn on_validate(&self, event: &ValidationEvent<'_>) {
+        self(event);
+    }
+}
+
+/// An [`AccessTokenValidator`] wrapper that reports each validation attempt to
+/// an [`OnValidate`] callback as a [`ValidationEvent`].
+///
+/// Works with any validator. One wrapper around a
+/// [`MultiIssuerValidator`](crate::validator::multi_issuer::MultiIssuerValidator)
+/// observes the whole deployment: routing failures surface as
+/// [`UnrecognizedIssuer`](ValidationOutcome::UnrecognizedIssuer), and both
+/// successes and delegated failures carry the routed issuer in
+/// [`ValidationEvent::iss`] — no need to wrap each source validator.
 ///
 /// # Example
 ///
 /// ```rust,no_run
-/// # use std::sync::Arc;
-/// # use huskarl_resource_server::validator::observe::{OnValidate, ValidationOutcome};
+/// # use huskarl_resource_server::validator::observe::{ObservedValidator, ValidationEvent};
+/// # fn wrap(validator: impl huskarl_resource_server::validator::AccessTokenValidator) {
 /// let resource = "my-api";
-/// let observer: Arc<dyn OnValidate> = Arc::new(move |outcome: ValidationOutcome| {
-///     metrics::counter!(
-///         "my.token.validate",
-///         "resource" => resource,
-///         "outcome" => outcome.as_str(),
-///     ).increment(1);
-/// });
+/// let observed = ObservedValidator::builder()
+///     .inner(validator)
+///     .on_validate(move |event: &ValidationEvent<'_>| {
+///         metrics::counter!(
+///             "my.token.validate",
+///             "resource" => resource,
+///             "issuer" => event.iss.unwrap_or("unknown").to_owned(),
+///             "outcome" => event.outcome.as_str(),
+///         )
+///         .increment(1);
+///         if let Some(error) = event.error {
+///             eprintln!("token rejected: {error:?}");
+///         }
+///     })
+///     .build();
+/// # let _ = observed;
+/// # }
 /// ```
-pub trait OnValidate: MaybeSendSync {
-    /// Called after each call to `validate_request`.
-    fn on_validate(&self, outcome: ValidationOutcome);
+pub struct ObservedValidator<V> {
+    inner: V,
+    on_validate: Arc<dyn OnValidate>,
 }
 
-impl<F: Fn(ValidationOutcome) + MaybeSendSync> OnValidate for F {
-    fn on_validate(&self, outcome: ValidationOutcome) {
-        self(outcome);
+#[bon::bon]
+impl<V> ObservedValidator<V> {
+    /// Creates a new [`ObservedValidator`].
+    #[builder]
+    pub fn new(
+        /// The validator whose outcomes are observed.
+        inner: V,
+        /// Callback invoked after each `validate_request` call.
+        #[builder(with = |cb: impl OnValidate + 'static| Arc::new(cb) as Arc<dyn OnValidate>)]
+        on_validate: Arc<dyn OnValidate>,
+    ) -> Self {
+        Self { inner, on_validate }
+    }
+}
+
+impl<V> ObservedValidator<V> {
+    /// Returns a reference to the inner validator.
+    pub fn inner(&self) -> &V {
+        &self.inner
+    }
+
+    /// Unwraps the inner validator.
+    pub fn into_inner(self) -> V {
+        self.inner
+    }
+}
+
+impl<V: AccessTokenValidator> AccessTokenValidator for ObservedValidator<V> {
+    type Claims = V::Claims;
+    type Error = V::Error;
+
+    fn validate_request<'a>(
+        &'a self,
+        headers: &'a http::HeaderMap,
+        method: &'a http::Method,
+        uri: &'a http::Uri,
+        client_cert_der: Option<&'a [u8]>,
+    ) -> MaybeSendBoxFuture<'a, ValidationResult<Self::Claims, Self::Error>> {
+        Box::pin(async move {
+            let result = self
+                .inner
+                .validate_request(headers, method, uri, client_cert_der)
+                .await;
+
+            let event = match &result.outcome {
+                Ok(Some(validated)) => ValidationEvent {
+                    outcome: ValidationOutcome::Success,
+                    error: None,
+                    iss: validated.iss.as_deref(),
+                },
+                Ok(None) => ValidationEvent {
+                    outcome: ValidationOutcome::NoToken,
+                    error: None,
+                    iss: None,
+                },
+                Err(e) => ValidationEvent {
+                    outcome: e.validation_outcome(),
+                    error: Some(e),
+                    iss: e.issuer(),
+                },
+            };
+            self.on_validate.on_validate(&event);
+
+            result
+        })
+    }
+}
+
+impl<V: ProvideValidatorMetadata> ProvideValidatorMetadata for ObservedValidator<V> {
+    fn validator_metadata(&self, resource: Option<&str>) -> ValidatorMetadata {
+        self.inner.validator_metadata(resource)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{
+        core::{
+            jwt::validator::JwtValidationError,
+            platform::{Duration, SystemTime},
+        },
+        validator::{
+            ValidatedRequest,
+            binding::DPoPBindingError,
+            error::{TokenBindingError, ValidateHeadersError},
+            introspection::IntrospectionValidateError,
+            multi_issuer::MultiIssuerError,
+        },
+    };
+
+    /// A validator double that returns a fixed outcome on every request.
+    struct StubValidator {
+        result: fn() -> Result<Option<ValidatedRequest<()>>, ValidateHeadersError>,
+    }
+
+    impl AccessTokenValidator for StubValidator {
+        type Claims = ();
+        type Error = ValidateHeadersError;
+
+        fn validate_request<'a>(
+            &'a self,
+            _headers: &'a http::HeaderMap,
+            _method: &'a http::Method,
+            _uri: &'a http::Uri,
+            _client_cert_der: Option<&'a [u8]>,
+        ) -> MaybeSendBoxFuture<'a, ValidationResult<(), ValidateHeadersError>> {
+            Box::pin(async {
+                ValidationResult {
+                    outcome: (self.result)(),
+                    dpop_nonce: None,
+                }
+            })
+        }
+    }
+
+    impl ProvideValidatorMetadata for StubValidator {
+        fn validator_metadata(&self, _resource: Option<&str>) -> ValidatorMetadata {
+            ValidatorMetadata::builder().build()
+        }
+    }
+
+    fn validated(iss: Option<&str>) -> ValidatedRequest<()> {
+        ValidatedRequest {
+            iss: iss.map(str::to_owned),
+            sub: None,
+            aud: Vec::new(),
+            jti: None,
+            iat: None,
+            exp: None,
+            cnf: None,
+            claims: (),
+            introspection_jwt: None,
+        }
+    }
+
+    fn binding_error() -> ValidateHeadersError {
+        ValidateHeadersError::Binding {
+            token_type: crate::TokenType::DPoP,
+            source: TokenBindingError::MissingDPoPHeader,
+        }
+    }
+
+    fn dpop_binding(source: DPoPBindingError) -> ValidateHeadersError {
+        ValidateHeadersError::Binding {
+            token_type: crate::TokenType::DPoP,
+            source: TokenBindingError::DPoPBinding { source },
+        }
+    }
+
+    #[rstest]
+    #[case::success(
+        || Ok(Some(validated(Some("https://as.example")))),
+        ValidationOutcome::Success,
+        Some("https://as.example")
+    )]
+    #[case::no_token(|| Ok(None), ValidationOutcome::NoToken, None)]
+    #[case::error(|| Err(binding_error()), ValidationOutcome::BindingError, None)]
+    #[tokio::test]
+    async fn observes_each_validation(
+        #[case] result: fn() -> Result<Option<ValidatedRequest<()>>, ValidateHeadersError>,
+        #[case] expected: ValidationOutcome,
+        #[case] expected_iss: Option<&str>,
+    ) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let observed = ObservedValidator::builder()
+            .inner(StubValidator { result })
+            .on_validate(move |event: &ValidationEvent<'_>| {
+                sink.lock().unwrap().push((
+                    event.outcome,
+                    event.error.is_some(),
+                    event.iss.map(str::to_owned),
+                ));
+            })
+            .build();
+
+        let outcome = observed
+            .validate_request(
+                &http::HeaderMap::new(),
+                &http::Method::GET,
+                &http::Uri::from_static("https://api.example/resource"),
+                None,
+            )
+            .await
+            .outcome;
+
+        // The observed result passes through unchanged; a rejection carries
+        // its error detail on the event.
+        let expect_error = expected == ValidationOutcome::BindingError;
+        assert_eq!(outcome.is_err(), expect_error);
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(expected, expect_error, expected_iss.map(str::to_owned))]
+        );
+    }
+
+    #[rstest]
+    // Expired splits out of the invalid-token bucket; other JWT failures stay.
+    #[case::expired(
+        ValidateHeadersError::InvalidJwt {
+            token_type: crate::TokenType::Bearer,
+            source: JwtValidationError::Expired {
+                expiration: SystemTime::UNIX_EPOCH,
+                now: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+            },
+        },
+        ValidationOutcome::Expired
+    )]
+    #[case::bad_signature(
+        ValidateHeadersError::InvalidJwt {
+            token_type: crate::TokenType::Bearer,
+            source: JwtValidationError::UnsignedToken,
+        },
+        ValidationOutcome::InvalidToken
+    )]
+    // A nonce challenge is routine churn, not a binding failure.
+    #[case::nonce_required(
+        dpop_binding(DPoPBindingError::NonceRequired { nonce: "n".into() }),
+        ValidationOutcome::NonceRequired
+    )]
+    #[case::thumbprint_mismatch(
+        dpop_binding(DPoPBindingError::ThumbprintMismatch),
+        ValidationOutcome::BindingError
+    )]
+    // Wire-5xx rejections are our failure, not the client's, whichever
+    // check tripped them.
+    #[case::server_fault(
+        dpop_binding(DPoPBindingError::RequestUriNotAbsolute { uri: "/x".into() }),
+        ValidationOutcome::CallError
+    )]
+    fn validate_headers_errors_classify(
+        #[case] error: ValidateHeadersError,
+        #[case] expected: ValidationOutcome,
+    ) {
+        assert_eq!(error.validation_outcome(), expected);
+    }
+
+    #[test]
+    fn introspection_inactive_token_is_invalid_not_call_error() {
+        let error = IntrospectionValidateError::Call {
+            token_type: crate::TokenType::Bearer,
+            source: crate::introspection::IntrospectionCallError::TokenInactive,
+        };
+        assert_eq!(error.validation_outcome(), ValidationOutcome::InvalidToken);
+    }
+
+    /// Multi-issuer failures classify through the boxed inner error and carry
+    /// the routed issuer, so one wrapper around a `MultiIssuerValidator`
+    /// yields per-issuer labels for routing and delegated failures alike.
+    #[rstest]
+    #[case::routing(
+        MultiIssuerError::UnrecognizedIssuer { iss: Some("https://rogue.example".into()) },
+        ValidationOutcome::UnrecognizedIssuer,
+        // Unverified `iss` values never become labels.
+        None
+    )]
+    #[case::delegated(
+        MultiIssuerError::Validation {
+            issuer: "https://as.example".into(),
+            error: Box::new(binding_error()),
+        },
+        ValidationOutcome::BindingError,
+        Some("https://as.example")
+    )]
+    fn multi_issuer_errors_classify(
+        #[case] error: MultiIssuerError,
+        #[case] expected: ValidationOutcome,
+        #[case] expected_iss: Option<&str>,
+    ) {
+        assert_eq!(error.validation_outcome(), expected);
+        assert_eq!(error.issuer(), expected_iss);
+    }
+
+    /// One wrapper around the composite is enough: delegated failures carry the
+    /// routed issuer, successes fall back to it when the source drops the
+    /// `iss` claim, and foreign tokens surface as `UnrecognizedIssuer`.
+    #[rstest]
+    #[case::registered_failure(
+        "https://as.example",
+        || Err(binding_error()),
+        ValidationOutcome::BindingError,
+        Some("https://as.example")
+    )]
+    #[case::registered_success_source_drops_iss(
+        "https://as.example",
+        || Ok(Some(validated(None))),
+        ValidationOutcome::Success,
+        Some("https://as.example")
+    )]
+    #[case::foreign(
+        "https://rogue.example",
+        || Err(binding_error()),
+        ValidationOutcome::UnrecognizedIssuer,
+        None
+    )]
+    #[tokio::test]
+    async fn one_decorator_over_multi_issuer_labels_per_issuer(
+        #[case] token_iss: &str,
+        #[case] result: fn() -> Result<Option<ValidatedRequest<()>>, ValidateHeadersError>,
+        #[case] expected: ValidationOutcome,
+        #[case] expected_iss: Option<&str>,
+    ) {
+        use base64::prelude::*;
+
+        use crate::validator::multi_issuer::MultiIssuerValidator;
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let observed = ObservedValidator::builder()
+            .inner(
+                MultiIssuerValidator::builder()
+                    .source("https://as.example", StubValidator { result })
+                    .build(),
+            )
+            .on_validate(move |event: &ValidationEvent<'_>| {
+                sink.lock()
+                    .unwrap()
+                    .push((event.outcome, event.iss.map(str::to_owned)));
+            })
+            .build();
+
+        let seg = |s: &str| BASE64_URL_SAFE_NO_PAD.encode(s);
+        let token = format!(
+            "{}.{}.{}",
+            seg(r#"{"alg":"RS256"}"#),
+            seg(&format!(r#"{{"iss":"{token_iss}"}}"#)),
+            seg("sig"),
+        );
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
+
+        observed
+            .validate_request(
+                &headers,
+                &http::Method::GET,
+                &http::Uri::from_static("https://api.example/resource"),
+                None,
+            )
+            .await;
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(expected, expected_iss.map(str::to_owned))]
+        );
     }
 }

--- a/huskarl-resource-server/src/validator/rfc9068/mod.rs
+++ b/huskarl-resource-server/src/validator/rfc9068/mod.rs
@@ -33,7 +33,6 @@ use crate::{
         dpop_proof::DPoPProofValidator,
         error::ValidateHeadersError,
         metadata::{ProvideValidatorMetadata, ValidatorMetadata},
-        observe::{OnValidate, ValidationOutcome},
     },
 };
 
@@ -53,7 +52,6 @@ pub struct Rfc9068Validator<Claims = ()> {
     issuer: String,
     realm: Option<String>,
     resource_metadata: Option<String>,
-    on_validate: Option<Arc<dyn OnValidate>>,
     _phantom: PhantomData<Claims>,
 }
 
@@ -146,10 +144,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
         /// [metadata](Self::validator_metadata), so clients can discover the
         /// document (RFC 9728 §5.1).
         resource_metadata: Option<String>,
-        /// Optional callback invoked after each [`validate_request`](Self::validate_request) call.
-        ///
-        /// Use this to record metrics, emit log events, or trigger alerts.
-        on_validate: Option<Arc<dyn OnValidate>>,
     ) -> Result<Self, Error> {
         let jws_verifier = jws_verifier_factory
             .build(jwks_uri.as_ref(), jws_verifier_platform.clone())
@@ -189,7 +183,6 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
             issuer,
             realm,
             resource_metadata,
-            on_validate,
             _phantom: PhantomData,
         })
     }
@@ -274,23 +267,9 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
         http_uri: &http::Uri,
         client_cert_der: Option<&[u8]>,
     ) -> ValidationResult<Rfc9068AccessTokenClaims<Claims>, ValidateHeadersError> {
-        let result = self
-            .inner
+        self.inner
             .validate_request(headers, http_method, http_uri, client_cert_der)
-            .await;
-
-        if let Some(cb) = &self.on_validate {
-            let validation_outcome = match &result.outcome {
-                Ok(Some(_)) => ValidationOutcome::Success,
-                Ok(None) => ValidationOutcome::NoToken,
-                Err(ValidateHeadersError::Extract { .. }) => ValidationOutcome::ExtractError,
-                Err(ValidateHeadersError::InvalidJwt { .. }) => ValidationOutcome::InvalidToken,
-                Err(ValidateHeadersError::Binding { .. }) => ValidationOutcome::BindingError,
-            };
-            cb.on_validate(validation_outcome);
-        }
-
-        result
+            .await
     }
 }
 

--- a/huskarl-resource-server/tests/multi_issuer.rs
+++ b/huskarl-resource-server/tests/multi_issuer.rs
@@ -280,7 +280,10 @@ async fn rejects_unrecognized_issuer() {
         .await;
 
     let err = validate(&validator, &bearer(&token)).await.unwrap_err();
-    assert!(matches!(err, MultiIssuerError::UnrecognizedIssuer));
+    assert!(matches!(
+        err,
+        MultiIssuerError::UnrecognizedIssuer { iss: Some(ref iss) } if iss == "https://evil.example"
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
The multi-issuer validator didn't have metrics, while metrics handling was duplicated across the other validators. By splitting this out, it can be handled across all three, while also admitting the possibility of other implementations.