### PR TITLE
feat(client): Extract callback query parsing into `CompleteInput`.

### DIFF
--- a/huskarl/docs/guide/authorization_code.md
+++ b/huskarl/docs/guide/authorization_code.md
@@ -89,8 +89,10 @@ let pending_state = start_output.pending_state;
 
 ## 4a. Complete the authorization flow
 
-When the authorization server redirects back to your application, extract the
-`code` and `state` query parameters and pass them to `complete()`.
+When the authorization server redirects back to your application, parse the
+callback URL (or just its query string) into a `CompleteInput` and pass it to
+`complete()`. Parsing captures `code`, `state`, and the RFC 9207 `iss`
+parameter, and rejects OAuth error responses (e.g. the user denied access).
 
 ```rust
 use huskarl::{
@@ -100,21 +102,29 @@ use huskarl::{
 # async fn complete_flow(
 #     grant: &AuthorizationCodeGrant,
 #     pending_state: &PendingState,
-#     code_from_callback: String,
-#     state_from_callback: String,
+#     callback_url: &str,
 # ) -> Result<(), Box<dyn std::error::Error>> {
 
-// Build from the query parameters in the redirect callback.
-let complete_input = CompleteInput::builder()
-    .code(code_from_callback)
-    .state(state_from_callback)
-    .build();
+// The redirect callback URL, or just its query string
+// ("code=..&state=..&iss=..").
+let complete_input: CompleteInput = callback_url.parse()?;
 
 let response = grant.complete(pending_state, complete_input).await?;
 let token: &AccessToken = response.access_token();
 # Ok(())
 # }
 ```
+
+To also set fields the callback does not carry — RFC 8707 `resource`
+indicators for the token exchange — use
+`CompleteInput::builder_from_callback(url)?`, which returns the parsed but
+unbuilt builder, set them, then `build()`.
+
+When building `CompleteInput` via its builder instead (e.g. from
+framework-typed query parameters), include `iss`: a server that advertises
+RFC 9207 support in its metadata — as conforming servers do — makes the
+parameter mandatory, and completion fails with `MissingIssuer` if it is
+dropped.
 
 ## 4b. Alternative for CLI tools: complete using the loopback server
 

--- a/huskarl/src/grant/authorization_code/error.rs
+++ b/huskarl/src/grant/authorization_code/error.rs
@@ -40,6 +40,39 @@ pub enum CompleteError {
     IdTokenIssuerNotConfigured,
 }
 
+/// An error parsing authorization-callback parameters into a
+/// [`CompleteInput`](super::CompleteInput).
+///
+/// The `OAuthError` variant is control flow for login UIs (e.g. the user
+/// denied access); the rest carry the underlying failure.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+#[non_exhaustive]
+pub enum ParseCallbackError {
+    /// The authorization server returned an error response instead of a code
+    /// (RFC 6749 §4.1.2.1).
+    #[snafu(display("Authorization server returned error: {error}"))]
+    OAuthError {
+        /// The `error` field in the `OAuth2` error response.
+        error: String,
+        /// The `error_description` field in the `OAuth2` error response.
+        error_description: Option<String>,
+    },
+    /// The callback parameters could not be parsed (malformed query, or a
+    /// single-valued parameter that appeared more than once — RFC 6749 §3.1).
+    #[snafu(display("Failed to parse callback parameters: {source}"))]
+    InvalidParameters {
+        /// The underlying parse error.
+        source: crate::core::oauth_form::Error,
+    },
+    /// A required parameter was missing from the callback.
+    #[snafu(display("Missing required parameter: {param}"))]
+    MissingParameter {
+        /// The missing parameter name.
+        param: &'static str,
+    },
+}
+
 /// An error that occurs when building an [`AuthorizationCodeGrant`](super::AuthorizationCodeGrant).
 ///
 /// Carried as the source of [`ErrorKind::Config`](crate::core::ErrorKind::Config)

--- a/huskarl/src/grant/authorization_code/loopback.rs
+++ b/huskarl/src/grant/authorization_code/loopback.rs
@@ -17,7 +17,10 @@ use url::Url;
 
 use crate::{
     core::{Error, jwt::validator::ValidatedJwt},
-    grant::{authorization_code::CompleteInput, core::TokenResponse},
+    grant::{
+        authorization_code::{CompleteInput, ParseCallbackError},
+        core::TokenResponse,
+    },
     token::id_token::IdTokenClaims,
 };
 
