### PR TITLE
refactor(crypto): Split sealing into its own module.

### DIFF
--- a/huskarl-core/docs/explanation/crypto_strategies.md
+++ b/huskarl-core/docs/explanation/crypto_strategies.md
@@ -204,12 +204,22 @@ reload on an explicit rotation event.
 
 ## Sealing: self-contained bundles
 
-Encryption has one more layer for values that must travel on their own —
-encrypted cookies, stateless tokens — where the nonce and tag have to ride along
-with the ciphertext. [`AeadSealer`](crate::crypto::cipher::AeadSealer) and
-[`AeadUnsealer`](crate::crypto::cipher::AeadUnsealer) describe that operation:
+The [`cipher`](crate::crypto::cipher) traits are the flexible base: they expose
+the AEAD operation in its `(nonce, ciphertext, tag)` parts, which is exactly what
+a scheme like JWE needs — it places each part in its own header/segment. Most
+callers, though, don't want to manage those parts; they just need to encrypt a
+value, store or send it, and decrypt it later. [`seal`](crate::crypto::seal) is
+that convenience layer, built *on* `cipher`: it packs the parts into one opaque,
+self-contained bundle. The trade is deliberate — the bundle framing is
+huskarl's own, so sealing is the wrong tool for JWE (whose framing is fixed by
+spec); reach past it to the `cipher` traits there.
+
+Sealing suits values that must travel on their own — encrypted cookies, stateless
+tokens — where the nonce and tag must be carried alongside the ciphertext.
+[`AeadSealer`](crate::crypto::seal::AeadSealer) and
+[`AeadUnsealer`](crate::crypto::seal::AeadUnsealer) describe that operation:
 sealing packs one opaque byte string, unsealing re-opens it.
-[`AeadV1Cipher`](crate::crypto::cipher::AeadV1Cipher) is the local
+[`AeadV1Sealer`](crate::crypto::seal::AeadV1Sealer) is the local
 implementation, framing an AEAD operation as a versioned, self-describing bundle
 (`[0x01 || nonce_len || tag_len || nonce || ciphertext || tag]`) over any inner
 key stack. Its impls are capability-conditional: an
@@ -217,25 +227,25 @@ key stack. Its impls are capability-conditional: an
 yields a sealer; an [`AeadDecryptor`](crate::crypto::cipher::AeadDecryptor) — a
 retired rotation key that can still open old bundles, say — yields an unsealer;
 and an inner with both, an [`AeadCipher`](crate::crypto::cipher::AeadCipher),
-yields an [`AeadSealerUnsealer`](crate::crypto::cipher::AeadSealerUnsealer), the
+yields an [`AeadSealerUnsealer`](crate::crypto::seal::AeadSealerUnsealer), the
 combined trait that erases to one `Arc<dyn AeadSealerUnsealer>` carrying both
 directions.
 
 Sealing is an **outbound** operation, but unlike signing it needs no separate
-selector trait: each [`seal`](crate::crypto::cipher::AeadSealer::seal) selects
+selector trait: each [`seal`](crate::crypto::seal::AeadSealer::seal) selects
 one frozen encryptor snapshot internally and runs the whole encrypt-then-frame
 sequence against it, so a rotation cannot land between choosing the key and
 using it — the read-header-then-sign hazard, closed off inside the one call.
 Key identity crosses the seam as a value: `seal` returns the bundle together
 with the `kid` of the key that sealed it, read off that same frozen snapshot,
-and [`unseal`](crate::crypto::cipher::AeadUnsealer::unseal) takes it back for
+and [`unseal`](crate::crypto::seal::AeadUnsealer::unseal) takes it back for
 direct key dispatch. Stored beside the bundle, the kid makes "which key
 protects this record" a metadata query; discarded, a multi-key unsealer tries
 its candidates, and the AEAD tag makes a wrong key a clean authentication
 failure, never a wrong plaintext. A kid only selects a key — an untrusted
 value can at worst cause a miss — and the bundle itself stays kid-free.
 
-Because a raw key is already a selector, `AeadV1Cipher::new(key)` is the whole
+Because a raw key is already a selector, `AeadV1Sealer::new(key)` is the whole
 fixed-key story. For a rotating key, put a
 [`ScheduledRefreshCipher`](crate::crypto::cipher::ScheduledRefreshCipher) (or
 [`RefreshableCipher`](crate::crypto::cipher::RefreshableCipher)) inside instead,
@@ -256,8 +266,8 @@ encryption can be delegated wholesale to an external service. A KMS- or
 Vault-style encrypt endpoint returns one opaque, self-describing token — there
 is no nonce/ciphertext/tag decomposition to expose, so such a service cannot
 implement [`AeadEncryptor`](crate::crypto::cipher::AeadEncryptor) at all — but
-it implements [`AeadSealer`](crate::crypto::cipher::AeadSealer) /
-[`AeadUnsealer`](crate::crypto::cipher::AeadUnsealer) naturally, handling
+it implements [`AeadSealer`](crate::crypto::seal::AeadSealer) /
+[`AeadUnsealer`](crate::crypto::seal::AeadUnsealer) naturally, handling
 rotation on its own side. It reports whatever key identity its service does —
 a KMS response often names the exact key version — or `None`; its tokens name
 their key internally either way, so unsealing may ignore the hint. Consumers

--- a/huskarl-core/fuzz/fuzz_targets/unseal_v1.rs
+++ b/huskarl-core/fuzz/fuzz_targets/unseal_v1.rs
@@ -6,9 +6,8 @@
 #![no_main]
 
 use huskarl_core::crypto::KeyMatchStrength;
-use huskarl_core::crypto::cipher::{
-    AeadDecryptor, AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError,
-};
+use huskarl_core::crypto::cipher::{AeadDecryptor, CipherMatch, DecryptError};
+use huskarl_core::crypto::seal::{AeadUnsealer, AeadV1Sealer};
 use huskarl_core::platform::MaybeSendBoxFuture;
 use libfuzzer_sys::fuzz_target;
 
@@ -43,7 +42,7 @@ impl AeadDecryptor for PassthroughDecryptor {
 }
 
 fuzz_target!(|data: &[u8]| {
-    let unsealer = AeadV1Cipher::new(PassthroughDecryptor);
+    let unsealer = AeadV1Sealer::new(PassthroughDecryptor);
     // Peel off up to 8 leading bytes as AAD so that path isn't always empty.
     let (aad, bundle) = data.split_at(data.len().min(8));
     let _ = futures_executor::block_on(unsealer.unseal(bundle, aad, None));

--- a/huskarl-core/src/crypto/cipher/error.rs
+++ b/huskarl-core/src/crypto/cipher/error.rs
@@ -36,21 +36,3 @@ impl DecryptError {
         }
     }
 }
-
-/// Errors that could occur during AEAD unsealing.
-///
-/// Used as the source of [`ErrorKind::Crypto`](crate::error::ErrorKind::Crypto)
-/// errors — cipher implementations construct these to describe *why* an
-/// unseal failed without expanding the kind-level vocabulary.
-///
-/// This covers only failures the framing layer itself detects. An
-/// authentication-tag mismatch is raised by the inner
-/// [`AeadDecryptor`](super::AeadDecryptor) and flows through as
-/// [`DecryptError::Other`], not as an `UnsealError`.
-#[non_exhaustive]
-#[derive(Debug, Snafu)]
-pub enum UnsealError {
-    /// The bundle is malformed or uses an unsupported version.
-    #[snafu(display("invalid bundle"))]
-    InvalidBundle,
-}

