### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-native"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-webcrypto"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "huskarl-core",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-resource-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "bon",

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.9.0...huskarl-core-v0.9.1) - 2026-07-20
+
+### Other
+
+- *(crypto)* Split sealing into its own module. ([#249](https://github.com/huskarl-rs/huskarl/pull/249))
+
 ## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.8.1...huskarl-core-v0.9.0) - 2026-07-19
 
 ### Added

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-native/CHANGELOG.md
+++ b/huskarl-crypto-native/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.10.0...huskarl-crypto-native-v0.10.1) - 2026-07-20
+
+### Other
+
+- *(crypto)* AEAD impls should avoid referring to sealing ([#252](https://github.com/huskarl-rs/huskarl/pull/252))
+
 ## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.9.0...huskarl-crypto-native-v0.10.0) - 2026-07-19
 
 ### Added

--- a/huskarl-crypto-native/Cargo.toml
+++ b/huskarl-crypto-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-native"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Native crypto for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-crypto-webcrypto/CHANGELOG.md
+++ b/huskarl-crypto-webcrypto/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.10.0...huskarl-crypto-webcrypto-v0.10.1) - 2026-07-20
+
+### Other
+
+- *(crypto)* AEAD impls should avoid referring to sealing ([#252](https://github.com/huskarl-rs/huskarl/pull/252))
+- *(crypto)* Split sealing into its own module. ([#249](https://github.com/huskarl-rs/huskarl/pull/249))
+
 ## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.9.0...huskarl-crypto-webcrypto-v0.10.0) - 2026-07-19
 
 ### Added

--- a/huskarl-crypto-webcrypto/Cargo.toml
+++ b/huskarl-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-webcrypto"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.92"
 description = "WebCrypto support for huskarl (OAuth2 client) ecosystem."

--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.10.0...huskarl-resource-server-v0.10.1) - 2026-07-20
+
+### Added
+
+- Get local Cargo dev-deps by path reference. ([#251](https://github.com/huskarl-rs/huskarl/pull/251))
+
 ## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.9.1...huskarl-resource-server-v0.10.0) - 2026-07-19
 
 ### Added

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.92"
 description = "OAuth2 resource server (JWT validation) support for the huskarl ecosystem."

--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.10.0...huskarl-v0.10.1) - 2026-07-20
+
+### Added
+
+- Get local Cargo dev-deps by path reference. ([#251](https://github.com/huskarl-rs/huskarl/pull/251))
+
 ## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.9.2...huskarl-v0.10.0) - 2026-07-19
 
 ### Added

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.92"
 description = '''


### PR DESCRIPTION



## 🤖 New release

* `huskarl-core`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `huskarl-crypto-webcrypto`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `huskarl-crypto-native`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `huskarl`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `huskarl-resource-server`: 0.10.0 -> 0.10.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl-core`

<blockquote>

## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.9.0...huskarl-core-v0.9.1) - 2026-07-20

### Other

- *(crypto)* Split sealing into its own module. ([#249](https://github.com/huskarl-rs/huskarl/pull/249))
</blockquote>

## `huskarl-crypto-webcrypto`

<blockquote>

## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.10.0...huskarl-crypto-webcrypto-v0.10.1) - 2026-07-20

### Other

- *(crypto)* AEAD impls should avoid referring to sealing ([#252](https://github.com/huskarl-rs/huskarl/pull/252))
- *(crypto)* Split sealing into its own module. ([#249](https://github.com/huskarl-rs/huskarl/pull/249))
</blockquote>

## `huskarl-crypto-native`

<blockquote>

## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.10.0...huskarl-crypto-native-v0.10.1) - 2026-07-20

### Other

- *(crypto)* AEAD impls should avoid referring to sealing ([#252](https://github.com/huskarl-rs/huskarl/pull/252))
</blockquote>

## `huskarl`

<blockquote>

## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.10.0...huskarl-v0.10.1) - 2026-07-20

### Added

- Get local Cargo dev-deps by path reference. ([#251](https://github.com/huskarl-rs/huskarl/pull/251))
</blockquote>

## `huskarl-resource-server`

<blockquote>

## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.10.0...huskarl-resource-server-v0.10.1) - 2026-07-20

### Added

- Get local Cargo dev-deps by path reference. ([#251](https://github.com/huskarl-rs/huskarl/pull/251))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).