@@ -432,45 +435,21 @@ async fn read_request_path_inner(stream: &mut TcpStream) -> Result<Option<String
 }
 
 fn parse_callback_params(path_and_query: &str) -> Result<CompleteInput, LoopbackError> {
-    /// The authorization-response parameters delivered to the redirect URI
-    /// (RFC 6749 §4.1.2 / §4.1.2.1, plus the RFC 9207 `iss`). Unknown
-    /// parameters are ignored; a repeated single-valued parameter is rejected.
-    #[derive(serde::Deserialize)]
-    struct CallbackParams {
-        code: Option<String>,
-        state: Option<String>,
-        error: Option<String>,
-        error_description: Option<String>,
-        iss: Option<String>,
-    }
-
-    // The callback parameters are the query component. For `response_mode=form_post`
+    // The parser takes the query after the first `?`. For `response_mode=form_post`
     // the body is folded in as a query string upstream, so this handles both.
-    let query = path_and_query.split_once('?').map_or("", |(_, q)| q);
-
-    let params: CallbackParams =
-        crate::core::oauth_form::from_str(query).context(InvalidCallbackParametersSnafu)?;
-
-    // An OAuth error response takes precedence (RFC 6749 §4.1.2.1).
-    if let Some(error) = params.error {
-        return Err(LoopbackError::OAuthError {
+    path_and_query.parse().map_err(|e| match e {
+        ParseCallbackError::OAuthError {
             error,
-            error_description: params.error_description,
-        });
-    }
-
-    let code = params
-        .code
-        .ok_or(LoopbackError::MissingParameter { param: "code" })?;
-    let state = params
-        .state
-        .ok_or(LoopbackError::MissingParameter { param: "state" })?;
-
-    Ok(CompleteInput::builder()
-        .code(code)
-        .state(state)
-        .maybe_iss(params.iss)
-        .build())
+            error_description,
+        } => LoopbackError::OAuthError {
+            error,
+            error_description,
+        },
+        ParseCallbackError::InvalidParameters { source } => {
+            LoopbackError::InvalidCallbackParameters { source }
+        }
+        ParseCallbackError::MissingParameter { param } => LoopbackError::MissingParameter { param },
+    })
 }
 
 async fn send_redirect(stream: &mut TcpStream, location: &str) -> Result<(), std::io::Error> {

--- a/huskarl/src/grant/authorization_code/mod.rs
+++ b/huskarl/src/grant/authorization_code/mod.rs
@@ -26,7 +26,7 @@ mod types;
 
 pub mod pkce;
 
-pub use error::{BuildError, CompleteError};
+pub use error::{BuildError, CompleteError, ParseCallbackError};
 pub use grant::{
     AuthorizationCodeGrant, AuthorizationCodeGrantBuilder, AuthorizationCodeGrantParameters,
 };
@@ -41,4 +41,4 @@ pub use jar::{Jar, NoJar};
 pub use loopback::{
     CallbackRenderer, CallbackResponse, ErrorContext, LoopbackError, SuccessContext, bind_loopback,
 };
-pub use types::{CompleteInput, PendingState, StartInput, StartOutput};
+pub use types::{CompleteInput, CompleteInputBuilder, PendingState, StartInput, StartOutput};

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -166,6 +166,12 @@ pub struct StartOutput {
 }
 
 /// The information needed to complete an authorization code flow.
+///
+/// Parse the callback URL or query string via [`FromStr`](std::str::FromStr)
+/// to capture `code`, `state`, and the RFC 9207 `iss`;
+/// [`builder_from_callback`](Self::builder_from_callback) also lets `resource`
+/// be set. When building by hand, include `iss` — it is required when the
+/// server advertises RFC 9207 support.
 #[derive(Debug, Clone, Builder)]
 pub struct CompleteInput {
     #[builder(into)]
@@ -175,6 +181,85 @@ pub struct CompleteInput {
     #[builder(into)]
     pub(super) iss: Option<String>,
     pub(super) resource: Option<Vec<String>>,
+}
+
+impl CompleteInput {
+    /// Parses the authorization-response parameters (RFC 6749 §4.1.2, plus
+    /// the RFC 9207 `iss`) into a seeded builder, so fields the callback
+    /// cannot carry — the RFC 8707
+    /// [`resource`](CompleteInputBuilder::resource) indicators — can be set
+    /// before building.
+    ///
+    /// Accepts the full callback URL, just its query, or a
+    /// `response_mode=form_post` body. Unknown parameters are ignored; a
+    /// repeated single-valued parameter is rejected.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the parameters cannot be parsed, `code` or `state` is
+    /// missing, or the callback is an OAuth error response
+    /// ([`OAuthError`](super::ParseCallbackError::OAuthError)).
+    pub fn builder_from_callback(
+        callback: &str,
+    ) -> Result<
+        CompleteInputBuilder<
+            complete_input_builder::SetState<
+                complete_input_builder::SetIss<complete_input_builder::SetCode>,
+            >,
+        >,
+        super::ParseCallbackError,
+    > {
+        use snafu::ResultExt as _;
+
+        use super::error::{InvalidParametersSnafu, ParseCallbackError};
+
+        #[derive(Deserialize)]
+        struct CallbackParams {
+            code: Option<String>,
+            state: Option<String>,
+            error: Option<String>,
+            error_description: Option<String>,
+            iss: Option<String>,
+        }
+
+        // Everything up to the first `?` is the URL/path part; a later raw
+        // `?` is query data (RFC 3986) and stays. A trailing fragment is cut
+        // — raw `#` cannot appear inside a query, so this is lossless.
+        let query = callback.split_once('?').map_or(callback, |(_, q)| q);
+        let query = query.split_once('#').map_or(query, |(q, _)| q);
+        let params: CallbackParams =
+            crate::core::oauth_form::from_str(query).context(InvalidParametersSnafu)?;
+
+        // An OAuth error response takes precedence (RFC 6749 §4.1.2.1).
+        if let Some(error) = params.error {
+            return Err(ParseCallbackError::OAuthError {
+                error,
+                error_description: params.error_description,
+            });
+        }
+
+        let code = params
+            .code
+            .ok_or(ParseCallbackError::MissingParameter { param: "code" })?;
+        let state = params
+            .state
+            .ok_or(ParseCallbackError::MissingParameter { param: "state" })?;
+
+        Ok(Self::builder()
+            .code(code)
+            .maybe_iss(params.iss)
+            .state(state))
+    }
+}
+
+impl std::str::FromStr for CompleteInput {
+    type Err = super::ParseCallbackError;
+
+    /// Equivalent to [`builder_from_callback`](Self::builder_from_callback)
+    /// followed by `build()`.
+    fn from_str(query: &str) -> Result<Self, Self::Err> {
+        Ok(Self::builder_from_callback(query)?.build())
+    }
 }
 
 /// The information needed to be stored from the initial flow setup, for use in the callback.
@@ -240,6 +325,8 @@ pub(super) fn generate_random_value() -> String {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -284,6 +371,70 @@ mod tests {
         }"#;
         let state: PendingState = serde_json::from_str(old).unwrap();
         assert_eq!(state.nonce.as_deref(), Some("n"));
+    }
+
+    // The URL part before the first `?` is discarded and the fragment cut.
+    #[rstest]
+    #[case::query_with_iss(
+        "code=abc&state=xyz&iss=https%3A%2F%2Fissuer.example.com",
+        Some("https://issuer.example.com")
+    )]
+    #[case::leading_question_mark("?code=abc&state=xyz", None)]
+    #[case::full_url_with_fragment("https://app.example.com/cb?code=abc&state=xyz#fragment", None)]
+    fn complete_input_parses_accepted_shapes(#[case] input: &str, #[case] iss: Option<&str>) {
+        let parsed: CompleteInput = input.parse().unwrap();
+        assert_eq!(parsed.code, "abc");
+        assert_eq!(parsed.state, "xyz");
+        assert_eq!(parsed.iss.as_deref(), iss);
+    }
+
+    #[test]
+    fn complete_input_builder_from_callback_carries_resource() {
+        let input = CompleteInput::builder_from_callback("code=abc&state=xyz")
+            .unwrap()
+            .resource(bon::vec!["https://api.example.com"])
+            .build();
+        assert_eq!(input.code, "abc");
+        assert_eq!(
+            input.resource,
+            Some(vec!["https://api.example.com".to_owned()])
+        );
+    }
+
+    #[test]
+    fn complete_input_parse_error_response_takes_precedence() {
+        let err = "code=abc&state=xyz&error=access_denied&error_description=user+denied"
+            .parse::<CompleteInput>()
+            .unwrap_err();
+        assert!(matches!(
+            &err,
+            super::super::ParseCallbackError::OAuthError { error, error_description }
+                if error == "access_denied" && error_description.as_deref() == Some("user denied")
+        ));
+    }
+
+    #[rstest]
+    #[case::missing_code("state=xyz", "code")]
+    #[case::missing_state("code=abc", "state")]
+    fn complete_input_parse_missing_parameter_rejected(#[case] input: &str, #[case] missing: &str) {
+        let err = input.parse::<CompleteInput>().unwrap_err();
+        assert!(matches!(
+            &err,
+            super::super::ParseCallbackError::MissingParameter { param } if *param == missing
+        ));
+    }
+
+    #[test]
+    fn complete_input_parse_duplicate_parameter_rejected() {
+        // A repeated single-valued parameter is rejected (RFC 6749 §3.1),
+        // rather than silently taking one value.
+        let err = "code=abc&state=xyz&state=zzz"
+            .parse::<CompleteInput>()
+            .unwrap_err();
+        assert!(matches!(
+            &err,
+            super::super::ParseCallbackError::InvalidParameters { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
This allows an implementation to hand off responsibility for getting parameters from the callback query to this library, avoiding having to deal with the details of how parameters are handled.