### PR TITLE
feat(crypto)!: Add back kid (optional string) for seal kid matching.

### DIFF
--- a/huskarl-core/docs/explanation/crypto_strategies.md
+++ b/huskarl-core/docs/explanation/crypto_strategies.md
@@ -226,13 +226,14 @@ selector trait: each [`seal`](crate::crypto::cipher::AeadSealer::seal) selects
 one frozen encryptor snapshot internally and runs the whole encrypt-then-frame
 sequence against it, so a rotation cannot land between choosing the key and
 using it — the read-header-then-sign hazard, closed off inside the one call.
-The price is opacity: a sealer exposes no `key_id`, so *which* key sealed a
-bundle cannot be observed or recorded alongside it — fitting, since the bundle
-carries no `kid` either. The inbound path leans on the AEAD tag instead: a
-multi-key unsealer tries its candidate keys, and a wrong key is a clean
-authentication failure, never a wrong plaintext.
-[`unseal`](crate::crypto::cipher::AeadUnsealer::unseal) still takes the same
-match criteria as decryption, for a caller that knows the key some other way.
+Key identity crosses the seam as a value: `seal` returns the bundle together
+with the `kid` of the key that sealed it, read off that same frozen snapshot,
+and [`unseal`](crate::crypto::cipher::AeadUnsealer::unseal) takes it back for
+direct key dispatch. Stored beside the bundle, the kid makes "which key
+protects this record" a metadata query; discarded, a multi-key unsealer tries
+its candidates, and the AEAD tag makes a wrong key a clean authentication
+failure, never a wrong plaintext. A kid only selects a key — an untrusted
+value can at worst cause a miss — and the bundle itself stays kid-free.
 
 Because a raw key is already a selector, `AeadV1Cipher::new(key)` is the whole
 fixed-key story. For a rotating key, put a
@@ -257,8 +258,10 @@ is no nonce/ciphertext/tag decomposition to expose, so such a service cannot
 implement [`AeadEncryptor`](crate::crypto::cipher::AeadEncryptor) at all — but
 it implements [`AeadSealer`](crate::crypto::cipher::AeadSealer) /
 [`AeadUnsealer`](crate::crypto::cipher::AeadUnsealer) naturally, handling
-rotation on its own side. Consumers bound on the sealer traits accept either
-world unchanged.
+rotation on its own side. It reports whatever key identity its service does —
+a KMS response often names the exact key version — or `None`; its tokens name
+their key internally either way, so unsealing may ignore the hint. Consumers
+bound on the sealer traits accept either world unchanged.
 
 ## The three operations, compared
 

--- a/huskarl-core/fuzz/fuzz_targets/unseal_v1.rs
+++ b/huskarl-core/fuzz/fuzz_targets/unseal_v1.rs
@@ -46,5 +46,5 @@ fuzz_target!(|data: &[u8]| {
     let unsealer = AeadV1Cipher::new(PassthroughDecryptor);
     // Peel off up to 8 leading bytes as AAD so that path isn't always empty.
     let (aad, bundle) = data.split_at(data.len().min(8));
-    let _ = futures_executor::block_on(unsealer.unseal(None, bundle, aad));
+    let _ = futures_executor::block_on(unsealer.unseal(bundle, aad, None));
 });

--- a/huskarl-core/src/crypto/cipher/mod.rs
+++ b/huskarl-core/src/crypto/cipher/mod.rs
@@ -246,6 +246,14 @@ impl<T: AeadEncryptorSelector + ?Sized> AeadEncryptorSelector for Arc<T> {
     }
 }
 
+/// The output from [`AeadSealer::seal`]
+pub struct SealOutput {
+    /// The opaque, self-describing bundle.
+    pub bundle: Vec<u8>,
+    /// The key ID of the key that sealed, when the implementation tracks one.
+    pub kid: Option<String>,
+}
+
 /// An encryptor that produces self-contained bundles.
 ///
 /// Where [`AeadEncryptor::encrypt`] returns the nonce, ciphertext, and tag as