--- a/huskarl-core/src/crypto/cipher/metrics_encryptor.rs
+++ b/huskarl-core/src/crypto/cipher/metrics_encryptor.rs
@@ -52,9 +52,10 @@ use crate::{
 /// # Example
 ///
 /// ```rust,no_run
-/// # use huskarl_core::crypto::cipher::{AeadV1Cipher, MetricsAeadEncryptorSelector};
+/// # use huskarl_core::crypto::cipher::MetricsAeadEncryptorSelector;
+/// # use huskarl_core::crypto::seal::AeadV1Sealer;
 /// # let my_cipher = (); // your inner `AeadCipher` / `AeadEncryptorSelector`
-/// let sealer = AeadV1Cipher::new(
+/// let sealer = AeadV1Sealer::new(
 ///     MetricsAeadEncryptorSelector::builder()
 ///         .inner(my_cipher)
 ///         .name("session-cookie")

--- a/huskarl-core/src/crypto/cipher/mod.rs
+++ b/huskarl-core/src/crypto/cipher/mod.rs
@@ -1,4 +1,6 @@
-//! Cipher implementations for encryption and decryption.
+//! AEAD content encryption and decryption: the parts-level
+//! `(nonce, ciphertext, tag)` primitives that content-encryption schemes such
+//! as JWE and the [sealing](crate::crypto::seal) layer build on.
 
 mod error;
 #[cfg(feature = "metrics")]
@@ -13,7 +15,7 @@ mod scheduled;
 use std::{borrow::Cow, sync::Arc};
 
 use bon::Builder;
-pub use error::{DecryptError, UnsealError};
+pub use error::DecryptError;
 #[cfg(feature = "metrics")]
 pub use metrics_decryptor::MetricsAeadDecryptor;
 #[cfg(feature = "metrics")]
@@ -25,7 +27,7 @@ pub use scheduled::ScheduledRefreshCipher;
 
 use crate::{
     crypto::KeyMatchStrength,
-    error::{Error, ErrorKind},
+    error::Error,
     platform::{MaybeSendBoxFuture, MaybeSendSync},
 };
 
@@ -85,7 +87,7 @@ impl CipherMatch<'_> {
 ///
 /// This trait is dyn-capable: consumers store it as `Arc<dyn AeadEncryptor>`.
 /// Write the `encrypt` body as `Box::pin(async move { ... })`; failures
-/// classify as [`ErrorKind::Crypto`].
+/// classify as [`ErrorKind::Crypto`](crate::error::ErrorKind::Crypto).
 pub trait AeadEncryptor: std::fmt::Debug + MaybeSendSync {
     /// Returns the content encryption algorithm identifier (e.g. `A256GCM`).
     fn enc_algorithm(&self) -> Cow<'_, str>;
@@ -102,7 +104,7 @@ pub trait AeadEncryptor: std::fmt::Debug + MaybeSendSync {
     ///
     /// # Errors
     ///
-    /// Returns [`ErrorKind::Crypto`] if the encryption operation fails.
+    /// Returns [`ErrorKind::Crypto`](crate::error::ErrorKind::Crypto) if the encryption operation fails.
     fn encrypt<'a>(
         &'a self,
         plaintext: &'a [u8],
@@ -164,7 +166,7 @@ pub trait AeadDecryptor: std::fmt::Debug + MaybeSendSync {
     /// criteria — decryption was not attempted, and
     /// [`RetryingDecryptor`] treats this as grounds for a refresh and one
     /// retry. All other failures — including authentication failure — classify
-    /// as [`ErrorKind::Crypto`] via [`DecryptError::Other`].
+    /// as [`ErrorKind::Crypto`](crate::error::ErrorKind::Crypto) via [`DecryptError::Other`].
     fn decrypt<'a>(
         &'a self,
         cipher_match: Option<&'a CipherMatch<'a>>,
@@ -246,512 +248,40 @@ impl<T: AeadEncryptorSelector + ?Sized> AeadEncryptorSelector for Arc<T> {
     }
 }
 
-/// The output from [`AeadSealer::seal`]
-pub struct SealOutput {
-    /// The opaque, self-describing bundle.
-    pub bundle: Vec<u8>,
-    /// The key ID of the key that sealed, when the implementation tracks one.
-    pub kid: Option<String>,
-}
+// ── Compatibility shims (deprecated in 0.9.1) ──────────────────────────────
+// The sealing seam moved to [`crate::crypto::seal`], and `AeadV1Cipher` was
+// renamed to `AeadV1Sealer`. These re-exports keep the 0.9.0 paths compiling.
 
-/// An encryptor that produces self-contained bundles.
-///
-/// Where [`AeadEncryptor::encrypt`] returns the nonce, ciphertext, and tag as
-/// separate fields, a sealer hands back one opaque byte string so the value
-/// can travel on its own — an encrypted cookie, a stateless token — and be
-/// re-opened later ([`AeadUnsealer`]) with just the bundle and the key.
-/// [`AeadV1Cipher`] is the local implementation; see it for a worked example.
-///
-/// This trait is dyn-capable: consumers store it as `Arc<dyn AeadSealer>`, or
-/// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
-pub trait AeadSealer: std::fmt::Debug + MaybeSendSync {
-    /// Encrypts `plaintext` into a [`SealOutput`]: an opaque, self-describing
-    /// bundle that a matching [`AeadUnsealer`] can re-open, plus the kid of
-    /// the key that sealed it, when the implementation tracks one. The bundle
-    /// layout belongs to the implementation — an externally-managed sealer
-    /// returns its service's token verbatim.
-    ///
-    /// Store the kid beside the bundle for direct key dispatch in
-    /// [`unseal`](AeadUnsealer::unseal); discarding it is equally valid.
-    fn seal<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>>;
-}
+/// Renamed and moved to [`crate::crypto::seal::AeadV1Sealer`].
+#[deprecated(
+    since = "0.9.1",
+    note = "renamed and moved to `huskarl_core::crypto::seal::AeadV1Sealer`"
+)]
+pub type AeadV1Cipher<C> = crate::crypto::seal::AeadV1Sealer<C>;
 
-/// A decryptor that consumes self-contained bundles produced by [`AeadSealer`].
-///
-/// This trait is dyn-capable: consumers store it as `Arc<dyn AeadUnsealer>`, or
-/// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
-pub trait AeadUnsealer: std::fmt::Debug + MaybeSendSync {
-    /// Decrypts a bundle produced by [`AeadSealer::seal`].
-    ///
-    /// `kid` is the key ID [`seal`](AeadSealer::seal) returned with the
-    /// bundle, if the caller stored it: multi-key implementations use it to
-    /// select the key directly. `None` is always safe — the AEAD tag makes a
-    /// wrong key a clean failure. A kid only selects, so an untrusted value
-    /// can at worst cause a miss.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DecryptError::NoMatchingKey`] if no key matched the given
-    /// `kid`; all other failures — malformed bundles, authentication
-    /// failure — classify as [`ErrorKind::Crypto`] via [`DecryptError::Other`].
-    fn unseal<'a>(
-        &'a self,
-        bundle: &'a [u8],
-        aad: &'a [u8],
-        kid: Option<&'a str>,
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>>;
-}
+/// Moved to [`crate::crypto::seal::SealOutput`].
+#[deprecated(
+    since = "0.9.1",
+    note = "moved to `huskarl_core::crypto::seal::SealOutput`"
+)]
+pub type SealOutput = crate::crypto::seal::SealOutput;
 
-/// Combined trait for types that can both seal and unseal.
-///
-/// Automatically implemented for any type with both capabilities. Store as
-/// `Arc<dyn AeadSealerUnsealer>` when both directions must come from the same
-/// source — an [`AeadV1Cipher`] over one key, or an externally-managed sealer
-/// (e.g. a KMS/Vault encrypt endpoint) whose tokens only it can re-open.
-pub trait AeadSealerUnsealer: AeadSealer + AeadUnsealer {}
+/// Moved to [`crate::crypto::seal::UnsealError`].
+#[deprecated(
+    since = "0.9.1",
+    note = "moved to `huskarl_core::crypto::seal::UnsealError`"
+)]
+pub type UnsealError = crate::crypto::seal::UnsealError;
 
