### PR TITLE
feat(core)!: Move server-side DPoP nonce checking into core

### DIFF
--- a/huskarl-core/src/dpop/mod.rs
+++ b/huskarl-core/src/dpop/mod.rs
@@ -3,10 +3,13 @@
 //! Provides traits for creating `DPoP` proofs that bind tokens to a specific
 //! client key pair. Separate traits handle the authorization server flow
 //! (token acquisition with nonce management) and resource server flow
-//! (proof creation bound to an access token).
+//! (proof creation bound to an access token). The server side of nonce
+//! management lives here too: [`DPoPNonceChecker`] issues and validates the
+//! nonces (RFC 9449 §8) that proofs must echo.
 
 mod implementation;
 mod no_dpop;
+mod nonce;
 mod sealed;
 
 use std::sync::Arc;
@@ -17,6 +20,7 @@ pub use implementation::{
     normalize_uri_for_dpop,
 };
 pub use no_dpop::{DPoPNotConfigured, NoDPoP};
+pub use nonce::{DPoPNonceChecker, NonceCheck, SealedTimestampNonce, SealedTimestampNonceBuilder};
 
 use crate::{
     error::Error,

--- a/huskarl-core/src/dpop/nonce.rs
+++ b/huskarl-core/src/dpop/nonce.rs
@@ -1,18 +1,20 @@
 //! Server-side `DPoP` nonce enforcement (RFC 9449 §8).
 //!
 //! A `DPoP` nonce is a server-chosen value the client must echo in its next
-//! proof, letting the resource server control proof freshness and limit replay.
-//! Implement [`DPoPNonceChecker`] to issue and validate nonces, or use the
-//! batteries-included [`SealedTimestampNonce`], which encodes the issue time in
-//! an AEAD-sealed token and so needs no server-side state.
+//! proof, letting the server control proof freshness and limit replay. Both
+//! server roles issue them: an authorization server at the token endpoint
+//! (§8) and a resource server on protected resources (§8.2). Implement
+//! [`DPoPNonceChecker`] to issue and validate nonces, or use the
+//! batteries-included [`SealedTimestampNonce`], which encodes the issue time
+//! in an AEAD-sealed token and so needs no server-side state.
 
 use std::sync::Arc;
 
 use bon::Builder;
 
-use crate::core::{
-    Error,
+use crate::{
     crypto::cipher::AeadSealerUnsealer,
+    error::{Error, ErrorKind},
     platform::{Duration, MaybeSendBoxFuture, MaybeSendSync, SystemTime},
 };
 
@@ -84,10 +86,10 @@ pub struct SealedTimestampNonce {
     /// The AEAD sealer/unsealer for nonce timestamps — one object that seals on
     /// the way out and unseals on the way in.
     ///
-    /// Wrap an [`AeadCipher`](crate::core::crypto::cipher::AeadCipher) (a key,
+    /// Wrap an [`AeadCipher`](crate::crypto::cipher::AeadCipher) (a key,
     /// or a rotating stack such as
-    /// [`ScheduledRefreshCipher`](crate::core::crypto::cipher::ScheduledRefreshCipher))
-    /// in [`AeadV1Cipher`](crate::core::crypto::cipher::AeadV1Cipher); an
+    /// [`ScheduledRefreshCipher`](crate::crypto::cipher::ScheduledRefreshCipher))
+    /// in [`AeadV1Cipher`](crate::crypto::cipher::AeadV1Cipher); an
     /// externally-managed sealer (e.g. a KMS encrypt endpoint) can implement
     /// the traits directly.
     #[builder(with = |sealer: impl AeadSealerUnsealer + 'static| Arc::new(sealer) as Arc<dyn AeadSealerUnsealer>)]
@@ -111,7 +113,7 @@ impl SealedTimestampNonce {
         use base64::prelude::*;
         let current_time = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|e| Error::new(crate::core::ErrorKind::DPoP, e))?
+            .map_err(|e| Error::new(ErrorKind::DPoP, e))?
             .as_secs()
             .to_be_bytes();
         // `seal` freezes one key snapshot per nonce, even under rotation. The
@@ -169,7 +171,7 @@ mod tests {
     use base64::prelude::*;
 
     use super::*;
-    use crate::core::crypto::{
+    use crate::crypto::{
         KeyMatchStrength,
         cipher::{
             AeadEncryptor, AeadOutput, AeadSealer as _, AeadV1Cipher, CipherMatch, DecryptError,
@@ -195,7 +197,7 @@ mod tests {
         }
     }
 
-    impl crate::core::crypto::cipher::AeadEncryptor for MockEncryptor {
+    impl crate::crypto::cipher::AeadEncryptor for MockEncryptor {
         fn enc_algorithm(&self) -> Cow<'_, str> {
             "mock".into()
         }
@@ -219,14 +221,14 @@ mod tests {
         }
     }
 
-    impl crate::core::crypto::cipher::AeadEncryptorSelector for MockCipher {
+    impl crate::crypto::cipher::AeadEncryptorSelector for MockCipher {
         fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
             let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
             Box::pin(async move { snapshot })
         }
     }
 
-    impl crate::core::crypto::cipher::AeadDecryptor for MockCipher {
+    impl crate::crypto::cipher::AeadDecryptor for MockCipher {
         fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
             Some(KeyMatchStrength::ByAlgorithm)
         }

--- a/huskarl-core/src/lib.rs
+++ b/huskarl-core/src/lib.rs
@@ -32,7 +32,8 @@ and explanation in a `_docs` module:
   authenticates to an authorization server (client secret, private-key JWT, or
   none).
 - **`DPoP`** — [`dpop`] provides proof-of-possession binding for the
-  authorization-server and resource-server flows.
+  authorization-server and resource-server flows, plus server-side nonce
+  issuance and validation.
 - **HTTP** — [`http`] defines the [`HttpClient`](http::HttpClient) seam that
   decouples the ecosystem from any specific HTTP implementation.
 - **Authorization-server metadata** — [`server_metadata`] models RFC 8414 /

--- a/huskarl-resource-server/docs/guide/dpop.md
+++ b/huskarl-resource-server/docs/guide/dpop.md
@@ -70,9 +70,9 @@ challenge in `WWW-Authenticate` responses.
 Proof `iat` freshness limits replay to a window of the *client's* clock. A
 server-issued nonce (RFC 9449 §8) closes that: proofs must echo a value your
 server chose recently. Enable it with a
-[`DpopNonceChecker`](crate::validator::dpop_nonce::DPoPNonceChecker); the
+[`DPoPNonceChecker`](crate::core::dpop::DPoPNonceChecker); the
 batteries-included
-[`SealedTimestampNonce`](crate::validator::dpop_nonce::SealedTimestampNonce)
+[`SealedTimestampNonce`](crate::core::dpop::SealedTimestampNonce)
 needs no storage — nonces are AEAD-sealed timestamps, so any replica holding
 the key can validate them:
 
@@ -82,7 +82,8 @@ the key can validate them:
 # use huskarl_resource_server::core::jwk::{JwksSource, OctBytes};
 # use huskarl_resource_server::core::prelude::*;
 # use huskarl_resource_server::core::secrets::{EnvVarSecret, encodings::Base64Encoding};
-# use huskarl_resource_server::validator::{dpop_nonce::SealedTimestampNonce, rfc9068::Rfc9068Validator};
+# use huskarl_resource_server::core::dpop::SealedTimestampNonce;
+# use huskarl_resource_server::validator::rfc9068::Rfc9068Validator;
 # use huskarl_crypto_native::aead::XChaChaKey;
 # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 # let http_client = huskarl_reqwest::ReqwestClient::builder().build().await?;

--- a/huskarl-resource-server/src/validator/binding.rs
+++ b/huskarl-resource-server/src/validator/binding.rs
@@ -12,12 +12,11 @@ use crate::{
     TokenType,
     core::{
         Error,
-        dpop::{hash_access_token_for_dpop, normalize_uri_for_dpop},
+        dpop::{DPoPNonceChecker, NonceCheck, hash_access_token_for_dpop, normalize_uri_for_dpop},
         jwt::ConfirmationClaim,
         secrets::SecretString,
     },
     validator::{
-        dpop_nonce::{DPoPNonceChecker, NonceCheck},
         dpop_proof::{DPoPProofError, DPoPProofValidator, ValidatedDPoPProof},
         error::{
             DPoPBindingSnafu, DPoPHeaderNotStringSnafu, DPoPRequiredForBoundTokenSnafu,

--- a/huskarl-resource-server/src/validator/custom/mod.rs
+++ b/huskarl-resource-server/src/validator/custom/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     core::{
         EndpointUrl, Error,
         crypto::verifier::{JwsVerifierFactory, JwsVerifierPlatform},
+        dpop::DPoPNonceChecker,
         jwt::{
             JtiUniquenessChecker,
             validator::{ClaimCheck, JwtValidator},
@@ -33,7 +34,6 @@ use crate::{
         binding::DPoPBindingChecker,
         common::ValidatorInner,
         custom::custom_validator_builder::{SetAuthorizationServer, SetJwksUri},
-        dpop_nonce::DPoPNonceChecker,
         dpop_proof::DPoPProofValidator,
         error::ValidateHeadersError,
         metadata::{ProvideValidatorMetadata, ValidatorMetadata},

--- a/huskarl-resource-server/src/validator/introspection/mod.rs
+++ b/huskarl-resource-server/src/validator/introspection/mod.rs
@@ -27,6 +27,7 @@ use crate::{
         EndpointUrl, Error,
         client_auth::ClientAuthentication,
         crypto::verifier::{JwsVerifierFactory, JwsVerifierPlatform},
+        dpop::DPoPNonceChecker,
         http::HttpClient,
         jwk::JwksSource,
         jwt::{JtiUniquenessChecker, validator::ClaimCheck},
@@ -37,7 +38,6 @@ use crate::{
     validator::{
         AccessTokenValidator, ValidatedRequest, ValidationResult,
         binding::{DPoPBindingChecker, check_token_binding},
-        dpop_nonce::DPoPNonceChecker,
         dpop_proof::DPoPProofValidator,
         extract::extract_token,
         introspection::{

--- a/huskarl-resource-server/src/validator/mod.rs
+++ b/huskarl-resource-server/src/validator/mod.rs
@@ -13,7 +13,6 @@
 mod binding;
 mod common;
 pub mod custom;
-pub mod dpop_nonce;
 pub mod dpop_proof;
 pub mod error;
 pub mod extract;

--- a/huskarl-resource-server/src/validator/rfc9068/mod.rs
+++ b/huskarl-resource-server/src/validator/rfc9068/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     core::{
         EndpointUrl, Error,
         crypto::verifier::{JwsVerifierFactory, JwsVerifierPlatform},
+        dpop::DPoPNonceChecker,
         jwt::{
             JtiUniquenessChecker,
             validator::{ClaimCheck, JwtValidator},
@@ -29,7 +30,6 @@ use crate::{
         ValidationResult,
         binding::DPoPBindingChecker,
         common::ValidatorInner,
-        dpop_nonce::DPoPNonceChecker,
         dpop_proof::DPoPProofValidator,
         error::ValidateHeadersError,
         metadata::{ProvideValidatorMetadata, ValidatorMetadata},


### PR DESCRIPTION
DPoP nonce generation more correctly lives in core, as it's cross-cutting across both resource server and authorization server.