### PR TITLE
feat(auth): Loosen lifetime requirements of oauth2 form keys.

### DIFF
--- a/huskarl-core/src/client_auth/jwt_bearer.rs
+++ b/huskarl-core/src/client_auth/jwt_bearer.rs
@@ -215,7 +215,7 @@ mod tests {
         }
     }
 
-    fn extract_form_str(form: &[(&'static str, FormValue<'_>)], key: &str) -> String {
+    fn extract_form_str(form: &[(&str, FormValue<'_>)], key: &str) -> String {
         form.iter().find(|(k, _)| *k == key).map_or_else(
             || unreachable!("key {key} not found in form params"),
             |(_, v)| match v {

--- a/huskarl-core/src/client_auth/mod.rs
+++ b/huskarl-core/src/client_auth/mod.rs
@@ -118,7 +118,7 @@ pub struct AuthenticationParams<'a> {
     /// Additional headers to include in the request.
     pub headers: Option<HeaderMap>,
     /// Additional form parameters to include in the request body.
-    pub form_params: Option<Vec<(&'static str, FormValue<'a>)>>,
+    pub form_params: Option<Vec<(&'a str, FormValue<'a>)>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
These were required to be 'static, but they only need to live as long as the containing struct.