-impl<T: AeadSealer + AeadUnsealer + ?Sized> AeadSealerUnsealer for T {}
-
-impl<T: AeadSealer + ?Sized> AeadSealer for Arc<T> {
-    fn seal<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>> {
-        self.as_ref().seal(plaintext, aad)
-    }
-}
-
-impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
-    fn unseal<'a>(
-        &'a self,
-        bundle: &'a [u8],
-        aad: &'a [u8],
-        kid: Option<&'a str>,
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        self.as_ref().unseal(bundle, aad, kid)
-    }
-}
-
-/// A bundle wrapper over an AEAD cipher using the v1 format:
-/// `[0x01 || nonce_len:u8 || tag_len:u8 || nonce || ciphertext || tag]`.
-///
-/// The implementations are conditional on the inner type's capabilities:
-/// wrapping an [`AeadCipher`] (a symmetric key, a rotating multi-key stack, or
-/// a KMS-backed cipher that handles both directions as one consistent object)
-/// yields an [`AeadSealerUnsealer`]; an [`AeadEncryptorSelector`] alone yields
-/// only an [`AeadSealer`], and a decrypt-only [`AeadDecryptor`] (e.g. a
-/// retired rotation key) only an [`AeadUnsealer`]. Each `seal` selects a
-/// frozen encryptor snapshot internally, so a rotation landing mid-seal cannot
-/// split one bundle across two keys.
-///
-/// # Example
-///
-/// ```
-/// # use std::borrow::Cow;
-/// # use huskarl_core::crypto::KeyMatchStrength;
-/// # use std::sync::Arc;
-/// # use huskarl_core::crypto::cipher::{
-/// #     AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, AeadOutput, AeadSealer,
-/// #     AeadUnsealer, AeadV1Cipher, CipherMatch, DecryptError, SealOutput,
-/// # };
-/// # use huskarl_core::error::Error;
-/// # use huskarl_core::platform::MaybeSendBoxFuture;
-/// # // Stand-in for the AEAD key a crypto backend (native / WebCrypto) provides:
-/// # // the key is a selector handing out its shared inner encryptor.
-/// # #[derive(Debug)]
-/// # struct BackendEncryptor;
-/// # impl AeadEncryptor for BackendEncryptor {
-/// #     fn enc_algorithm(&self) -> Cow<'_, str> { "A256GCM".into() }
-/// #     fn key_id(&self) -> Option<Cow<'_, str>> { Some("2026-07".into()) }
-/// #     fn encrypt<'a>(&'a self, plaintext: &'a [u8], _aad: &'a [u8])
-/// #         -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-/// #         let ciphertext = plaintext.to_vec();
-/// #         Box::pin(async move { Ok(AeadOutput { nonce: vec![7], ciphertext, tag: vec![9] }) })
-/// #     }
-/// # }
-/// # #[derive(Debug)]
-/// # struct BackendCipher { inner: Arc<BackendEncryptor> }
-/// # impl BackendCipher {
-/// #     fn new() -> Self { Self { inner: Arc::new(BackendEncryptor) } }
-/// # }
-/// # impl AeadEncryptorSelector for BackendCipher {
-/// #     fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-/// #         let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
-/// #         Box::pin(async move { snapshot })
-/// #     }
-/// # }
-/// # impl AeadDecryptor for BackendCipher {
-/// #     fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-/// #         Some(KeyMatchStrength::ByAlgorithm)
-/// #     }
-/// #     fn decrypt<'a>(&'a self, _cm: Option<&'a CipherMatch<'a>>, _nonce: &'a [u8],
-/// #         ciphertext: &'a [u8], _tag: &'a [u8], _aad: &'a [u8])
-/// #         -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-/// #         let plaintext = ciphertext.to_vec();
-/// #         Box::pin(async move { Ok(plaintext) })
-/// #     }
-/// # }
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let cipher = AeadV1Cipher::new(BackendCipher::new());
-///
-/// // `seal` packs the version byte, nonce, tag and ciphertext into one
-/// // bundle, plus the kid of the key that sealed it...
-/// let SealOutput { bundle, kid } = cipher.seal(b"session-state", b"aad").await?;
-/// // ...which dispatches `unseal` straight to that key (`None` tries all).
-/// let recovered = cipher.unseal(&bundle, b"aad", kid.as_deref()).await?;
-/// assert_eq!(recovered, b"session-state");
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug)]
-pub struct AeadV1Cipher<C>(C);
-
-impl<C> AeadV1Cipher<C> {
-    /// Wraps a cipher in the v1 bundle format.
-    pub fn new(cipher: C) -> Self {
-        Self(cipher)
-    }
-}
-
-impl<C: AeadEncryptorSelector> AeadSealer for AeadV1Cipher<C> {
-    fn seal<'a>(
-        &'a self,
-        plaintext: &'a [u8],
-        aad: &'a [u8],
-    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>> {
-        Box::pin(async move {
-            // One frozen snapshot per seal: under rotation, the returned kid
-            // names exactly the key that sealed.
-            let encryptor = self.0.select_encryptor().await;
-            let kid = encryptor.key_id().map(Cow::into_owned);
-            let output = encryptor.encrypt(plaintext, aad).await?;
-
-            let nonce_len: u8 = output.nonce.len().try_into().map_err(|_| {
-                Error::new(crate::ErrorKind::Crypto, "nonce length exceeds u8::MAX")
-            })?;
-            let tag_len: u8 =
-                output.tag.len().try_into().map_err(|_| {
-                    Error::new(crate::ErrorKind::Crypto, "tag length exceeds u8::MAX")
-                })?;
-
-            let mut bundle = Vec::with_capacity(
-                3 + output.nonce.len() + output.ciphertext.len() + output.tag.len(),
-            );
-            bundle.push(0x01);
-            bundle.push(nonce_len);
-            bundle.push(tag_len);
-            bundle.extend_from_slice(&output.nonce);
-            bundle.extend_from_slice(&output.ciphertext);
-            bundle.extend_from_slice(&output.tag);
-
-            Ok(SealOutput { bundle, kid })
-        })
-    }
-}
-
-fn invalid_bundle() -> Error {
-    Error::new(ErrorKind::Crypto, UnsealError::InvalidBundle)
-}
-
-impl<C: AeadDecryptor> AeadUnsealer for AeadV1Cipher<C> {
-    fn unseal<'a>(
-        &'a self,
-        bundle: &'a [u8],
-        aad: &'a [u8],
-        kid: Option<&'a str>,
-    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-        Box::pin(async move {
-            if bundle.len() < 3 || bundle[0] != 0x01 {
-                return Err(invalid_bundle().into());
-            }
-
-            let nonce_len = bundle[1] as usize;
-            let tag_len = bundle[2] as usize;
-
-            if bundle.len() < 3 + nonce_len + tag_len {
-                return Err(invalid_bundle().into());
-            }
-
-            let nonce = &bundle[3..3 + nonce_len];
-            let tag = &bundle[bundle.len() - tag_len..];
-            let ciphertext = &bundle[3 + nonce_len..bundle.len() - tag_len];
-
-            let cipher_match = kid.map(|kid| CipherMatch::builder().kid(kid).build());
-
-            self.0
-                .decrypt(cipher_match.as_ref(), nonce, ciphertext, tag, aad)
-                .await
-        })
-    }
-}
+// Trait re-exports: rustc does not lint deprecated `use` re-exports, so these
+// resolve silently for back-compat (rustdoc still renders the deprecation).
+// Prefer the `crate::crypto::seal` paths.
+#[deprecated(since = "0.9.1", note = "moved to `huskarl_core::crypto::seal`")]
+pub use crate::crypto::seal::{AeadSealer, AeadSealerUnsealer, AeadUnsealer};
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[derive(Debug)]
-    struct MockEncryptor;
-
-    impl AeadEncryptor for MockEncryptor {
-        fn enc_algorithm(&self) -> Cow<'_, str> {
-            "mock".into()
-        }
-
-        fn key_id(&self) -> Option<Cow<'_, str>> {
-            Some("mock-kid".into())
-        }
-
-        fn encrypt<'a>(
-            &'a self,
-            plaintext: &'a [u8],
-            _aad: &'a [u8],
-        ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
-            Box::pin(async move {
-                Ok(AeadOutput {
-                    nonce: vec![1, 2, 3],
-                    ciphertext: plaintext.iter().map(|b| b ^ 0xFF).collect(),
-                    tag: vec![4, 5, 6, 7],
-                })
-            })
-        }
-    }
-
-    /// Raw-key shape: a selector handing out its shared inner encryptor.
-    #[derive(Debug)]
-    struct MockKey {
-        inner: Arc<MockEncryptor>,
-    }
-
-    impl MockKey {
-        fn new() -> Self {
-            Self {
-                inner: Arc::new(MockEncryptor),
-            }
-        }
-    }
-
-    impl AeadEncryptorSelector for MockKey {
-        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
-            Box::pin(async move { snapshot })
-        }
-    }
-
-    #[derive(Debug)]
-    struct MockDecryptor;
-
-    impl AeadDecryptor for MockDecryptor {
-        fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-            Some(KeyMatchStrength::ByAlgorithm)
-        }
-
-        fn decrypt<'a>(
-            &'a self,
-            _cipher_match: Option<&'a CipherMatch<'a>>,
-            _nonce: &'a [u8],
-            ciphertext: &'a [u8],
-            _tag: &'a [u8],
-            _aad: &'a [u8],
-        ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-            // Reverse the XOR
-            Box::pin(async move { Ok(ciphertext.iter().map(|b| b ^ 0xFF).collect()) })
-        }
-    }
-
-    /// One object with both capabilities (the symmetric-key / KMS shape).
-    #[derive(Debug)]
-    struct MockCipher {
-        inner: Arc<MockEncryptor>,
-    }
-
-    impl MockCipher {
-        fn new() -> Self {
-            Self {
-                inner: Arc::new(MockEncryptor),
-            }
-        }
-    }
-
-    impl AeadEncryptorSelector for MockCipher {
-        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
-            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
-            Box::pin(async move { snapshot })
-        }
-    }
-
-    impl AeadDecryptor for MockCipher {
-        fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-            MockDecryptor.cipher_match(m)
-        }
-
-        fn decrypt<'a>(
-            &'a self,
-            cipher_match: Option<&'a CipherMatch<'a>>,
-            nonce: &'a [u8],
-            ciphertext: &'a [u8],
-            tag: &'a [u8],
-            aad: &'a [u8],
-        ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-            Box::pin(async move {
-                MockDecryptor
-                    .decrypt(cipher_match, nonce, ciphertext, tag, aad)
-                    .await
-            })
-        }
-    }
-
-    fn assert_invalid_bundle(err: &DecryptError) {
-        let DecryptError::Other { source } = err else {
-            unreachable!("expected DecryptError::Other, got {err:?}");
-        };
-        assert_eq!(source.kind(), ErrorKind::Crypto);
-        assert_eq!(source.to_string(), "cryptographic operation failed");
-        assert_eq!(
-            std::error::Error::source(source)
-                .expect("source")
-                .to_string(),
-            "invalid bundle"
-        );
-    }
-
-    #[tokio::test]
-    async fn seal_roundtrip() {
-        let plaintext = b"hello world";
-        let aad = b"associated";
-
-        let sealer = AeadV1Cipher::new(MockKey::new());
-        let SealOutput { bundle, kid } = sealer.seal(plaintext, aad).await.unwrap();
-        assert_eq!(kid.as_deref(), Some("mock-kid"));
-
-        let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let recovered = unsealer.unseal(&bundle, aad, kid.as_deref()).await.unwrap();
-        assert_eq!(recovered, plaintext);
-    }
-
-    #[tokio::test]
-    async fn erased_cipher_roundtrip() {
-        let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Cipher::new(MockKey::new()));
-        let SealOutput { bundle, .. } = sealer.seal(b"hello", b"").await.unwrap();
-
-        let unsealer: Arc<dyn AeadUnsealer> = Arc::new(AeadV1Cipher::new(MockDecryptor));
-        let recovered = unsealer.unseal(&bundle, b"", None).await.unwrap();
-        assert_eq!(recovered, b"hello");
-    }
-
-    /// The erased combined type must satisfy generic `S: AeadSealerUnsealer`
-    /// bounds (e.g. `SealedTimestampNonce`) — construction, not just method calls.
-    #[tokio::test]
-    async fn erased_sealer_unsealer_satisfies_combined_bound() {
-        fn assert_combined<S: AeadSealerUnsealer>(s: S) -> S {
-            s
-        }
-
-        let cipher: Arc<dyn AeadSealerUnsealer> = Arc::new(AeadV1Cipher::new(MockCipher::new()));
-        let cipher = assert_combined(cipher);
-        let SealOutput { bundle, .. } = cipher.seal(b"hello", b"aad").await.unwrap();
-        let recovered = cipher.unseal(&bundle, b"aad", None).await.unwrap();
-        assert_eq!(recovered, b"hello");
-    }
-
-    #[tokio::test]
-    async fn bundle_format() {
-        let plaintext = b"AB";
-        let sealer = AeadV1Cipher::new(MockKey::new());
-        let SealOutput { bundle, .. } = sealer.seal(plaintext, b"").await.unwrap();
-
-        // [0x01, nonce_len=3, tag_len=4, nonce=[1,2,3], ciphertext=[0xBE, 0xBD], tag=[4,5,6,7]]
-        assert_eq!(bundle[0], 0x01);
-        assert_eq!(bundle[1], 3); // nonce_len
-        assert_eq!(bundle[2], 4); // tag_len
-        assert_eq!(&bundle[3..6], &[1, 2, 3]); // nonce
-        assert_eq!(&bundle[6..8], &[0x41 ^ 0xFF, 0x42 ^ 0xFF]); // ciphertext
-        assert_eq!(&bundle[8..12], &[4, 5, 6, 7]); // tag
-    }
-
-    #[tokio::test]
-    async fn unseal_wrong_version() {
-        let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let err = unsealer.unseal(&[0x02, 0, 0], b"", None).await.unwrap_err();
-        assert_invalid_bundle(&err);
-    }
-
-    #[tokio::test]
-    async fn unseal_too_short() {
-        let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let err = unsealer.unseal(&[0x01], b"", None).await.unwrap_err();
-        assert_invalid_bundle(&err);
-    }
-
-    #[tokio::test]
-    async fn unseal_truncated() {
-        let unsealer = AeadV1Cipher::new(MockDecryptor);
-        // nonce_len=10, tag_len=10, but only 1 byte of data after header
-        let err = unsealer
-            .unseal(&[0x01, 10, 10, 0x00], b"", None)
-            .await
-            .unwrap_err();
-        assert_invalid_bundle(&err);
-    }
-
-    #[tokio::test]
-    async fn unseal_empty() {
-        let unsealer = AeadV1Cipher::new(MockDecryptor);
-        let err = unsealer.unseal(&[], b"", None).await.unwrap_err();
-        assert_invalid_bundle(&err);
-    }
-
-    /// The kid handed to `unseal` must reach the inner decryptor as a
-    /// kid-only [`CipherMatch`]; `None` must arrive as no criteria at all.
-    #[tokio::test]
-    async fn unseal_forwards_kid_as_cipher_match() {
-        #[derive(Debug)]
-        struct KidAssertingDecryptor {
-            expected: Option<&'static str>,
-        }
-
-        impl AeadDecryptor for KidAssertingDecryptor {
-            fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
-                Some(KeyMatchStrength::ByAlgorithm)
-            }
-
-            fn decrypt<'a>(
-                &'a self,
-                cipher_match: Option<&'a CipherMatch<'a>>,
-                _nonce: &'a [u8],
-                ciphertext: &'a [u8],
-                _tag: &'a [u8],
-                _aad: &'a [u8],
-            ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
-                assert_eq!(cipher_match.and_then(|m| m.kid), self.expected);
-                assert_eq!(cipher_match.and_then(|m| m.enc), None);
-                Box::pin(async move { Ok(ciphertext.to_vec()) })
-            }
-        }
-
-        let SealOutput { bundle, .. } = AeadV1Cipher::new(MockKey::new())
-            .seal(b"x", b"")
-            .await
-            .unwrap();
-        for (unsealer, kid) in [
-            (
-                AeadV1Cipher::new(KidAssertingDecryptor {
-                    expected: Some("mock-kid"),
-                }),
-                Some("mock-kid"),
-            ),
-            (
-                AeadV1Cipher::new(KidAssertingDecryptor { expected: None }),
-                None,
-            ),
-        ] {
-            unsealer.unseal(&bundle, b"", kid).await.unwrap();
-        }
-    }
 
     fn cipher_match<'a>(enc: Option<&'a str>, kid: Option<&'a str>) -> CipherMatch<'a> {
         CipherMatch { enc, kid }

--- a/huskarl-core/src/crypto/cipher/multi.rs
+++ b/huskarl-core/src/crypto/cipher/multi.rs
@@ -254,9 +254,8 @@ mod tests {
         Error,
         crypto::{
             KeyMatchStrength::*,
-            cipher::{
-                AeadOutput, AeadSealer, AeadSealerUnsealer, AeadUnsealer, AeadV1Cipher, SealOutput,
-            },
+            cipher::AeadOutput,
+            seal::{AeadSealer, AeadSealerUnsealer, AeadUnsealer, AeadV1Sealer, SealOutput},
         },
         error::ErrorKind,
     };
@@ -620,7 +619,7 @@ mod tests {
         }
     }
 
