### PR TITLE
feat(dpop)!: Support per-session DPoP keys via grant-level binding.

### DIFF
--- a/huskarl-core/src/dpop/implementation.rs
+++ b/huskarl-core/src/dpop/implementation.rs
@@ -91,6 +91,100 @@ impl AuthorizationServerDPoP for DPoP {
             nonces: Arc::default(),
         })
     }
+
+    fn with_session_key(
+        &self,
+        _signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error> {
+        // A fixed-key grant must not be silently overridden with a session key.
+        Err(fixed_key_override_error())
+    }
+}
+
+/// Authorization-server `DPoP` holding only the shared, server-scoped nonce
+/// (RFC 9449); the signing key is bound per session with
+/// [`with_session_key`](AuthorizationServerDPoP::with_session_key) (the
+/// grants' `with_session_dpop_key`).
+///
+/// Lets a multi-tenant client keep one grant per authorization server with a
+/// distinct key per user session, all sharing this nonce. Using the template
+/// directly without binding a key fails on first proof.
+#[derive(Debug, Clone, Default)]
+pub struct SessionKeyedDPoP {
+    nonce: Arc<Mutex<Option<Arc<String>>>>,
+}
+
+impl SessionKeyedDPoP {
+    /// Creates a `SessionKeyedDPoP` with a fresh, empty shared nonce.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl super::sealed::Sealed for SessionKeyedDPoP {}
+
+impl AuthorizationServerDPoP for SessionKeyedDPoP {
+    fn update_nonce(&self, nonce: String) {
+        let _ = self
+            .nonce
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(Arc::new(nonce));
+    }
+
+    fn get_current_thumbprint(&self) -> MaybeSendBoxFuture<'_, Option<String>> {
+        // Key is bound per session via `with_session_key`.
+        Box::pin(async { None })
+    }
+
+    fn proof<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        _dpop_jkt: Option<&'a str>,
+    ) -> MaybeSendBoxFuture<'a, Result<Option<SecretString>, Error>> {
+        // Reached only when no per-session key was bound.
+        Box::pin(async { Err(no_session_key_error()) })
+    }
+
+    fn to_resource_server_dpop(&self) -> Arc<dyn ResourceServerDPoP> {
+        // Resource-server proofs come from the keyed `DPoP` produced by
+        // `with_session_key`, not from the unkeyed session template.
+        Arc::new(SessionKeyedResourceDPoP)
+    }
+
+    fn with_session_key(
+        &self,
+        signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error> {
+        Ok(Arc::new(DPoP {
+            signer,
+            nonce: Arc::clone(&self.nonce), // shared per-server nonce
+        }))
+    }
+}
+
+/// Placeholder resource-server `DPoP` for a [`SessionKeyedDPoP`] with no key
+/// bound. Per-session resource-server proofs come from the keyed [`DPoP`] that
+/// [`SessionKeyedDPoP::with_session_key`] produces, not from this object.
+#[derive(Debug, Clone, Copy, Default)]
+struct SessionKeyedResourceDPoP;
+
+impl super::sealed::Sealed for SessionKeyedResourceDPoP {}
+
+impl ResourceServerDPoP for SessionKeyedResourceDPoP {
+    fn update_nonce(&self, _uri: &Uri, _nonce: String) {}
+
+    fn proof<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        _access_token: &'a SecretString,
+        _dpop_jkt: &'a str,
+    ) -> MaybeSendBoxFuture<'a, Result<Option<SecretString>, Error>> {
+        Box::pin(async { Err(no_session_key_error()) })
+    }
 }
 
 impl super::sealed::Sealed for ResourceDPoP {}
