### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "base64 0.23.1",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "arc-swap",
  "base64 0.23.1",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-native"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-crypto-webcrypto"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64 0.23.1",
  "huskarl-core",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-google-cloud"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bon",
  "der",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-macros"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bon",
  "darling 0.24.1",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-redis"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bon",
  "hex",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-reqwest"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bon",
  "bytes",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "huskarl-resource-server"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64 0.23.1",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,15 +35,15 @@ default-members = [
 exclude = ["huskarl-core/fuzz"]
 
 [workspace.dependencies]
-huskarl = { version = "0.10", path = "./huskarl" }
-huskarl-core = { version = "0.9", path = "./huskarl-core" }
-huskarl-macros = { version = "0.3", path = "./huskarl-macros" }
-huskarl-redis = { version = "0.2", path = "./huskarl-redis" }
-huskarl-reqwest = { version = "0.8", path = "./huskarl-reqwest" }
-huskarl-crypto-native = { version = "0.10", path = "./huskarl-crypto-native" }
-huskarl-crypto-webcrypto = { version = "0.10", path = "./huskarl-crypto-webcrypto" }
-huskarl-google-cloud = { version = "0.7", path = "./huskarl-google-cloud" }
-huskarl-resource-server = { version = "0.10", path = "./huskarl-resource-server" }
+huskarl = { version = "0.11", path = "./huskarl" }
+huskarl-core = { version = "0.10", path = "./huskarl-core" }
+huskarl-macros = { version = "0.4", path = "./huskarl-macros" }
+huskarl-redis = { version = "0.3", path = "./huskarl-redis" }
+huskarl-reqwest = { version = "0.9", path = "./huskarl-reqwest" }
+huskarl-crypto-native = { version = "0.11", path = "./huskarl-crypto-native" }
+huskarl-crypto-webcrypto = { version = "0.11", path = "./huskarl-crypto-webcrypto" }
+huskarl-google-cloud = { version = "0.8", path = "./huskarl-google-cloud" }
+huskarl-resource-server = { version = "0.11", path = "./huskarl-resource-server" }
 
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 bon = { version = "3.9", default-features = false, features = [

--- a/huskarl-core/CHANGELOG.md
+++ b/huskarl-core/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.9.1...huskarl-core-v0.10.0) - 2026-08-24
+
+### Added
+
+- *(core)* [**breaking**] classify failed HTTP responses ([#287](https://github.com/huskarl-rs/huskarl/pull/287))
+- *(macros)* add Classify derive ([#285](https://github.com/huskarl-rs/huskarl/pull/285))
+- *(core)* introduce retry advice and OAuth verdicts ([#283](https://github.com/huskarl-rs/huskarl/pull/283))
+- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))
+- *(client)* [**breaking**] Default jws_verifier_factory to a JwksSource ([#269](https://github.com/huskarl-rs/huskarl/pull/269))
+- *(core)* [**breaking**] Add capability for verifier loading to fail without failing startup. ([#268](https://github.com/huskarl-rs/huskarl/pull/268))
+- *(core)* Add more syntax extension traits to the prelude. ([#266](https://github.com/huskarl-rs/huskarl/pull/266))
+- *(core)* Update the list of tracked verifier algs in metrics. ([#265](https://github.com/huskarl-rs/huskarl/pull/265))
+- *(core)* Use a monotonic clock for CachedSecret TTL. ([#263](https://github.com/huskarl-rs/huskarl/pull/263))
+- *(client)* [**breaking**] Support signed JARM authorization responses ([#259](https://github.com/huskarl-rs/huskarl/pull/259))
+- *(core)* [**breaking**] Carry error_description alongside the OAuth error code ([#257](https://github.com/huskarl-rs/huskarl/pull/257))
+
+### Fixed
+
+- *(core)* Handle exp time uniformly on WASM and native ([#278](https://github.com/huskarl-rs/huskarl/pull/278))
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+- *(core)* Implement PartialEq for oct keys in constant time. ([#271](https://github.com/huskarl-rs/huskarl/pull/271))
+- *(auth)* Set more headers as sensitive if they have sensitive information. ([#270](https://github.com/huskarl-rs/huskarl/pull/270))
+- *(core)* Reject malformed JWS part counts without allocating. ([#262](https://github.com/huskarl-rs/huskarl/pull/262))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- *(google-cloud)* Import huskarl-google-cloud into this workspace. ([#303](https://github.com/huskarl-rs/huskarl/pull/303))
+- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
+- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
+- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
+- [**breaking**] remove error migration compatibility ([#296](https://github.com/huskarl-rs/huskarl/pull/296))
+- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
+- *(core)* Add tests for aud parsing code ([#280](https://github.com/huskarl-rs/huskarl/pull/280))
+- *(core)* Add explicit thumbprint tests
+- *(client)* Remove stray file
+
 ## [0.9.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.9.0...huskarl-core-v0.9.1) - 2026-07-20
 
 ### Other

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-core"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Base library for the huskarl OAuth2 ecosystem."

--- a/huskarl-crypto-native/CHANGELOG.md
+++ b/huskarl-crypto-native/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.10.1...huskarl-crypto-native-v0.11.0) - 2026-08-24
+
+### Fixed
+
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
+- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
+- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
+- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
+
 ## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.10.0...huskarl-crypto-native-v0.10.1) - 2026-07-20
 
 ### Other

--- a/huskarl-crypto-native/Cargo.toml
+++ b/huskarl-crypto-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-native"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Native crypto for the huskarl OAuth2 ecosystem."

--- a/huskarl-crypto-webcrypto/CHANGELOG.md
+++ b/huskarl-crypto-webcrypto/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.10.1...huskarl-crypto-webcrypto-v0.11.0) - 2026-08-24
+
+### Fixed
+
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
+- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
+- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
+
 ## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.10.0...huskarl-crypto-webcrypto-v0.10.1) - 2026-07-20
 
 ### Other

--- a/huskarl-crypto-webcrypto/Cargo.toml
+++ b/huskarl-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-crypto-webcrypto"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "WebCrypto support for the huskarl OAuth2 ecosystem."

--- a/huskarl-google-cloud/CHANGELOG.md
+++ b/huskarl-google-cloud/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-google-cloud-v0.7.0...huskarl-google-cloud-v0.8.0) - 2026-08-24
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- *(google-cloud)* Import huskarl-google-cloud into this workspace. ([#303](https://github.com/huskarl-rs/huskarl/pull/303))

--- a/huskarl-google-cloud/Cargo.toml
+++ b/huskarl-google-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-google-cloud"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Google Cloud cryptographic integrations for the huskarl OAuth2 ecosystem."

--- a/huskarl-macros/CHANGELOG.md
+++ b/huskarl-macros/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.4.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.1...huskarl-macros-v0.4.0) - 2026-08-24
+
+### Added
+
+- *(macros)* add Classify derive ([#285](https://github.com/huskarl-rs/huskarl/pull/285))
+- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
+- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
+
 ## [0.3.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.0...huskarl-macros-v0.3.1) - 2026-07-08
 
 ### Added

--- a/huskarl-macros/Cargo.toml
+++ b/huskarl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-macros"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Procedural macros for the huskarl OAuth2 ecosystem."

--- a/huskarl-redis/CHANGELOG.md
+++ b/huskarl-redis/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.2.0...huskarl-redis-v0.3.0) - 2026-08-24
+
+### Added
+
+- *(client)* [**breaking**] Support signed JARM authorization responses ([#259](https://github.com/huskarl-rs/huskarl/pull/259))
+
+### Fixed
+
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
+- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
+- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
+
 ## [0.2.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.1.1...huskarl-redis-v0.2.0) - 2026-07-19
 
 ### Added

--- a/huskarl-redis/Cargo.toml
+++ b/huskarl-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-redis"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Redis-backed replay prevention for the huskarl OAuth2 ecosystem."

--- a/huskarl-reqwest/CHANGELOG.md
+++ b/huskarl-reqwest/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-reqwest-v0.8.0...huskarl-reqwest-v0.9.0) - 2026-08-24
+
+### Fixed
+
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
+- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
+
 ## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-reqwest-v0.7.1...huskarl-reqwest-v0.8.0) - 2026-07-19
 
 ### Added

--- a/huskarl-reqwest/Cargo.toml
+++ b/huskarl-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-reqwest"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.92"
 description = "reqwest support for the huskarl OAuth2 ecosystem."

--- a/huskarl-resource-server/CHANGELOG.md
+++ b/huskarl-resource-server/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.10.1...huskarl-resource-server-v0.11.0) - 2026-08-24
+
+### Added
+
+- *(resource-server)* Classify the outcome of a challenge ([#299](https://github.com/huskarl-rs/huskarl/pull/299))
+- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))
+
+### Fixed
+
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
+- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
+- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
+- [**breaking**] remove error migration compatibility ([#296](https://github.com/huskarl-rs/huskarl/pull/296))
+- *(resource-server)* [**breaking**] adopt classified errors ([#295](https://github.com/huskarl-rs/huskarl/pull/295))
+
 ## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.10.0...huskarl-resource-server-v0.10.1) - 2026-07-20
 
 ### Added

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl-resource-server"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Resource server (JWT validation) support for the huskarl OAuth2 ecosystem."

--- a/huskarl/CHANGELOG.md
+++ b/huskarl/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.10.1...huskarl-v0.11.0) - 2026-08-24
+
+### Added
+
+- *(device)* apply retry advice while polling ([#294](https://github.com/huskarl-rs/huskarl/pull/294))
+- *(cache)* [**breaking**] expose token recovery decisions ([#293](https://github.com/huskarl-rs/huskarl/pull/293))
+- *(core)* introduce retry advice and OAuth verdicts ([#283](https://github.com/huskarl-rs/huskarl/pull/283))
+- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))
+- *(userinfo)* [**breaking**] from_grant becomes a builder accepting verifier, can require signing ([#281](https://github.com/huskarl-rs/huskarl/pull/281))
+- *(client)* [**breaking**] Default jws_verifier_factory to a JwksSource ([#269](https://github.com/huskarl-rs/huskarl/pull/269))
+- *(client)* Make auth code redirect_uri public. ([#267](https://github.com/huskarl-rs/huskarl/pull/267))
+- *(client)* [**breaking**] Carry error_uri alongside the OAuth error code ([#261](https://github.com/huskarl-rs/huskarl/pull/261))
+- *(client)* [**breaking**] Return CompleteOutput from auth completion. ([#260](https://github.com/huskarl-rs/huskarl/pull/260))
+- *(client)* [**breaking**] Support signed JARM authorization responses ([#259](https://github.com/huskarl-rs/huskarl/pull/259))
+- *(core)* [**breaking**] Carry error_description alongside the OAuth error code ([#257](https://github.com/huskarl-rs/huskarl/pull/257))
+
+### Fixed
+
+- *(cache)* Use monotonic Instant instead of SystemTime ([#279](https://github.com/huskarl-rs/huskarl/pull/279))
+- *(client)* Redact secret fields from Debug of CompleteInput. ([#277](https://github.com/huskarl-rs/huskarl/pull/277))
+- *(client)* Be more careful about choosing IPv4 vs IPv6 loopback. ([#276](https://github.com/huskarl-rs/huskarl/pull/276))
+- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
+- *(client)* Don't fail device auth flow on 5xx ([#274](https://github.com/huskarl-rs/huskarl/pull/274))
+- *(client)* Forward normal and mtls token endpoints to refresh grant. ([#273](https://github.com/huskarl-rs/huskarl/pull/273))
+- *(cache)* Improve circuit breaker handling. ([#272](https://github.com/huskarl-rs/huskarl/pull/272))
+- *(auth)* Set more headers as sensitive if they have sensitive information. ([#270](https://github.com/huskarl-rs/huskarl/pull/270))
+
+### Other
+
+- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
+- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
+- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
+- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
+- [**breaking**] remove error migration compatibility ([#296](https://github.com/huskarl-rs/huskarl/pull/296))
+- *(huskarl)* [**breaking**] classify registration and userinfo failures ([#292](https://github.com/huskarl-rs/huskarl/pull/292))
+- *(huskarl)* [**breaking**] classify authorization flow failures ([#291](https://github.com/huskarl-rs/huskarl/pull/291))
+- *(huskarl)* [**breaking**] classify token endpoint failures ([#290](https://github.com/huskarl-rs/huskarl/pull/290))
+- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
+- *(client)* [**breaking**] Implement authorization code callback handling implementation. ([#258](https://github.com/huskarl-rs/huskarl/pull/258))
+- *(client)* Fix doc building on docs.rs ([#255](https://github.com/huskarl-rs/huskarl/pull/255))
+
 ## [0.10.1](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.10.0...huskarl-v0.10.1) - 2026-07-20
 
 ### Added

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huskarl"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = '''


### PR DESCRIPTION



## 🤖 New release

* `huskarl-macros`: 0.3.1 -> 0.4.0
* `huskarl-core`: 0.9.1 -> 0.10.0 (✓ API compatible changes)
* `huskarl-crypto-webcrypto`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `huskarl-crypto-native`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `huskarl`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `huskarl-resource-server`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `huskarl-reqwest`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `huskarl-google-cloud`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `huskarl-redis`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `huskarl-macros`

<blockquote>

## [0.4.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-macros-v0.3.1...huskarl-macros-v0.4.0) - 2026-08-24

### Added

- *(macros)* add Classify derive ([#285](https://github.com/huskarl-rs/huskarl/pull/285))
- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
</blockquote>

## `huskarl-core`

<blockquote>

## [0.10.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-core-v0.9.1...huskarl-core-v0.10.0) - 2026-08-24

### Added

- *(core)* [**breaking**] classify failed HTTP responses ([#287](https://github.com/huskarl-rs/huskarl/pull/287))
- *(macros)* add Classify derive ([#285](https://github.com/huskarl-rs/huskarl/pull/285))
- *(core)* introduce retry advice and OAuth verdicts ([#283](https://github.com/huskarl-rs/huskarl/pull/283))
- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))
- *(client)* [**breaking**] Default jws_verifier_factory to a JwksSource ([#269](https://github.com/huskarl-rs/huskarl/pull/269))
- *(core)* [**breaking**] Add capability for verifier loading to fail without failing startup. ([#268](https://github.com/huskarl-rs/huskarl/pull/268))
- *(core)* Add more syntax extension traits to the prelude. ([#266](https://github.com/huskarl-rs/huskarl/pull/266))
- *(core)* Update the list of tracked verifier algs in metrics. ([#265](https://github.com/huskarl-rs/huskarl/pull/265))
- *(core)* Use a monotonic clock for CachedSecret TTL. ([#263](https://github.com/huskarl-rs/huskarl/pull/263))
- *(client)* [**breaking**] Support signed JARM authorization responses ([#259](https://github.com/huskarl-rs/huskarl/pull/259))
- *(core)* [**breaking**] Carry error_description alongside the OAuth error code ([#257](https://github.com/huskarl-rs/huskarl/pull/257))

### Fixed

- *(core)* Handle exp time uniformly on WASM and native ([#278](https://github.com/huskarl-rs/huskarl/pull/278))
- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
- *(core)* Implement PartialEq for oct keys in constant time. ([#271](https://github.com/huskarl-rs/huskarl/pull/271))
- *(auth)* Set more headers as sensitive if they have sensitive information. ([#270](https://github.com/huskarl-rs/huskarl/pull/270))
- *(core)* Reject malformed JWS part counts without allocating. ([#262](https://github.com/huskarl-rs/huskarl/pull/262))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- *(google-cloud)* Import huskarl-google-cloud into this workspace. ([#303](https://github.com/huskarl-rs/huskarl/pull/303))
- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
- [**breaking**] remove error migration compatibility ([#296](https://github.com/huskarl-rs/huskarl/pull/296))
- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
- *(core)* Add tests for aud parsing code ([#280](https://github.com/huskarl-rs/huskarl/pull/280))
- *(core)* Add explicit thumbprint tests
- *(client)* Remove stray file
</blockquote>

## `huskarl-crypto-webcrypto`

<blockquote>

## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-webcrypto-v0.10.1...huskarl-crypto-webcrypto-v0.11.0) - 2026-08-24

### Fixed

- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
</blockquote>

## `huskarl-crypto-native`

<blockquote>

## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-crypto-native-v0.10.1...huskarl-crypto-native-v0.11.0) - 2026-08-24

### Fixed

- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
</blockquote>

## `huskarl`

<blockquote>

## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-v0.10.1...huskarl-v0.11.0) - 2026-08-24

### Added

- *(device)* apply retry advice while polling ([#294](https://github.com/huskarl-rs/huskarl/pull/294))
- *(cache)* [**breaking**] expose token recovery decisions ([#293](https://github.com/huskarl-rs/huskarl/pull/293))
- *(core)* introduce retry advice and OAuth verdicts ([#283](https://github.com/huskarl-rs/huskarl/pull/283))
- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))
- *(userinfo)* [**breaking**] from_grant becomes a builder accepting verifier, can require signing ([#281](https://github.com/huskarl-rs/huskarl/pull/281))
- *(client)* [**breaking**] Default jws_verifier_factory to a JwksSource ([#269](https://github.com/huskarl-rs/huskarl/pull/269))
- *(client)* Make auth code redirect_uri public. ([#267](https://github.com/huskarl-rs/huskarl/pull/267))
- *(client)* [**breaking**] Carry error_uri alongside the OAuth error code ([#261](https://github.com/huskarl-rs/huskarl/pull/261))
- *(client)* [**breaking**] Return CompleteOutput from auth completion. ([#260](https://github.com/huskarl-rs/huskarl/pull/260))
- *(client)* [**breaking**] Support signed JARM authorization responses ([#259](https://github.com/huskarl-rs/huskarl/pull/259))
- *(core)* [**breaking**] Carry error_description alongside the OAuth error code ([#257](https://github.com/huskarl-rs/huskarl/pull/257))

### Fixed

- *(cache)* Use monotonic Instant instead of SystemTime ([#279](https://github.com/huskarl-rs/huskarl/pull/279))
- *(client)* Redact secret fields from Debug of CompleteInput. ([#277](https://github.com/huskarl-rs/huskarl/pull/277))
- *(client)* Be more careful about choosing IPv4 vs IPv6 loopback. ([#276](https://github.com/huskarl-rs/huskarl/pull/276))
- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))
- *(client)* Don't fail device auth flow on 5xx ([#274](https://github.com/huskarl-rs/huskarl/pull/274))
- *(client)* Forward normal and mtls token endpoints to refresh grant. ([#273](https://github.com/huskarl-rs/huskarl/pull/273))
- *(cache)* Improve circuit breaker handling. ([#272](https://github.com/huskarl-rs/huskarl/pull/272))
- *(auth)* Set more headers as sensitive if they have sensitive information. ([#270](https://github.com/huskarl-rs/huskarl/pull/270))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
- [**breaking**] remove error migration compatibility ([#296](https://github.com/huskarl-rs/huskarl/pull/296))
- *(huskarl)* [**breaking**] classify registration and userinfo failures ([#292](https://github.com/huskarl-rs/huskarl/pull/292))
- *(huskarl)* [**breaking**] classify authorization flow failures ([#291](https://github.com/huskarl-rs/huskarl/pull/291))
- *(huskarl)* [**breaking**] classify token endpoint failures ([#290](https://github.com/huskarl-rs/huskarl/pull/290))
- *(core)* [**breaking**] migrate internal errors to classifications ([#288](https://github.com/huskarl-rs/huskarl/pull/288))
- *(client)* [**breaking**] Implement authorization code callback handling implementation. ([#258](https://github.com/huskarl-rs/huskarl/pull/258))
- *(client)* Fix doc building on docs.rs ([#255](https://github.com/huskarl-rs/huskarl/pull/255))
</blockquote>

## `huskarl-resource-server`

<blockquote>

## [0.11.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-resource-server-v0.10.1...huskarl-resource-server-v0.11.0) - 2026-08-24

### Added

- *(resource-server)* Classify the outcome of a challenge ([#299](https://github.com/huskarl-rs/huskarl/pull/299))
- [**breaking**] Make builder_from_metadata/etc. return Result instead of Option ([#282](https://github.com/huskarl-rs/huskarl/pull/282))

### Fixed

- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
- explain classified errors and recovery ([#297](https://github.com/huskarl-rs/huskarl/pull/297))
- [**breaking**] remove error migration compatibility ([#296](https://github.com/huskarl-rs/huskarl/pull/296))
- *(resource-server)* [**breaking**] adopt classified errors ([#295](https://github.com/huskarl-rs/huskarl/pull/295))
</blockquote>

## `huskarl-reqwest`

<blockquote>

## [0.9.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-reqwest-v0.8.0...huskarl-reqwest-v0.9.0) - 2026-08-24

### Fixed

- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
</blockquote>

## `huskarl-google-cloud`

<blockquote>

## [0.8.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-google-cloud-v0.7.0...huskarl-google-cloud-v0.8.0) - 2026-08-24

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- *(google-cloud)* Import huskarl-google-cloud into this workspace. ([#303](https://github.com/huskarl-rs/huskarl/pull/303))
</blockquote>

## `huskarl-redis`

<blockquote>

## [0.3.0](https://github.com/huskarl-rs/huskarl/compare/huskarl-redis-v0.2.0...huskarl-redis-v0.3.0) - 2026-08-24

### Added

- *(client)* [**breaking**] Support signed JARM authorization responses ([#259](https://github.com/huskarl-rs/huskarl/pull/259))

### Fixed

- Improve the panic story of the crate. ([#275](https://github.com/huskarl-rs/huskarl/pull/275))

### Other

- [**breaking**] Update dependencies and update crate descriptions. ([#304](https://github.com/huskarl-rs/huskarl/pull/304))
- Improve some documentation ([#302](https://github.com/huskarl-rs/huskarl/pull/302))
- Improve docs discovery ([#300](https://github.com/huskarl-rs/huskarl/pull/300))
- *(adapters)* propagate classified backend errors ([#289](https://github.com/huskarl-rs/huskarl/pull/289))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).