-    /// The rotated-cookie-keys shape: one `AeadV1Cipher<MultiKeyCipher>` seals
+    /// The rotated-cookie-keys shape: one `AeadV1Sealer<MultiKeyCipher>` seals
     /// every new cookie with the current primary key while still unsealing cookies
     /// sealed by any key left in the decryptor set — and a key dropped from the set
     /// can no longer open its old cookies. Erased to `Arc<dyn AeadSealerUnsealer>`,
@@ -633,7 +632,7 @@ mod tests {
         let SealOutput {
             bundle: old_v1,
             kid: old_v1_kid,
-        } = AeadV1Cipher::new(KeyedCookieCipher::new("v1"))
+        } = AeadV1Sealer::new(KeyedCookieCipher::new("v1"))
             .seal(b"session", b"aad")
             .await
             .unwrap();
@@ -641,14 +640,14 @@ mod tests {
         let SealOutput {
             bundle: retired_v0,
             kid: retired_v0_kid,
-        } = AeadV1Cipher::new(KeyedCookieCipher::new("v0"))
+        } = AeadV1Sealer::new(KeyedCookieCipher::new("v0"))
             .seal(b"session", b"aad")
             .await
             .unwrap();
 
         // After rotation: seal with v2, still decrypt v2 and v1 (v0 dropped).
         let cookies: Arc<dyn AeadSealerUnsealer> =