@@ -163,6 +257,22 @@ fn no_thumbprint_error() -> Error {
 
 fn no_matching_key_error() -> Error {
     Error::from(ErrorKind::DPoP).with_context("no matching key for the given thumbprint")
+}
+
+/// A per-session key was bound, but this `DPoP` is not session-keyed.
+fn fixed_key_override_error() -> Error {
+    Error::from(ErrorKind::DPoP).with_context(
+        "a per-session DPoP key was bound, but this grant is configured with a fixed DPoP key; \
+         configure SessionKeyedDPoP to accept per-session keys",
+    )
+}
+
+/// A `SessionKeyedDPoP` template was used directly, without a key bound.
+fn no_session_key_error() -> Error {
+    Error::from(ErrorKind::DPoP).with_context(
+        "SessionKeyedDPoP has no key bound; bind a per-session key first (the grant's \
+         with_session_dpop_key)",
+    )
 }
 
 fn origin_from_uri(uri: &Uri) -> Origin {
@@ -500,5 +610,102 @@ mod tests {
         let claims2: serde_json::Value =
             serde_json::from_slice(&BASE64_URL_SAFE_NO_PAD.decode(parts2[1]).unwrap()).unwrap();
         assert_eq!(claims2["nonce"], "nonce-2");
+    }
+
+    // --- SessionKeyedDPoP ---
+
+    #[tokio::test]
+    async fn session_keyed_dpop_binds_session_key() {
+        let jwk = mock_public_jwk();
+        let thumbprint = jwk.thumbprint();
+        let signer: Arc<dyn AsymmetricJwsSignerSelector> =
+            Arc::new(MockAsymmetricJwsSigner { jwk });
+
+        let session = SessionKeyedDPoP::new();
+        // No key until one is bound.
+        assert!(session.get_current_thumbprint().await.is_none());
+
+        let keyed = session.with_session_key(signer).unwrap();
+
+        // Thumbprint now comes from the bound session key.
+        assert_eq!(
+            keyed.get_current_thumbprint().await.as_deref(),
+            Some(thumbprint.as_str())
+        );
+
+        let uri: Uri = "https://auth.example.com/token".parse().unwrap();
+        let proof = keyed
+            .proof(&Method::POST, &uri, Some(&thumbprint))
+            .await
+            .unwrap();
+        assert!(proof.is_some());
+    }
+
+    #[tokio::test]
+    async fn session_keyed_dpop_shares_nonce_across_sessions() {
+        let jwk = mock_public_jwk();
+        let thumbprint = jwk.thumbprint();
+
+        let session = SessionKeyedDPoP::new();
+        let a = session
+            .with_session_key(Arc::new(MockAsymmetricJwsSigner { jwk: jwk.clone() }))
+            .unwrap();
+        let b = session
+            .with_session_key(Arc::new(MockAsymmetricJwsSigner { jwk }))
+            .unwrap();
+
+        // A nonce learned via one session's proof object is visible to another
+        // and to the shared template — the nonce is server-scoped, not per-key.
+        a.update_nonce("server-nonce".into());
+
+        let uri: Uri = "https://auth.example.com/token".parse().unwrap();
+        let proof = b
+            .proof(&Method::POST, &uri, Some(&thumbprint))
+            .await
+            .unwrap()
+            .unwrap();
+        let parts: Vec<&str> = proof.expose_secret().split('.').collect();
+        let claims: serde_json::Value =
+            serde_json::from_slice(&BASE64_URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert_eq!(claims["nonce"], "server-nonce");
+    }
+
+    #[tokio::test]
+    async fn session_keyed_dpop_without_key_errors() {
+        let session = SessionKeyedDPoP::new();
+        let uri: Uri = "https://auth.example.com/token".parse().unwrap();
+        let err = session
+            .proof(&Method::POST, &uri, Some("jkt"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DPoP);
+    }
+
+    #[tokio::test]
+    async fn fixed_dpop_rejects_session_key() {
+        let session_key: Arc<dyn AsymmetricJwsSignerSelector> = Arc::new(MockAsymmetricJwsSigner {
+            jwk: mock_public_jwk(),
+        });
+        let dpop = DPoP::builder()
+            .signer(MockAsymmetricJwsSigner {
+                jwk: mock_public_jwk(),
+            })
+            .build();
+        // `unwrap_err` would require the Ok type (a non-Debug trait object) to
+        // be Debug, so recover the error via `.err()`.
+        let err = dpop.with_session_key(session_key).err().unwrap();
+        assert_eq!(err.kind(), ErrorKind::DPoP);
+    }
+
+    #[tokio::test]
+    async fn no_dpop_rejects_session_key() {
+        let session_key: Arc<dyn AsymmetricJwsSignerSelector> = Arc::new(MockAsymmetricJwsSigner {
+            jwk: mock_public_jwk(),
+        });
+        let err = crate::dpop::NoDPoP
+            .with_session_key(session_key)
+            .err()
+            .unwrap();
+        assert_eq!(err.kind(), ErrorKind::DPoP);
     }
 }

--- a/huskarl-core/src/dpop/mod.rs
+++ b/huskarl-core/src/dpop/mod.rs
@@ -16,13 +16,14 @@ use std::sync::Arc;
 
 use http::{Method, Uri};
 pub use implementation::{
-    DPoP, DPoPBuilder, ResourceDPoP, ResourceDPoPBuilder, hash_access_token_for_dpop,
-    normalize_uri_for_dpop,
+    DPoP, DPoPBuilder, ResourceDPoP, ResourceDPoPBuilder, SessionKeyedDPoP,
+    hash_access_token_for_dpop, normalize_uri_for_dpop,
 };
 pub use no_dpop::{DPoPNotConfigured, NoDPoP};
 pub use nonce::{DPoPNonceChecker, NonceCheck, SealedTimestampNonce, SealedTimestampNonceBuilder};
 
 use crate::{
+    crypto::signer::AsymmetricJwsSignerSelector,
     error::Error,
     platform::{MaybeSendBoxFuture, MaybeSendSync},
     secrets::SecretString,
@@ -53,6 +54,19 @@ pub trait AuthorizationServerDPoP: sealed::Sealed + MaybeSendSync {
 
     /// Returns the corresponding resource server variant.
     fn to_resource_server_dpop(&self) -> Arc<dyn ResourceServerDPoP>;
+
+    /// Binds a per-session signing key, sharing this instance's server-scoped
+    /// nonce.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless this is a [`SessionKeyedDPoP`]; a fixed-key
+    /// [`DPoP`] or [`NoDPoP`] rejects the override rather than silently
+    /// accepting it.
+    fn with_session_key(
+        &self,
+        signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error>;
 }
 
 /// Proof implementation for `DPoP` when calling resource servers.
@@ -94,6 +108,13 @@ impl<T: AuthorizationServerDPoP + ?Sized> AuthorizationServerDPoP for &T {
     fn to_resource_server_dpop(&self) -> Arc<dyn ResourceServerDPoP> {
         (**self).to_resource_server_dpop()
     }
+
+    fn with_session_key(
+        &self,
+        signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error> {
+        (**self).with_session_key(signer)
+    }
 }
 
 impl<T: AuthorizationServerDPoP + ?Sized> AuthorizationServerDPoP for Box<T> {
@@ -117,6 +138,13 @@ impl<T: AuthorizationServerDPoP + ?Sized> AuthorizationServerDPoP for Box<T> {
     fn to_resource_server_dpop(&self) -> Arc<dyn ResourceServerDPoP> {
         (**self).to_resource_server_dpop()
     }
+
+    fn with_session_key(
+        &self,
+        signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error> {
+        (**self).with_session_key(signer)
+    }
 }
 
 impl<T: AuthorizationServerDPoP + ?Sized> AuthorizationServerDPoP for Arc<T> {
@@ -139,6 +167,13 @@ impl<T: AuthorizationServerDPoP + ?Sized> AuthorizationServerDPoP for Arc<T> {
 
     fn to_resource_server_dpop(&self) -> Arc<dyn ResourceServerDPoP> {
         (**self).to_resource_server_dpop()
+    }
+
+    fn with_session_key(
+        &self,
+        signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error> {
+        (**self).with_session_key(signer)
     }
 }
 

--- a/huskarl-core/src/dpop/no_dpop.rs
+++ b/huskarl-core/src/dpop/no_dpop.rs
@@ -4,6 +4,7 @@ use http::{Method, Uri};
 use snafu::Snafu;
 
 use crate::{
+    crypto::signer::AsymmetricJwsSignerSelector,
     dpop::{AuthorizationServerDPoP, ResourceServerDPoP},
     error::{Error, ErrorKind},
     platform::MaybeSendBoxFuture,
@@ -45,6 +46,17 @@ impl AuthorizationServerDPoP for NoDPoP {
 
     fn to_resource_server_dpop(&self) -> Arc<dyn ResourceServerDPoP> {
         Arc::new(NoDPoP)
+    }
+
+    fn with_session_key(
+        &self,
+        _signer: Arc<dyn AsymmetricJwsSignerSelector>,
+    ) -> Result<Arc<dyn AuthorizationServerDPoP>, Error> {
+        // DPoP is disabled here; a per-session key needs SessionKeyedDPoP.
+        Err(Error::from(ErrorKind::DPoP).with_context(
+            "a per-session DPoP key was bound, but DPoP is not enabled on this grant; \
+             configure it with SessionKeyedDPoP",
+        ))
     }
 }
 

--- a/huskarl/src/cache/grant_token_source/tests.rs
+++ b/huskarl/src/cache/grant_token_source/tests.rs
@@ -856,3 +856,62 @@ async fn open_breaker_does_not_mask_retryable_refresh() {
         matches!(e, GetTokenError::RefreshFailed { .. })
     });
 }
+
+/// A session-bound grant powers the whole source chain: the internally-built
+/// refresh request signs with the session key (via `to_refresh_grant`), and
+/// the source's resource-server `DPoP` proves against the issued token — the
+/// two things an unbound `SessionKeyedDPoP` template cannot do.
+#[cfg(not(target_family = "wasm"))]
+#[tokio::test]
+async fn session_bound_grant_powers_source_dpop_and_refresh() {
+    use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
+
+    use crate::{core::dpop::SessionKeyedDPoP, grant::refresh::RefreshGrant, token::AccessToken};
+
+    let http = MockHttpClient::default();
+    let grant = RefreshGrant::builder()
+        .token_endpoint("https://as.example.com/token".parse().unwrap())
+        .client_id("client")
+        .http_client(http.clone())
+        .client_auth(NoAuth)
+        .dpop(SessionKeyedDPoP::new())
+        .build()
+        .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+        .unwrap();
+
+    let store = SharedRefreshStore::default();
+    store.set(&refresh_token("the-rt")).await.unwrap();
+    let source = GrantTokenSource::builder()
+        .grant(grant)
+        .grant_parameters(NoSource)
+        .refresh_store(store)
+        .build();
+
+    // Refresh path: the DPoP proof on the token request comes from the bound
+    // session key; with no key bound this call fails before any HTTP.
+    http.push(
+        StatusCode::OK,
+        r#"{"access_token":"at","token_type":"DPoP"}"#,
+    );
+    let token = source.token().await.unwrap();
+    let AccessToken::DPoP(at) = token.access_token() else {
+        panic!("expected a DPoP-bound access token");
+    };
+
+    // Resource-server path: the captured proof object holds the session key,
+    // and its proof thumbprint-matches the token's jkt.
+    let proof = source
+        .resource_server_dpop()
+        .proof(
+            &http::Method::GET,
+            &"https://rs.example.com/resource".parse().unwrap(),
+            at.token(),
+            at.jkt(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        proof.is_some(),
+        "session-bound RS DPoP must produce a proof"
+    );
+}

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -14,6 +14,7 @@ use crate::{
     core::{
         EndpointUrl, Error, ErrorKind,
         client_auth::AuthenticationContext,
+        dpop::AuthorizationServerDPoP,
         jwt::validator::ValidatedJwt,
         platform::{Duration, SystemTime},
         secrets::SecretString,
@@ -382,6 +383,19 @@ impl AuthorizationCodeGrant {
             }
         }
 
+        // The grant's DPoP key must match the key bound at authorization time
+        // (its thumbprint is the persisted `dpop_jkt`) — catches a wrong session
+        // key bound via `with_session_dpop_key` after the key round-tripped
+        // through the caller's session store, before the code is spent.
+        if pending_state.dpop_jkt.is_some()
+            && self.dpop.get_current_thumbprint().await != pending_state.dpop_jkt
+        {
+            return Err(Error::from(ErrorKind::DPoP).with_context(
+                "the grant's DPoP key does not match the key bound at authorization time \
+                 (dpop_jkt); bind the same session key used at start",
+            ));
+        }
+
         let token = self
             .exchange(AuthorizationCodeGrantParameters {
                 dpop_jkt: pending_state.dpop_jkt.clone(),
@@ -501,17 +515,21 @@ fn add_payload_to_uri<T: Serialize>(endpoint: &EndpointUrl, payload: T) -> Resul
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use bytes::Bytes;
 
     use super::*;
     use crate::{
         core::{
             client_auth::NoAuth,
+            dpop::SessionKeyedDPoP,
             http::{HttpClient, HttpResponse, Idempotency},
             platform::MaybeSendBoxFuture,
             server_metadata::AuthorizationServerMetadata,
         },
-        grant::authorization_code::types::StartInput,
+        grant::authorization_code::types::{CompleteInput, StartInput},
+        token::AccessToken,
     };
 
     /// `start()` with direct delivery performs no HTTP; this client asserts that.
@@ -603,6 +621,157 @@ mod tests {
                 })
             })
         }
+    }
+
+    /// Records each request's path and whether it carried a `DPoP` header,
+    /// serving canned PAR and token responses.
+    #[derive(Clone, Default)]
+    struct RecordingHttp {
+        seen: Arc<Mutex<Vec<(String, bool)>>>,
+    }
+
+    impl HttpClient for RecordingHttp {
+        fn execute(
+            &self,
+            request: http::Request<Bytes>,
+            _idempotency: Idempotency,
+        ) -> MaybeSendBoxFuture<'_, Result<HttpResponse, Error>> {
+            let path = request.uri().path().to_string();
+            let has_dpop = request.headers().contains_key("DPoP");
+            self.seen.lock().unwrap().push((path.clone(), has_dpop));
+
+            let (status, body) = if path.ends_with("/par") {
+                (
+                    http::StatusCode::CREATED,
+                    Bytes::from_static(
+                        br#"{"request_uri":"urn:ietf:params:oauth:request_uri:abc","expires_in":90}"#,
+                    ),
+                )
+            } else {
+                (
+                    http::StatusCode::OK,
+                    Bytes::from_static(br#"{"access_token":"at","token_type":"DPoP"}"#),
+                )
+            };
+            Box::pin(async move {
+                Ok(HttpResponse {
+                    status,
+                    headers: http::HeaderMap::new(),
+                    body,
+                })
+            })
+        }
+    }
+
+    async fn session_keyed_par_grant(http: RecordingHttp) -> Grant {
+        AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(http)
+            .client_auth(NoAuth)
+            .dpop(SessionKeyedDPoP::new())
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .pushed_authorization_request_endpoint("https://as.example.com/par".parse().unwrap())
+            .prefer_pushed_authorization_requests(true)
+            .redirect_uri("http://127.0.0.1/cb")
+            .build()
+            .await
+            .unwrap()
+    }
+
+    /// One grant per authorization server; a per-session grant derived at each
+    /// leg (simulating the key round-tripping through the caller's session
+    /// store) signs the PAR request and the token exchange with the same key.
+    #[tokio::test]
+    async fn session_key_signs_par_and_token() {
+        use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
+
+        let http = RecordingHttp::default();
+        let grant = session_keyed_par_grant(http.clone()).await;
+        let key = PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap();
+
+        let output = grant
+            .with_session_dpop_key(key.clone())
+            .unwrap()
+            .start(StartInput::scope(bon::vec!["api"]))
+            .await
+            .unwrap();
+
+        let token = grant
+            .with_session_dpop_key(key)
+            .unwrap()
+            .complete(
+                &output.pending_state,
+                CompleteInput::builder()
+                    .code("the-code")
+                    .state(output.pending_state.state.clone())
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(token.access_token(), AccessToken::DPoP(_)));
+
+        let seen = http.seen.lock().unwrap();
+        assert!(
+            seen.iter().any(|(p, dpop)| p.ends_with("/par") && *dpop),
+            "PAR request should carry a DPoP proof: {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|(p, dpop)| p.ends_with("/token") && *dpop),
+            "token request should carry a DPoP proof: {seen:?}"
+        );
+    }
+
+    /// A different key bound at completion than the one bound at PAR time is
+    /// rejected before the token request goes out.
+    #[tokio::test]
+    async fn mismatched_session_key_at_complete_is_rejected() {
+        use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
+
+        let http = RecordingHttp::default();
+        let grant = session_keyed_par_grant(http.clone()).await;
+
+        let output = grant
+            .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+            .unwrap()
+            .start(StartInput::scope(bon::vec!["api"]))
+            .await
+            .unwrap();
+
+        let result = grant
+            .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+            .unwrap()
+            .complete(
+                &output.pending_state,
+                CompleteInput::builder()
+                    .code("the-code")
+                    .state(output.pending_state.state.clone())
+                    .build(),
+            )
+            .await;
+
+        let err = result.expect_err("mismatched DPoP key must be rejected");
+        assert_eq!(err.kind(), ErrorKind::DPoP);
+        let seen = http.seen.lock().unwrap();
+        assert!(
+            !seen.iter().any(|(p, _)| p.ends_with("/token")),
+            "no token request should be made on mismatch: {seen:?}"
+        );
+    }
+
+    /// The unbound session-keyed template itself refuses to run a flow: PAR
+    /// proof signing fails until a session key is bound.
+    #[tokio::test]
+    async fn unbound_session_template_rejects_start() {
+        let http = RecordingHttp::default();
+        let grant = session_keyed_par_grant(http.clone()).await;
+
+        let err = grant
+            .start(StartInput::scope(bon::vec!["api"]))
+            .await
+            .expect_err("unbound SessionKeyedDPoP must not sign a PAR request");
+        assert_eq!(err.kind(), ErrorKind::DPoP);
     }
 
     #[tokio::test]

--- a/huskarl/src/grant/authorization_code/grant.rs
+++ b/huskarl/src/grant/authorization_code/grant.rs
@@ -7,7 +7,10 @@ use crate::{
     core::{
         EndpointUrl, Error, ErrorKind,
         client_auth::ClientAuthentication,
-        crypto::verifier::{JwsVerifier, JwsVerifierFactory, JwsVerifierPlatform},
+        crypto::{
+            signer::AsymmetricJwsSignerSelector,
+            verifier::{JwsVerifier, JwsVerifierFactory, JwsVerifierPlatform},
+        },
         dpop::{AuthorizationServerDPoP, NoDPoP},
         http::HttpClient,
     },
@@ -118,6 +121,28 @@ impl AuthorizationCodeGrant {
     #[must_use]
     pub fn client_id(&self) -> &str {
         &self.client_id
+    }
+
+    /// Binds a per-session `DPoP` key, returning a grant that signs with it.
+    ///
+    /// Derived grants share the grant's server-scoped `DPoP` nonce, so one
+    /// grant per authorization server serves every session. Bind the same key
+    /// before [`start`](Self::start) and [`complete`](Self::complete);
+    /// `complete` rejects a key that differs from the one bound at
+    /// authorization time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the configured `DPoP` is
+    /// [`SessionKeyedDPoP`](crate::core::dpop::SessionKeyedDPoP).
+    pub fn with_session_dpop_key(
+        &self,
+        key: impl AsymmetricJwsSignerSelector + 'static,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            dpop: self.dpop.with_session_key(Arc::new(key))?,
+            ..self.clone()
+        })
     }
 }
 

--- a/huskarl/src/grant/jwt_bearer.rs
+++ b/huskarl/src/grant/jwt_bearer.rs
@@ -19,6 +19,7 @@ use crate::{
     core::{
         EndpointUrl, Error,
         client_auth::ClientAuthentication,
+        crypto::signer::AsymmetricJwsSignerSelector,
         dpop::{AuthorizationServerDPoP, NoDPoP},
         http::HttpClient,
         platform::MaybeSendBoxFuture,
@@ -39,7 +40,7 @@ use crate::{
 ///
 /// See the [module documentation][crate::grant::jwt_bearer] for a usage guide.
 #[huskarl_macros::from_metadata(metadata = crate::core::server_metadata::AuthorizationServerMetadata)]
-#[derive(Builder)]
+#[derive(Clone, Builder)]
 #[builder(on(String, into))]
 pub struct JwtBearerGrant {
     /// The client ID. Optional: omit it for an unidentified client (the
@@ -87,6 +88,27 @@ pub struct JwtBearerGrant {
     /// form auth for client secrets.
     #[from_metadata(path = "token_endpoint_auth_methods_supported")]
     token_endpoint_auth_methods_supported: Option<Vec<String>>,
+}
+
+impl JwtBearerGrant {
+    /// Binds a per-session `DPoP` key, returning a grant that signs with it.
+    ///
+    /// Derived grants share the grant's server-scoped `DPoP` nonce, so one
+    /// grant per authorization server serves every session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the configured `DPoP` is
+    /// [`SessionKeyedDPoP`](crate::core::dpop::SessionKeyedDPoP).
+    pub fn with_session_dpop_key(
+        &self,
+        key: impl AsymmetricJwsSignerSelector + 'static,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            dpop: self.dpop.with_session_key(Arc::new(key))?,
+            ..self.clone()
+        })
+    }
 }
 
 impl core::fmt::Debug for JwtBearerGrant {
@@ -223,7 +245,11 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        core::{client_auth::NoAuth, dpop::DPoP, secrets::SecretString},
+        core::{
+            client_auth::NoAuth,
+            dpop::{DPoP, SessionKeyedDPoP},
+            secrets::SecretString,
+        },
         grant::jwt_bearer::{JwtBearerGrant, JwtBearerGrantParameters},
         token::AccessToken,
     };
@@ -232,6 +258,62 @@ mod tests {
 
     fn http_client() -> ReqwestClient {
         reqwest::Client::new().into()
+    }
+
+    /// One grant per authorization server; a per-session grant derived from it
+    /// signs the token proof with that session's key.
+    #[tokio::test]
+    async fn test_exchange_with_session_dpop_key() {
+        use httpmock::prelude::*;
+
+        use crate::prelude::*;
+
+        let grant = JwtBearerGrant::builder()
+            .token_endpoint(
+                MOCK_SERVER
+                    .url("/session_dpop/jwt_bearer/token")
+                    .parse()
+                    .unwrap(),
+            )
+            .client_id("client")
+            .http_client(http_client())
+            .client_auth(NoAuth)
+            .dpop(SessionKeyedDPoP::new())
+            .build()
+            .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+            .unwrap();
+
+        let mock = MOCK_SERVER
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/session_dpop/jwt_bearer/token")
+                    .header_exists("DPoP")
+                    .form_urlencoded_tuple(
+                        "grant_type",
+                        "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    );
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .json_body(json!({
+                        "access_token": "access_token",
+                        "token_type": "DPoP",
+                    }));
+            })
+            .await;
+
+        let response = grant
+            .exchange(
+                JwtBearerGrantParameters::builder()
+                    .assertion("the.signed.assertion")
+                    .build(),
+            )
+            .await;
+
+        mock.assert();
+        assert!(matches!(
+            response.unwrap().access_token(),
+            AccessToken::DPoP(_)
+        ));
     }
 
     #[test]

--- a/huskarl/src/grant/refresh.rs
+++ b/huskarl/src/grant/refresh.rs
@@ -15,8 +15,9 @@ use serde::Serialize;
 
 use crate::{
     core::{
-        EndpointUrl,
+        EndpointUrl, Error,
         client_auth::ClientAuthentication,
+        crypto::signer::AsymmetricJwsSignerSelector,
         dpop::{AuthorizationServerDPoP, NoDPoP},
         http::HttpClient,
         secrets::SecretString,
@@ -75,6 +76,27 @@ pub struct RefreshGrant {
     /// form auth for client secrets.
     #[from_metadata(path = "token_endpoint_auth_methods_supported")]
     token_endpoint_auth_methods_supported: Option<Vec<String>>,
+}
+
+impl RefreshGrant {
+    /// Binds a per-session `DPoP` key, returning a grant that signs with it.
+    ///
+    /// Derived grants share the grant's server-scoped `DPoP` nonce, so one
+    /// grant per authorization server serves every session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the configured `DPoP` is
+    /// [`SessionKeyedDPoP`](crate::core::dpop::SessionKeyedDPoP).
+    pub fn with_session_dpop_key(
+        &self,
+        key: impl AsymmetricJwsSignerSelector + 'static,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            dpop: self.dpop.with_session_key(Arc::new(key))?,
+            ..self.clone()
+        })
+    }
 }
 
 impl core::fmt::Debug for RefreshGrant {
@@ -218,5 +240,97 @@ mod tests {
             !encoded.contains(','),
             "resource values should not be comma-joined: {encoded}"
         );
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod session_keyed_dpop_tests {
+    use std::sync::LazyLock;
+
+    use httpmock::MockServer;
+    use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
+    use huskarl_reqwest::ReqwestClient;
+    use serde_json::json;
+
+    use crate::{
+        core::{ErrorKind, client_auth::NoAuth, dpop::SessionKeyedDPoP, secrets::SecretString},
+        grant::{
+            core::OAuth2ExchangeGrant,
+            refresh::{RefreshGrant, RefreshGrantParameters},
+        },
+        token::{AccessToken, RefreshToken},
+    };
+
+    static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
+
+    fn http_client() -> ReqwestClient {
+        reqwest::Client::new().into()
+    }
+
+    /// One grant per authorization server; a per-session grant derived from it
+    /// drives a real `DPoP`-signed refresh request.
+    #[tokio::test]
+    async fn session_bound_grant_signs_dpop_proof() {
+        use httpmock::prelude::*;
+
+        let grant = RefreshGrant::builder()
+            .token_endpoint(MOCK_SERVER.url("/session_keyed/token").parse().unwrap())
+            .client_id("client")
+            .http_client(http_client())
+            .client_auth(NoAuth)
+            .dpop(SessionKeyedDPoP::new())
+            .build();
+
+        let mock = MOCK_SERVER
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/session_keyed/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .header_exists("DPoP")
+                    .form_urlencoded_tuple("grant_type", "refresh_token")
+                    .form_urlencoded_tuple("refresh_token", "the-refresh-token");
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .json_body(json!({
+                        "access_token": "access_token",
+                        "token_type": "DPoP",
+                    }));
+            })
+            .await;
+
+        let response = grant
+            .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+            .unwrap()
+            .exchange(
+                RefreshGrantParameters::builder()
+                    .refresh_token(RefreshToken::new(
+                        SecretString::new("the-refresh-token"),
+                        None,
+                    ))
+                    .build(),
+            )
+            .await;
+
+        mock.assert();
+        let response = response.unwrap();
+        assert!(matches!(response.access_token(), AccessToken::DPoP(_)));
+    }
+
+    /// Binding a per-session key onto a grant that is not session-keyed (here
+    /// the default `NoDPoP`) fails at binding time, before any request.
+    #[tokio::test]
+    async fn session_key_without_session_keyed_dpop_is_rejected() {
+        let grant = RefreshGrant::builder()
+            .token_endpoint(MOCK_SERVER.url("/never_called/token").parse().unwrap())
+            .client_id("client")
+            .http_client(http_client())
+            .client_auth(NoAuth)
+            .build();
+
+        let err = grant
+            .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+            .expect_err("binding a session key onto a NoDPoP grant must error");
+        assert_eq!(err.kind(), ErrorKind::DPoP);
     }
 }

--- a/huskarl/src/grant/token_exchange.rs
+++ b/huskarl/src/grant/token_exchange.rs
@@ -18,6 +18,7 @@ use crate::{
     core::{
         EndpointUrl, Error,
         client_auth::ClientAuthentication,
+        crypto::signer::AsymmetricJwsSignerSelector,
         dpop::{AuthorizationServerDPoP, NoDPoP},
         http::HttpClient,
         platform::MaybeSendBoxFuture,
@@ -37,7 +38,7 @@ use crate::{
 ///
 /// See the [module documentation][crate::grant::token_exchange] for a usage guide.
 #[huskarl_macros::from_metadata(metadata = crate::core::server_metadata::AuthorizationServerMetadata)]
-#[derive(Builder)]
+#[derive(Clone, Builder)]
 #[builder(on(String, into))]
 pub struct TokenExchangeGrant {
     /// The client ID. Optional: omit it for an unidentified client (RFC 8693 §2
@@ -84,6 +85,27 @@ pub struct TokenExchangeGrant {
     /// form auth for client secrets.
     #[from_metadata(path = "token_endpoint_auth_methods_supported")]
     token_endpoint_auth_methods_supported: Option<Vec<String>>,
+}
+
+impl TokenExchangeGrant {
+    /// Binds a per-session `DPoP` key, returning a grant that signs with it.
+    ///
+    /// Derived grants share the grant's server-scoped `DPoP` nonce, so one
+    /// grant per authorization server serves every session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the configured `DPoP` is
+    /// [`SessionKeyedDPoP`](crate::core::dpop::SessionKeyedDPoP).
+    pub fn with_session_dpop_key(
+        &self,
+        key: impl AsymmetricJwsSignerSelector + 'static,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            dpop: self.dpop.with_session_key(Arc::new(key))?,
+            ..self.clone()
+        })
+    }
 }
 
 impl core::fmt::Debug for TokenExchangeGrant {
@@ -429,4 +451,90 @@ pub struct TokenExchangeGrantForm {
     subject_token_type: SecurityTokenType,
     actor_token: Option<SecretString>,
     actor_token_type: Option<SecurityTokenType>,
+}
+
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod session_dpop_tests {
+    use std::sync::LazyLock;
+
+    use httpmock::MockServer;
+    use huskarl_crypto_native::asymmetric::signer::{GenerateAlgorithm, PrivateKey};
+    use huskarl_reqwest::ReqwestClient;
+    use serde_json::json;
+
+    use super::{
+        SecurityToken, SecurityTokenType, TokenExchangeGrant, TokenExchangeGrantParameters,
+    };
+    use crate::{
+        core::{client_auth::NoAuth, dpop::SessionKeyedDPoP},
+        grant::core::OAuth2ExchangeGrant,
+        token::AccessToken,
+    };
+
+    static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
+
+    fn http_client() -> ReqwestClient {
+        reqwest::Client::new().into()
+    }
+
+    /// One grant per authorization server; a per-session grant derived from it
+    /// signs the token proof with that session's key.
+    #[tokio::test]
+    async fn exchange_with_session_dpop_key() {
+        use httpmock::prelude::*;
+
+        let grant = TokenExchangeGrant::builder()
+            .token_endpoint(
+                MOCK_SERVER
+                    .url("/session_dpop/token_exchange/token")
+                    .parse()
+                    .unwrap(),
+            )
+            .client_id("client")
+            .http_client(http_client())
+            .client_auth(NoAuth)
+            .dpop(SessionKeyedDPoP::new())
+            .build()
+            .with_session_dpop_key(PrivateKey::generate(GenerateAlgorithm::Es256, None).unwrap())
+            .unwrap();
+
+        let mock = MOCK_SERVER
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/session_dpop/token_exchange/token")
+                    .header_exists("DPoP")
+                    .form_urlencoded_tuple(
+                        "grant_type",
+                        "urn:ietf:params:oauth:grant-type:token-exchange",
+                    );
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .json_body(json!({
+                        "access_token": "access_token",
+                        "token_type": "DPoP",
+                        "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                    }));
+            })
+            .await;
+
+        let response = grant
+            .exchange(
+                TokenExchangeGrantParameters::builder()
+                    .subject(
+                        SecurityToken::builder()
+                            .token("subject-token")
+                            .token_type(SecurityTokenType::AccessToken)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .await;
+
+        mock.assert();
+        assert!(matches!(
+            response.unwrap().access_token(),
+            AccessToken::DPoP(_)
+        ));
+    }
 }


### PR DESCRIPTION
One SessionKeyedDPoP grant per authorization server; derive a per-session grant with with_session_dpop_key(key), which shares the server-scoped nonce. A bound grant flows through GrantTokenSource, refresh, and resource-server proofs unchanged.