### PR TITLE
feat: Get local Cargo dev-deps by path reference.

### DIFF
--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -57,8 +57,8 @@ metrics = { workspace = true }
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-huskarl-crypto-native = { workspace = true }
-huskarl-reqwest = { workspace = true }
+huskarl-crypto-native = { path = "../huskarl-crypto-native" }
+huskarl-reqwest = { path = "../huskarl-reqwest" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 httpmock = "0.8.3"
 rstest = { version = "0.26", default-features = false }

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -83,15 +83,15 @@ doc-scrape-examples = true
 
 [dev-dependencies]
 huskarl = { path = ".", default-features = true }
-huskarl-crypto-native = { workspace = true }
-huskarl-resource-server = { workspace = true }
+huskarl-crypto-native = { path = "../huskarl-crypto-native" }
+huskarl-resource-server = { path = "../huskarl-resource-server" }
 
 [target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 huskarl = { path = ".", features = ["authorization-flow-loopback"] }
-huskarl-reqwest = { workspace = true, features = ["rustls-tls"] }
+huskarl-reqwest = { path = "../huskarl-reqwest", features = ["rustls-tls"] }
 rstest = { version = "0.26", default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "time"] }
 reqwest = { version = "0.13", features = ["cookies", "form", "json", "query"] }


### PR DESCRIPTION
By getting local deps by path reference, we drop the need for them to be published before the crate itself. This should avoid issues with publish order and release-plz.