-            Arc::new(AeadV1Cipher::new(MultiKeyCipher::new(
+            Arc::new(AeadV1Sealer::new(MultiKeyCipher::new(
                 KeyedCookieCipher::new("v2"),
                 MultiKeyDecryptor::new(vec![
                     Arc::new(KeyedCookieCipher::new("v2")) as Arc<dyn AeadDecryptor>,

--- a/huskarl-core/src/crypto/mod.rs
+++ b/huskarl-core/src/crypto/mod.rs
@@ -6,7 +6,8 @@
 //!
 //! This module holds the signing ([`signer`]), verification ([`verifier`]), and
 //! encryption ([`cipher`]) traits, plus the shared key-matching types
-//! ([`KeyMatchStrength`]). Concrete implementations live in platform crates.
+//! ([`KeyMatchStrength`]); [`seal`] is a convenience layer over [`cipher`] for
+//! self-contained bundles. Concrete implementations live in platform crates.
 //!
 //! Each base trait comes with a family of composable wrappers (multi-key,
 //! refreshable, scheduled-refresh, retrying) that decorate it without changing
@@ -15,6 +16,7 @@
 
 pub mod cipher;
 pub(crate) mod refreshable;
+pub mod seal;
 pub mod signer;
 pub mod verifier;
 

--- a/huskarl-core/src/crypto/seal.rs
+++ b/huskarl-core/src/crypto/seal.rs
@@ -1,0 +1,547 @@
+//! Sealing: encrypt a value into one opaque, self-contained bundle and re-open
+//! it later — a convenience layer over [`cipher`](crate::crypto::cipher) for
+//! values that travel on their own (encrypted cookies, stateless tokens). See
+//! [composing crypto strategies](crate::_docs::explanation::crypto_strategies)
+//! for how it relates to JWE and the parts-level cipher traits.
+
+use std::{borrow::Cow, sync::Arc};
+
+use snafu::Snafu;
+
+use crate::{
+    crypto::cipher::{AeadDecryptor, AeadEncryptorSelector, CipherMatch, DecryptError},
+    error::{Error, ErrorKind},
+    platform::{MaybeSendBoxFuture, MaybeSendSync},
+};
+
+/// Errors that could occur during AEAD unsealing.
+///
+/// Used as the source of [`ErrorKind::Crypto`] errors — sealer implementations
+/// construct these to describe *why* an unseal
+/// failed without expanding the kind-level vocabulary.
+///
+/// This covers only failures the framing layer itself detects. An
+/// authentication-tag mismatch is raised by the inner
+/// [`AeadDecryptor`] and flows through as
+/// [`DecryptError::Other`], not as an `UnsealError`.
+#[non_exhaustive]
+#[derive(Debug, Snafu)]
+pub enum UnsealError {
+    /// The bundle is malformed or uses an unsupported version.
+    #[snafu(display("invalid bundle"))]
+    InvalidBundle,
+}
+
+/// The output from [`AeadSealer::seal`]
+pub struct SealOutput {
+    /// The opaque, self-describing bundle.
+    pub bundle: Vec<u8>,
+    /// The key ID of the key that sealed, when the implementation tracks one.
+    pub kid: Option<String>,
+}
+
+/// An encryptor that produces self-contained bundles.
+///
+/// Where [`AeadEncryptor::encrypt`](crate::crypto::cipher::AeadEncryptor::encrypt)
+/// returns the nonce, ciphertext, and tag as separate fields, a sealer hands
+/// back one opaque byte string so the value can travel on its own — an
+/// encrypted cookie, a stateless token — and be re-opened later
+/// ([`AeadUnsealer`]) with just the bundle and the key. [`AeadV1Sealer`] is the
+/// local implementation; see it for a worked example.
+///
+/// This trait is dyn-capable: consumers store it as `Arc<dyn AeadSealer>`, or
+/// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
+pub trait AeadSealer: std::fmt::Debug + MaybeSendSync {
+    /// Encrypts `plaintext` into a [`SealOutput`]: an opaque, self-describing
+    /// bundle that a matching [`AeadUnsealer`] can re-open, plus the kid of
+    /// the key that sealed it, when the implementation tracks one. The bundle
+    /// layout belongs to the implementation — an externally-managed sealer
+    /// returns its service's token verbatim.
+    ///
+    /// Store the kid beside the bundle for direct key dispatch in
+    /// [`unseal`](AeadUnsealer::unseal); discarding it is equally valid.
+    fn seal<'a>(
+        &'a self,
+        plaintext: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>>;
+}
+
+/// A decryptor that consumes self-contained bundles produced by [`AeadSealer`].
+///
+/// This trait is dyn-capable: consumers store it as `Arc<dyn AeadUnsealer>`, or
+/// as `Arc<dyn AeadSealerUnsealer>` when both directions are needed.
+pub trait AeadUnsealer: std::fmt::Debug + MaybeSendSync {
+    /// Decrypts a bundle produced by [`AeadSealer::seal`].
+    ///
+    /// `kid` is the key ID [`seal`](AeadSealer::seal) returned with the
+    /// bundle, if the caller stored it: multi-key implementations use it to
+    /// select the key directly. `None` is always safe — the AEAD tag makes a
+    /// wrong key a clean failure. A kid only selects, so an untrusted value
+    /// can at worst cause a miss.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecryptError::NoMatchingKey`] if no key matched the given
+    /// `kid`; all other failures — malformed bundles, authentication
+    /// failure — classify as [`ErrorKind::Crypto`] via [`DecryptError::Other`].
+    fn unseal<'a>(
+        &'a self,
+        bundle: &'a [u8],
+        aad: &'a [u8],
+        kid: Option<&'a str>,
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>>;
+}
+
+/// Combined trait for types that can both seal and unseal.
+///
+/// Automatically implemented for any type with both capabilities. Store as
+/// `Arc<dyn AeadSealerUnsealer>` when both directions must come from the same
+/// source — an [`AeadV1Sealer`] over one key, or an externally-managed sealer
+/// (e.g. a KMS/Vault encrypt endpoint) whose tokens only it can re-open.
+pub trait AeadSealerUnsealer: AeadSealer + AeadUnsealer {}
+
+impl<T: AeadSealer + AeadUnsealer + ?Sized> AeadSealerUnsealer for T {}
+
+impl<T: AeadSealer + ?Sized> AeadSealer for Arc<T> {
+    fn seal<'a>(
+        &'a self,
+        plaintext: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>> {
+        self.as_ref().seal(plaintext, aad)
+    }
+}
+
+impl<T: AeadUnsealer + ?Sized> AeadUnsealer for Arc<T> {
+    fn unseal<'a>(
+        &'a self,
+        bundle: &'a [u8],
+        aad: &'a [u8],
+        kid: Option<&'a str>,
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+        self.as_ref().unseal(bundle, aad, kid)
+    }
+}
+
+/// A bundle wrapper over an AEAD cipher using the v1 format:
+/// `[0x01 || nonce_len:u8 || tag_len:u8 || nonce || ciphertext || tag]`.
+///
+/// The implementations are conditional on the inner type's capabilities:
+/// wrapping an [`AeadCipher`](crate::crypto::cipher::AeadCipher) (a symmetric
+/// key, a rotating multi-key stack, or a KMS-backed cipher that handles both
+/// directions as one consistent object) yields an [`AeadSealerUnsealer`]; an
+/// [`AeadEncryptorSelector`] alone yields only an [`AeadSealer`], and a
+/// decrypt-only [`AeadDecryptor`] (e.g. a retired rotation key) only an
+/// [`AeadUnsealer`]. Each `seal` selects a frozen encryptor snapshot
+/// internally, so a rotation landing mid-seal cannot split one bundle across
+/// two keys.
+///
+/// # Example
+///
+/// ```
+/// # use std::borrow::Cow;
+/// # use huskarl_core::crypto::KeyMatchStrength;
+/// # use std::sync::Arc;
+/// # use huskarl_core::crypto::cipher::{
+/// #     AeadDecryptor, AeadEncryptor, AeadEncryptorSelector, AeadOutput, CipherMatch, DecryptError,
+/// # };
+/// # use huskarl_core::crypto::seal::{AeadSealer, AeadUnsealer, AeadV1Sealer, SealOutput};
+/// # use huskarl_core::error::Error;
+/// # use huskarl_core::platform::MaybeSendBoxFuture;
+/// # // Stand-in for the AEAD key a crypto backend (native / WebCrypto) provides:
+/// # // the key is a selector handing out its shared inner encryptor.
+/// # #[derive(Debug)]
+/// # struct BackendEncryptor;
+/// # impl AeadEncryptor for BackendEncryptor {
+/// #     fn enc_algorithm(&self) -> Cow<'_, str> { "A256GCM".into() }
+/// #     fn key_id(&self) -> Option<Cow<'_, str>> { Some("2026-07".into()) }
+/// #     fn encrypt<'a>(&'a self, plaintext: &'a [u8], _aad: &'a [u8])
+/// #         -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
+/// #         let ciphertext = plaintext.to_vec();
+/// #         Box::pin(async move { Ok(AeadOutput { nonce: vec![7], ciphertext, tag: vec![9] }) })
+/// #     }
+/// # }
+/// # #[derive(Debug)]
+/// # struct BackendCipher { inner: Arc<BackendEncryptor> }
+/// # impl BackendCipher {
+/// #     fn new() -> Self { Self { inner: Arc::new(BackendEncryptor) } }
+/// # }
+/// # impl AeadEncryptorSelector for BackendCipher {
+/// #     fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+/// #         let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+/// #         Box::pin(async move { snapshot })
+/// #     }
+/// # }
+/// # impl AeadDecryptor for BackendCipher {
+/// #     fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+/// #         Some(KeyMatchStrength::ByAlgorithm)
+/// #     }
+/// #     fn decrypt<'a>(&'a self, _cm: Option<&'a CipherMatch<'a>>, _nonce: &'a [u8],
+/// #         ciphertext: &'a [u8], _tag: &'a [u8], _aad: &'a [u8])
+/// #         -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+/// #         let plaintext = ciphertext.to_vec();
+/// #         Box::pin(async move { Ok(plaintext) })
+/// #     }
+/// # }
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let cipher = AeadV1Sealer::new(BackendCipher::new());
+///
+/// // `seal` packs the version byte, nonce, tag and ciphertext into one
+/// // bundle, plus the kid of the key that sealed it...
+/// let SealOutput { bundle, kid } = cipher.seal(b"session-state", b"aad").await?;
+/// // ...which dispatches `unseal` straight to that key (`None` tries all).
+/// let recovered = cipher.unseal(&bundle, b"aad", kid.as_deref()).await?;
+/// assert_eq!(recovered, b"session-state");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct AeadV1Sealer<C>(C);
+
+impl<C> AeadV1Sealer<C> {
+    /// Wraps a cipher in the v1 bundle format.
+    pub fn new(cipher: C) -> Self {
+        Self(cipher)
+    }
+}
+
+impl<C: AeadEncryptorSelector> AeadSealer for AeadV1Sealer<C> {
+    fn seal<'a>(
+        &'a self,
+        plaintext: &'a [u8],
+        aad: &'a [u8],
+    ) -> MaybeSendBoxFuture<'a, Result<SealOutput, Error>> {
+        Box::pin(async move {
+            // One frozen snapshot per seal: under rotation, the returned kid
+            // names exactly the key that sealed.
+            let encryptor = self.0.select_encryptor().await;
+            let kid = encryptor.key_id().map(Cow::into_owned);
+            let output = encryptor.encrypt(plaintext, aad).await?;
+
+            let nonce_len: u8 = output.nonce.len().try_into().map_err(|_| {
+                Error::new(crate::ErrorKind::Crypto, "nonce length exceeds u8::MAX")
+            })?;
+            let tag_len: u8 =
+                output.tag.len().try_into().map_err(|_| {
+                    Error::new(crate::ErrorKind::Crypto, "tag length exceeds u8::MAX")
+                })?;
+
+            let mut bundle = Vec::with_capacity(
+                3 + output.nonce.len() + output.ciphertext.len() + output.tag.len(),
+            );
+            bundle.push(0x01);
+            bundle.push(nonce_len);
+            bundle.push(tag_len);
+            bundle.extend_from_slice(&output.nonce);
+            bundle.extend_from_slice(&output.ciphertext);
+            bundle.extend_from_slice(&output.tag);
+
+            Ok(SealOutput { bundle, kid })
+        })
+    }
+}
+
+fn invalid_bundle() -> Error {
+    Error::new(ErrorKind::Crypto, UnsealError::InvalidBundle)
+}
+
+impl<C: AeadDecryptor> AeadUnsealer for AeadV1Sealer<C> {
+    fn unseal<'a>(
+        &'a self,
+        bundle: &'a [u8],
+        aad: &'a [u8],
+        kid: Option<&'a str>,
+    ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+        Box::pin(async move {
+            if bundle.len() < 3 || bundle[0] != 0x01 {
+                return Err(invalid_bundle().into());
+            }
+
+            let nonce_len = bundle[1] as usize;
+            let tag_len = bundle[2] as usize;
+
+            if bundle.len() < 3 + nonce_len + tag_len {
+                return Err(invalid_bundle().into());
+            }
+
+            let nonce = &bundle[3..3 + nonce_len];
+            let tag = &bundle[bundle.len() - tag_len..];
+            let ciphertext = &bundle[3 + nonce_len..bundle.len() - tag_len];
+
+            let cipher_match = kid.map(|kid| CipherMatch::builder().kid(kid).build());
+
+            self.0
+                .decrypt(cipher_match.as_ref(), nonce, ciphertext, tag, aad)
+                .await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::{
+        KeyMatchStrength,
+        cipher::{AeadEncryptor, AeadOutput},
+    };
+
+    #[derive(Debug)]
+    struct MockEncryptor;
+
+    impl AeadEncryptor for MockEncryptor {
+        fn enc_algorithm(&self) -> Cow<'_, str> {
+            "mock".into()
+        }
+
+        fn key_id(&self) -> Option<Cow<'_, str>> {
+            Some("mock-kid".into())
+        }
+
+        fn encrypt<'a>(
+            &'a self,
+            plaintext: &'a [u8],
+            _aad: &'a [u8],
+        ) -> MaybeSendBoxFuture<'a, Result<AeadOutput, Error>> {
+            Box::pin(async move {
+                Ok(AeadOutput {
+                    nonce: vec![1, 2, 3],
+                    ciphertext: plaintext.iter().map(|b| b ^ 0xFF).collect(),
+                    tag: vec![4, 5, 6, 7],
+                })
+            })
+        }
+    }
+
+    /// Raw-key shape: a selector handing out its shared inner encryptor.
+    #[derive(Debug)]
+    struct MockKey {
+        inner: Arc<MockEncryptor>,
+    }
+
+    impl MockKey {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockEncryptor),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for MockKey {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockDecryptor;
+
+    impl AeadDecryptor for MockDecryptor {
+        fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+            Some(KeyMatchStrength::ByAlgorithm)
+        }
+
+        fn decrypt<'a>(
+            &'a self,
+            _cipher_match: Option<&'a CipherMatch<'a>>,
+            _nonce: &'a [u8],
+            ciphertext: &'a [u8],
+            _tag: &'a [u8],
+            _aad: &'a [u8],
+        ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+            // Reverse the XOR
+            Box::pin(async move { Ok(ciphertext.iter().map(|b| b ^ 0xFF).collect()) })
+        }
+    }
+
+    /// One object with both capabilities (the symmetric-key / KMS shape).
+    #[derive(Debug)]
+    struct MockCipher {
+        inner: Arc<MockEncryptor>,
+    }
+
+    impl MockCipher {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockEncryptor),
+            }
+        }
+    }
+
+    impl AeadEncryptorSelector for MockCipher {
+        fn select_encryptor(&self) -> MaybeSendBoxFuture<'_, Arc<dyn AeadEncryptor>> {
+            let snapshot: Arc<dyn AeadEncryptor> = self.inner.clone();
+            Box::pin(async move { snapshot })
+        }
+    }
+
+    impl AeadDecryptor for MockCipher {
+        fn cipher_match(&self, m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+            MockDecryptor.cipher_match(m)
+        }
+
+        fn decrypt<'a>(
+            &'a self,
+            cipher_match: Option<&'a CipherMatch<'a>>,
+            nonce: &'a [u8],
+            ciphertext: &'a [u8],
+            tag: &'a [u8],
+            aad: &'a [u8],
+        ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+            Box::pin(async move {
+                MockDecryptor
+                    .decrypt(cipher_match, nonce, ciphertext, tag, aad)
+                    .await
+            })
+        }
+    }
+
+    fn assert_invalid_bundle(err: &DecryptError) {
+        let DecryptError::Other { source } = err else {
+            unreachable!("expected DecryptError::Other, got {err:?}");
+        };
+        assert_eq!(source.kind(), ErrorKind::Crypto);
+        assert_eq!(source.to_string(), "cryptographic operation failed");
+        assert_eq!(
+            std::error::Error::source(source)
+                .expect("source")
+                .to_string(),
+            "invalid bundle"
+        );
+    }
+
+    #[tokio::test]
+    async fn seal_roundtrip() {
+        let plaintext = b"hello world";
+        let aad = b"associated";
+
+        let sealer = AeadV1Sealer::new(MockKey::new());
+        let SealOutput { bundle, kid } = sealer.seal(plaintext, aad).await.unwrap();
+        assert_eq!(kid.as_deref(), Some("mock-kid"));
+
+        let unsealer = AeadV1Sealer::new(MockDecryptor);
+        let recovered = unsealer.unseal(&bundle, aad, kid.as_deref()).await.unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[tokio::test]
+    async fn erased_cipher_roundtrip() {
+        let sealer: Arc<dyn AeadSealer> = Arc::new(AeadV1Sealer::new(MockKey::new()));
+        let SealOutput { bundle, .. } = sealer.seal(b"hello", b"").await.unwrap();
+
+        let unsealer: Arc<dyn AeadUnsealer> = Arc::new(AeadV1Sealer::new(MockDecryptor));
+        let recovered = unsealer.unseal(&bundle, b"", None).await.unwrap();
+        assert_eq!(recovered, b"hello");
+    }
+
+    /// The erased combined type must satisfy generic `S: AeadSealerUnsealer`
+    /// bounds (e.g. `SealedTimestampNonce`) — construction, not just method calls.
+    #[tokio::test]
+    async fn erased_sealer_unsealer_satisfies_combined_bound() {
+        fn assert_combined<S: AeadSealerUnsealer>(s: S) -> S {
+            s
+        }
+
+        let cipher: Arc<dyn AeadSealerUnsealer> = Arc::new(AeadV1Sealer::new(MockCipher::new()));
+        let cipher = assert_combined(cipher);
+        let SealOutput { bundle, .. } = cipher.seal(b"hello", b"aad").await.unwrap();
+        let recovered = cipher.unseal(&bundle, b"aad", None).await.unwrap();
+        assert_eq!(recovered, b"hello");
+    }
+
+    #[tokio::test]
+    async fn bundle_format() {
+        let plaintext = b"AB";
+        let sealer = AeadV1Sealer::new(MockKey::new());
+        let SealOutput { bundle, .. } = sealer.seal(plaintext, b"").await.unwrap();
+
+        // [0x01, nonce_len=3, tag_len=4, nonce=[1,2,3], ciphertext=[0xBE, 0xBD], tag=[4,5,6,7]]
+        assert_eq!(bundle[0], 0x01);
+        assert_eq!(bundle[1], 3); // nonce_len
+        assert_eq!(bundle[2], 4); // tag_len
+        assert_eq!(&bundle[3..6], &[1, 2, 3]); // nonce
+        assert_eq!(&bundle[6..8], &[0x41 ^ 0xFF, 0x42 ^ 0xFF]); // ciphertext
+        assert_eq!(&bundle[8..12], &[4, 5, 6, 7]); // tag
+    }
+
+    #[tokio::test]
+    async fn unseal_wrong_version() {
+        let unsealer = AeadV1Sealer::new(MockDecryptor);
+        let err = unsealer.unseal(&[0x02, 0, 0], b"", None).await.unwrap_err();
+        assert_invalid_bundle(&err);
+    }
+
+    #[tokio::test]
+    async fn unseal_too_short() {
+        let unsealer = AeadV1Sealer::new(MockDecryptor);
+        let err = unsealer.unseal(&[0x01], b"", None).await.unwrap_err();
+        assert_invalid_bundle(&err);
+    }
+
+    #[tokio::test]
+    async fn unseal_truncated() {
+        let unsealer = AeadV1Sealer::new(MockDecryptor);
+        // nonce_len=10, tag_len=10, but only 1 byte of data after header
+        let err = unsealer
+            .unseal(&[0x01, 10, 10, 0x00], b"", None)
+            .await
+            .unwrap_err();
+        assert_invalid_bundle(&err);
+    }
+
+    #[tokio::test]
+    async fn unseal_empty() {
+        let unsealer = AeadV1Sealer::new(MockDecryptor);
+        let err = unsealer.unseal(&[], b"", None).await.unwrap_err();
+        assert_invalid_bundle(&err);
+    }
+
+    /// The kid handed to `unseal` must reach the inner decryptor as a
+    /// kid-only [`CipherMatch`]; `None` must arrive as no criteria at all.
+    #[tokio::test]
+    async fn unseal_forwards_kid_as_cipher_match() {
+        #[derive(Debug)]
+        struct KidAssertingDecryptor {
+            expected: Option<&'static str>,
+        }
+
+        impl AeadDecryptor for KidAssertingDecryptor {
+            fn cipher_match(&self, _m: &CipherMatch<'_>) -> Option<KeyMatchStrength> {
+                Some(KeyMatchStrength::ByAlgorithm)
+            }
+
+            fn decrypt<'a>(
+                &'a self,
+                cipher_match: Option<&'a CipherMatch<'a>>,
+                _nonce: &'a [u8],
+                ciphertext: &'a [u8],
+                _tag: &'a [u8],
+                _aad: &'a [u8],
+            ) -> MaybeSendBoxFuture<'a, Result<Vec<u8>, DecryptError>> {
+                assert_eq!(cipher_match.and_then(|m| m.kid), self.expected);
+                assert_eq!(cipher_match.and_then(|m| m.enc), None);
+                Box::pin(async move { Ok(ciphertext.to_vec()) })
+            }
+        }
+
+        let SealOutput { bundle, .. } = AeadV1Sealer::new(MockKey::new())
+            .seal(b"x", b"")
+            .await
+            .unwrap();
+        for (unsealer, kid) in [
+            (
+                AeadV1Sealer::new(KidAssertingDecryptor {
+                    expected: Some("mock-kid"),
+                }),
+                Some("mock-kid"),
+            ),
+            (
+                AeadV1Sealer::new(KidAssertingDecryptor { expected: None }),
+                None,
+            ),
+        ] {
+            unsealer.unseal(&bundle, b"", kid).await.unwrap();
+        }
+    }
+}

