### PR TITLE
feat(redis)!: Make key prefix mandatory to avoid accidental cross-context reuse

### DIFF
--- a/huskarl-redis/src/jti.rs
+++ b/huskarl-redis/src/jti.rs
@@ -34,8 +34,8 @@ pub struct RedisJtiUniquenessChecker<C> {
     connection: C,
     /// How long a seen JTI is remembered. See the type docs for sizing.
     ttl: Duration,
-    /// Key prefix; give each checker sharing a Redis database its own prefix.
-    #[builder(into, default = String::from("jti:"))]
+    /// Key prefix; give each checker sharing a Redis database its own prefix (e.g. `jti:`).
+    #[builder(into)]
     key_prefix: String,
 }
 
@@ -117,6 +117,7 @@ mod tests {
         let checker = RedisJtiUniquenessChecker::builder()
             .connection(mock)
             .ttl(Duration::from_mins(5))
+            .key_prefix("jti:")
             .build();
 
         assert_eq!(checker.check_and_mark_seen(JTI).await.unwrap(), seen);
@@ -148,6 +149,7 @@ mod tests {
         let checker = RedisJtiUniquenessChecker::builder()
             .connection(mock)
             .ttl(Duration::from_mins(5))
+            .key_prefix("jti:")
             .build();
 
         let err = checker.check_and_mark_seen(JTI).await.unwrap_err();

--- a/huskarl-redis/src/lib.rs
+++ b/huskarl-redis/src/lib.rs
@@ -20,6 +20,7 @@
 //!         .connection(connection)
 //!         // Must cover the validator's acceptance window plus clock leeway.
 //!         .ttl(Duration::from_mins(5))
+//!         .key_prefix("jti:")
 //!         .build(),
 //! );
 //! # drop(checker);


### PR DESCRIPTION
With a default key prefix, it's too easy to allow multiple use cases to contaminate each other.