@@ -257,15 +265,19 @@ impl<T: AeadEncryptorSelector + ?Sized> AeadEncryptorSelector for Arc<T> {
 /// This trait is dyn-capable: consumers store it as `Arc<dyn AeadSealer>`, or
 /// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
 pub trait AeadSealer: std::fmt::Debug + MaybeSendSync {
-    /// Encrypts `plaintext` and returns an opaque, self-describing bundle that
-    /// a matching [`AeadUnsealer`] can re-open. The layout belongs to the
-    /// implementation — an externally-managed sealer returns its service's
-    /// token verbatim.
+    /// Encrypts `plaintext` into a [`SealOutput`]: an opaque, self-describing
+    /// bundle that a matching [`AeadUnsealer`] can re-open, plus the kid of
+    /// the key that sealed it, when the implementation tracks one. The bundle
+    /// layout belongs to the implementation — an externally-managed sealer
+    /// returns its service's token verbatim.
+    ///
+    /// Store the kid beside the bundle for direct key dispatch in
+    /// [`unseal`](AeadUnsealer::unseal); discarding it is equally valid.
     fn seal<'a>(
         &'a self,
         plaintext: &'a [u8],
         aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>>;
+    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>>;
 }
 
 /// A decryptor that consumes self-contained bundles produced by [`AeadSealer`].
@@ -275,21 +287,22 @@ pub trait AeadSealer: std::fmt::Debug + MaybeSendSync {
 pub trait AeadUnsealer: std::fmt::Debug + MaybeSendSync {
     /// Decrypts a bundle produced by [`AeadSealer::seal`].
     ///
-    /// `cipher_match` carries optional key selection criteria known out-of-band.
-    /// Multi-key decryptors use this to select the correct key without trying
-    /// all candidates; without it, try-all is still safe — the AEAD tag makes a
-    /// wrong key a clean failure.
+    /// `kid` is the key ID [`seal`](AeadSealer::seal) returned with the
+    /// bundle, if the caller stored it: multi-key implementations use it to
+    /// select the key directly. `None` is always safe — the AEAD tag makes a
+    /// wrong key a clean failure. A kid only selects, so an untrusted value
+    /// can at worst cause a miss.
     ///
     /// # Errors
     ///
-    /// Returns [`DecryptError::NoMatchingKey`] if no key matched the selection
-    /// criteria; all other failures — malformed bundles, authentication
+    /// Returns [`DecryptError::NoMatchingKey`] if no key matched the given
+    /// `kid`; all other failures — malformed bundles, authentication
     /// failure — classify as [`ErrorKind::Crypto`] via [`DecryptError::Other`].
     fn unseal<'a>(
         &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
         bundle: &'a [u8],
         aad: &'a [u8],
+        kid: Option<&'a str>,
     ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>>;
 }
 
@@ -308,7 +321,7 @@ impl<T: AeadSealer + ?Sized> AeadSealer for Arc<T> {
         &'a self,
         plaintext: &'a [u8],
         aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
+    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>> {
         self.as_ref().seal(plaintext, aad)
     }
 }
@@ -316,11 +329,11 @@ impl<T: AeadSealer + ?Sized> AeadSealer for Arc<T> {
 impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
     fn unseal<'a>(
         &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
         bundle: &'a [u8],
         aad: &'a [u8],
+        kid: Option<&'a str>,
     ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        self.as_ref().unseal(cipher_match, bundle, aad)
+        self.as_ref().unseal(bundle, aad, kid)
     }
 }
 
@@ -344,7 +357,7 @@ impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
 /// # use std::sync::Arc;
 /// # use huskarl_core::crypto::cipher::{
 /// #     AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, AeadOutput, AeadSealer,
-/// #     AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError,
+/// #     AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError, SealOutput,
 /// # };
 /// # use huskarl_core::error::Error;
 /// # use huskarl_core::platform::MaybeSendBoxFuture;
@@ -354,7 +367,7 @@ impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
 /// # struct BackendEncryptor;
 /// # impl AeadEncryptor for BackendEncryptor {
 /// #     fn enc_algorithm(&self) -> Cow<'_, str> { "A256GCM".into() }
-/// #     fn key_id(&self) -> Option<Cow<'_, str>> { None }
+/// #     fn key_id(&self) -> Option<Cow<'_, str>> { Some("2026-07".into()) }
 /// #     fn encrypt<'a>(&'a self, plaintext: &'a [u8], _aad: &'a [u8])
 /// #         -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
 /// #         let ciphertext = plaintext.to_vec();
@@ -386,10 +399,11 @@ impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let cipher = AeadV1Cipher::new(BackendCipher::new());
 ///
-/// // `seal` packs the version byte, nonce, tag and ciphertext into one bundle...
-/// let bundle = cipher.seal(b"session-state", b"aad").await?;
-/// // ...that `unseal` re-opens with only the bundle and the same aad.
-/// let recovered = cipher.unseal(None, &bundle, b"aad").await?;
+/// // `seal` packs the version byte, nonce, tag and ciphertext into one
+/// // bundle, plus the kid of the key that sealed it...
+/// let SealOutput { bundle, kid } = cipher.seal(b"session-state", b"aad").await?;
+/// // ...which dispatches `unseal` straight to that key (`None` tries all).
+/// let recovered = cipher.unseal(&bundle, b"aad", kid.as_deref()).await?;
 /// assert_eq!(recovered, b"session-state");
 /// # Ok(())
 /// # }
@@ -409,16 +423,13 @@ impl<C: AeadEncryptorSelector> AeadSealer for AeadV1Cipher<C> {
         &'a self,
         plaintext: &'a [u8],
         aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, Error>> {
+    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>> {
         Box::pin(async move {
-            // One frozen snapshot per seal: under rotation, the key that seals
-            // is the key any metadata read off the same snapshot names.
-            let output = self
-                .0
-                .select_encryptor()
-                .await
-                .encrypt(plaintext, aad)
-                .await?;
+            // One frozen snapshot per seal: under rotation, the returned kid
+            // names exactly the key that sealed.
+            let encryptor = self.0.select_encryptor().await;
+            let kid = encryptor.key_id().map(Cow::into_owned);
+            let output = encryptor.encrypt(plaintext, aad).await?;
 
             let nonce_len: u8 = output.nonce.len().try_into().map_err(|_| {
                 Error::new(crate::ErrorKind::Crypto, "nonce length exceeds u8::MAX")
@@ -438,7 +449,7 @@ impl<C: AeadEncryptorSelector> AeadSealer for AeadV1Cipher<C> {
             bundle.extend_from_slice(&output.ciphertext);
             bundle.extend_from_slice(&output.tag);
 
-            Ok(bundle)
+            Ok(SealOutput { bundle, kid })
         })
     }
 }
@@ -450,9 +461,9 @@ fn invalid_bundle() -> Error {
 impl<C: AeadDecryptor> AeadUnsealer for AeadV1Cipher<C> {
     fn unseal<'a>(
         &'a self,
-        cipher_match: Option<&'a CipherMatch<'a>>,
         bundle: &'a [u8],
         aad: &'a [u8],
+        kid: Option<&'a str>,
     ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
         Box::pin(async move {
             if bundle.len() < 3 || bundle[0] != 0x01 {
@@ -470,8 +481,10 @@ impl<C: AeadDecryptor> AeadUnsealer for AeadV1Cipher<C> {
             let tag = &bundle[bundle.len() - tag_len..];
             let ciphertext = &bundle[3 + nonce_len..bundle.len() - tag_len];
 
+            let cipher_match = kid.map(|kid| CipherMatch::builder().kid(kid).build());
+
             self.0
-                .decrypt(cipher_match, nonce, ciphertext, tag, aad)
+                .decrypt(cipher_match.as_ref(), nonce, ciphertext, tag, aad)
                 .await
         })
     }
@@ -490,7 +503,7 @@ mod tests {
         }
 
         fn key_id(&self) -> Option<Cow<'_, str>> {
-            None
+            Some("mock-kid".into())
         }
 
         fn encrypt<'a>(
@@ -612,20 +625,21 @@ mod tests {
         let aad = b"associated";
 
         let sealer = AeadV1Cipher::new(MockKey::new());
-        let bundle = sealer.seal(plaintext, aad).await.unwrap();
+        let SealOutput { bundle, kid } = sealer.seal(plaintext, aad).await.unwrap();
+        assert_eq!(kid.as_deref(), Some("mock-kid"));
 
         let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let recovered = unsealer.unseal(None, &bundle, aad).await.unwrap();
+        let recovered = unsealer.unseal(&bundle, aad, kid.as_deref()).await.unwrap();
         assert_eq!(recovered, plaintext);
     }
 
     #[tokio::test]
     async fn erased_cipher_roundtrip() {
         let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(MockKey::new()));
-        let bundle = sealer.seal(b"hello", b"").await.unwrap();
+        let SealOutput { bundle, .. } = sealer.seal(b"hello", b"").await.unwrap();
 
         let unsealer: Arc<dyn AeadUnsealer> = Arc::new(AeadV1Cipher::new(MockDecryptor));
-        let recovered = unsealer.unseal(None, &bundle, b"").await.unwrap();
+        let recovered = unsealer.unseal(&bundle, b"", None).await.unwrap();
         assert_eq!(recovered, b"hello");
     }
 
@@ -639,8 +653,8 @@ mod tests {
 
         let cipher: Arc<dyn AeadSealerUnsealer> = Arc::new(AeadV1Cipher::new(MockCipher::new()));
         let cipher = assert_combined(cipher);
-        let bundle = cipher.seal(b"hello", b"aad").await.unwrap();
-        let recovered = cipher.unseal(None, &bundle, b"aad").await.unwrap();
+        let SealOutput { bundle, .. } = cipher.seal(b"hello", b"aad").await.unwrap();
+        let recovered = cipher.unseal(&bundle, b"aad", None).await.unwrap();
         assert_eq!(recovered, b"hello");
     }
 
@@ -648,7 +662,7 @@ mod tests {
     async fn bundle_format() {
         let plaintext = b"AB";
         let sealer = AeadV1Cipher::new(MockKey::new());
-        let bundle = sealer.seal(plaintext, b"").await.unwrap();
+        let SealOutput { bundle, .. } = sealer.seal(plaintext, b"").await.unwrap();
 
         // [0x01, nonce_len=3, tag_len=4, nonce=[1,2,3], ciphertext=[0xBE, 0xBD], tag=[4,5,6,7]]
         assert_eq!(bundle[0], 0x01);
@@ -662,14 +676,14 @@ mod tests {
     #[tokio::test]
     async fn unseal_wrong_version() {
         let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let err = unsealer.unseal(None, &[0x02, 0, 0], b"").await.unwrap_err();
+        let err = unsealer.unseal(&[0x02, 0, 0], b"", None).await.unwrap_err();
         assert_invalid_bundle(&err);
     }
 
     #[tokio::test]
     async fn unseal_too_short() {
         let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let err = unsealer.unseal(None, &[0x01], b"").await.unwrap_err();
+        let err = unsealer.unseal(&[0x01], b"", None).await.unwrap_err();
         assert_invalid_bundle(&err);
     }
 
@@ -678,7 +692,7 @@ mod tests {
         let unsealer = AeadV1Cipher::new(MockDecryptor);
         // nonce_len=10, tag_len=10, but only 1 byte of data after header
         let err = unsealer
-            .unseal(None, &[0x01, 10, 10, 0x00], b"")
+            .unseal(&[0x01, 10, 10, 0x00], b"", None)
             .await
             .unwrap_err();
         assert_invalid_bundle(&err);
@@ -687,8 +701,56 @@ mod tests {
     #[tokio::test]
     async fn unseal_empty() {
         let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let err = unsealer.unseal(None, &[], b"").await.unwrap_err();
+        let err = unsealer.unseal(&[], b"", None).await.unwrap_err();
         assert_invalid_bundle(&err);
+    }
+
+    /// The kid handed to `unseal` must reach the inner decryptor as a
+    /// kid-only [`CipherMatch`]; `None` must arrive as no criteria at all.
+    #[tokio::test]
+    async fn unseal_forwards_kid_as_cipher_match() {
+        #[derive(Debug)]
+        struct KidAssertingDecryptor {
+            expected: Option<&'static str>,
+        }
+
+        impl AeadDecryptor for KidAssertingDecryptor {
+            fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+                Some(KeyMatchStrength::ByAlgorithm)
+            }
+
+            fn decrypt<'a>(
+                &'a self,
+                cipher_match: Option<&'a CipherMatch<'a>>,
+                _nonce: &'a [u8],
+                ciphertext: &'a [u8],
+                _tag: &'a [u8],
+                _aad: &'a [u8],
+            ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+                assert_eq!(cipher_match.and_then(|m| m.kid), self.expected);
+                assert_eq!(cipher_match.and_then(|m| m.enc), None);
+                Box::pin(async move { Ok(ciphertext.to_vec()) })
+            }
+        }
+
+        let SealOutput { bundle, .. } = AeadV1Cipher::new(MockKey::new())
+            .seal(b"x", b"")
+            .await
+            .unwrap();
+        for (unsealer, kid) in [
+            (
+                AeadV1Cipher::new(KidAssertingDecryptor {
+                    expected: Some("mock-kid"),
+                }),
+                Some("mock-kid"),
+            ),
+            (
+                AeadV1Cipher::new(KidAssertingDecryptor { expected: None }),
+                None,
+            ),
+        ] {
+            unsealer.unseal(&bundle, b"", kid).await.unwrap();
+        }
     }
 
     fn cipher_match<'a>(enc: Option<&'a str>, kid: Option<&'a str>) -> CipherMatch<'a> {

--- a/huskarl-core/src/crypto/cipher/multi.rs
+++ b/huskarl-core/src/crypto/cipher/multi.rs
@@ -254,7 +254,9 @@ mod tests {
         Error,
         crypto::{
             KeyMatchStrength::*,
-            cipher::{AeadOutput, AeadSealer, AeadSealerUnsealer, AeadUnsealer, AeadV1Cipher},
+            cipher::{
+                AeadOutput, AeadSealer, AeadSealerUnsealer, AeadUnsealer, AeadV1Cipher, SealOutput,
+            },
         },
         error::ErrorKind,
     };
@@ -626,12 +628,20 @@ mod tests {
     #[tokio::test]
     async fn rotated_cookie_keys_seal_new_and_unseal_old() {
         // A cookie minted with v1 before the rotation, and one minted with a
-        // since-retired key v0 that is no longer carried.
-        let old_v1 = AeadV1Cipher::new(KeyedCookieCipher::new("v1"))
+        // since-retired key v0 that is no longer carried. Each seal reports
+        // the kid of the key that sealed, for the caller to store.
+        let SealOutput {
+            bundle: old_v1,
+            kid: old_v1_kid,
+        } = AeadV1Cipher::new(KeyedCookieCipher::new("v1"))
             .seal(b"session", b"aad")
             .await
             .unwrap();
-        let retired_v0 = AeadV1Cipher::new(KeyedCookieCipher::new("v0"))
+        assert_eq!(old_v1_kid.as_deref(), Some("v1"));
+        let SealOutput {
+            bundle: retired_v0,
+            kid: retired_v0_kid,
+        } = AeadV1Cipher::new(KeyedCookieCipher::new("v0"))
             .seal(b"session", b"aad")
             .await
             .unwrap();
@@ -647,28 +657,45 @@ mod tests {
             )));
 
         // New cookies are sealed with the current primary (v2)...
-        let new_cookie = cookies.seal(b"session", b"aad").await.unwrap();
+        let SealOutput {
+            bundle: new_cookie,
+            kid: new_kid,
+        } = cookies.seal(b"session", b"aad").await.unwrap();
+        assert_eq!(new_kid.as_deref(), Some("v2"));
         assert_eq!(
             &new_cookie[new_cookie.len() - 2..],
             b"v2",
             "new cookies are sealed with the primary key"
         );
 
-        // ...and every key still in the set opens the cookies it sealed, with no
-        // out-of-band kid — the bundle carries none, so the decryptor tries keys
-        // in turn until one authenticates.
+        // ...a stored kid dispatches straight to the key that sealed...
         assert_eq!(
-            cookies.unseal(None, &new_cookie, b"aad").await.unwrap(),
+            cookies
+                .unseal(&old_v1, b"aad", old_v1_kid.as_deref())
+                .await
+                .unwrap(),
+            b"session"
+        );
+        // ...and with no kid the decryptor tries keys in turn until one
+        // authenticates — the bundle itself carries none.
+        assert_eq!(
+            cookies.unseal(&new_cookie, b"aad", None).await.unwrap(),
             b"session"
         );
         assert_eq!(
-            cookies.unseal(None, &old_v1, b"aad").await.unwrap(),
+            cookies.unseal(&old_v1, b"aad", None).await.unwrap(),
             b"session"
         );
 
-        // The retired key's cookie no longer opens once its key leaves the set.
+        // The retired key's cookie no longer opens once its key leaves the
+        // set — its stored kid matches nothing, and try-all authenticates
+        // nothing.
         cookies
-            .unseal(None, &retired_v0, b"aad")
+            .unseal(&retired_v0, b"aad", retired_v0_kid.as_deref())
+            .await
+            .expect_err("a dropped key's kid matches no candidate");
+        cookies
+            .unseal(&retired_v0, b"aad", None)
             .await
             .expect_err("a key dropped from the set can no longer unseal");
     }

--- a/huskarl-resource-server/src/validator/dpop_nonce.rs
+++ b/huskarl-resource-server/src/validator/dpop_nonce.rs
@@ -114,9 +114,11 @@ impl SealedTimestampNonce {
             .map_err(|e| Error::new(crate::core::ErrorKind::DPoP, e))?
             .as_secs()
             .to_be_bytes();
-        // `seal` freezes one key snapshot per nonce, even under rotation.
-        let sealed_bytes = self.sealer.seal(&current_time, &self.aad).await?;
-        Ok(BASE64_URL_SAFE_NO_PAD.encode(sealed_bytes))
+        // `seal` freezes one key snapshot per nonce, even under rotation. The
+        // kid is dropped: a nonce is opaque to the client that echoes it back,
+        // so unsealing relies on try-all instead.
+        let sealed = self.sealer.seal(&current_time, &self.aad).await?;
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(sealed.bundle))
     }
 
     async fn nonce_age_secs(&self, nonce: Option<&str>) -> Option<u64> {
@@ -124,7 +126,7 @@ impl SealedTimestampNonce {
         let nonce_bytes = BASE64_URL_SAFE_NO_PAD.decode(nonce?).ok()?;
         let unsealed_bytes = self
             .sealer
-            .unseal(None, &nonce_bytes, &self.aad)
+            .unseal(&nonce_bytes, &self.aad, None)
             .await
             .ok()?;
         let timestamp_bytes = <[u8; 8]>::try_from(unsealed_bytes).ok()?;
@@ -259,7 +261,7 @@ mod tests {
             .seal(&issued_at.to_be_bytes(), &checker.aad)
             .await
             .unwrap();
-        BASE64_URL_SAFE_NO_PAD.encode(sealed)
+        BASE64_URL_SAFE_NO_PAD.encode(sealed.bundle)
     }
 
     #[tokio::test]


### PR DESCRIPTION
Sealing needs a kid for the ability to short-circuit decryption with a known key, but also (more importantly) the ability to know what keys are in use by at-rest data.