--- a/huskarl-core/src/dpop/nonce.rs
+++ b/huskarl-core/src/dpop/nonce.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use bon::Builder;
 
 use crate::{
-    crypto::cipher::AeadSealerUnsealer,
+    crypto::seal::AeadSealerUnsealer,
     error::{Error, ErrorKind},
     platform::{Duration, MaybeSendBoxFuture, MaybeSendSync, SystemTime},
 };
@@ -89,7 +89,7 @@ pub struct SealedTimestampNonce {
     /// Wrap an [`AeadCipher`](crate::crypto::cipher::AeadCipher) (a key,
     /// or a rotating stack such as
     /// [`ScheduledRefreshCipher`](crate::crypto::cipher::ScheduledRefreshCipher))
-    /// in [`AeadV1Cipher`](crate::crypto::cipher::AeadV1Cipher); an
+    /// in [`AeadV1Sealer`](crate::crypto::seal::AeadV1Sealer); an
     /// externally-managed sealer (e.g. a KMS encrypt endpoint) can implement
     /// the traits directly.
     ///
@@ -178,9 +178,8 @@ mod tests {
     use super::*;
     use crate::crypto::{
         KeyMatchStrength,
-        cipher::{
-            AeadEncryptor, AeadOutput, AeadSealer as _, AeadV1Cipher, CipherMatch, DecryptError,
-        },
+        cipher::{AeadEncryptor, AeadOutput, CipherMatch, DecryptError},
+        seal::{AeadSealer as _, AeadV1Sealer},
     };
 
     #[derive(Debug)]
@@ -252,7 +251,7 @@ mod tests {
 
     fn checker() -> SealedTimestampNonce {
         SealedTimestampNonce::builder()
-            .sealer(AeadV1Cipher::new(MockCipher::new()))
+            .sealer(AeadV1Sealer::new(MockCipher::new()))
             .build()
     }
 

--- a/huskarl-crypto-webcrypto/src/aead.rs
+++ b/huskarl-crypto-webcrypto/src/aead.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for Inner {
 /// signer/verifier.
 ///
 /// Wrap it the same way as any other [`AeadCipher`](huskarl_core::crypto::cipher::AeadCipher):
-/// `AeadV1Cipher::new(key)` for the bundle envelope, and the reload wrappers
+/// `AeadV1Sealer::new(key)` for the bundle envelope, and the reload wrappers
 /// ([`RetryingDecryptor`](huskarl_core::crypto::cipher::RetryingDecryptor),
 /// [`MultiKeyCipher`](huskarl_core::crypto::cipher::MultiKeyCipher)) compose
 /// over it for hot key rotation.
@@ -335,7 +335,7 @@ impl AeadEncryptor for Inner {
             .context(AwaitSnafu)?;
 
             // WebCrypto returns ciphertext || tag; split the trailing tag off so
-            // the bundle layer (`AeadV1Cipher`) can frame nonce/ciphertext/tag.
+            // the bundle layer (`AeadV1Sealer`) can frame nonce/ciphertext/tag.
             let combined = Uint8Array::new(&result).to_vec();
             if combined.len() < TAG_LEN {
                 return Err(OpError::ShortCiphertext.into());
@@ -582,7 +582,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn enc_algorithm_reflects_key_size() {
-        // The reported `enc` is what `AeadV1Cipher` writes into the envelope and
+        // The reported `enc` is what `AeadV1Sealer` writes into the envelope and
         // what `cipher_match` keys on, so each AES size must label itself.
         for (len, enc) in [(16usize, "A128GCM"), (24, "A192GCM"), (32, "A256GCM")] {
             let key = key_from(vec![3u8; len], None).await;


### PR DESCRIPTION
Sealing and AEAD ciphering are separate ideas - the first is more opaque and just "give me bytes", whereas the cipher traits are more low-level, and present the low level details in a way that can be either used for sealing, or for JWE operations.