### PR TITLE
refactor(client)!: Implement authorization code callback handling implementation

### DIFF
--- a/huskarl/docs/guide/authorization_code.md
+++ b/huskarl/docs/guide/authorization_code.md
@@ -92,7 +92,10 @@ let pending_state = start_output.pending_state;
 When the authorization server redirects back to your application, parse the
 callback URL (or just its query string) into a `CompleteInput` and pass it to
 `complete()`. Parsing captures `code`, `state`, and the RFC 9207 `iss`
-parameter, and rejects OAuth error responses (e.g. the user denied access).
+parameter. An OAuth error response (e.g. the user denied access) also parses;
+`complete()` state-checks it like any other callback, then surfaces it with the
+server's `oauth_error_code()` and `oauth_error_description()`. An unsolicited
+error response is rejected as a state mismatch, not reported as a denied login.
 
 ```rust
 use huskarl::{

--- a/huskarl/src/grant/authorization_code/error.rs
+++ b/huskarl/src/grant/authorization_code/error.rs
@@ -6,11 +6,24 @@ use snafu::Snafu;
 /// errors returned by
 /// [`complete`](super::AuthorizationCodeGrant::complete) /
 /// [`complete_oidc`](super::AuthorizationCodeGrant::complete_oidc) — match on
-/// the error kind rather than downcasting to this type.
+/// the error kind, and read an `OAuthError`'s members off the wrapping
+/// [`Error`](crate::core::Error), rather than downcasting to this type.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(super)))]
 #[non_exhaustive]
 pub enum CompleteError {
+    /// The callback was an OAuth error response (RFC 6749 §4.1.2.1) — e.g.
+    /// the user denied access.
+    ///
+    /// Only a response bound to the flow reaches this variant; an unsolicited
+    /// one is [`StateMismatch`](Self::StateMismatch).
+    #[snafu(display("Authorization server returned error: {error}"))]
+    OAuthError {
+        /// The `error` field in the `OAuth2` error response.
+        error: String,
+        /// The `error_description` field in the `OAuth2` error response.
+        error_description: Option<String>,
+    },
     /// There was a mismatch between the required and returned issuer values.
     #[snafu(display("Issuer mismatch: original = {}, callback = {}", original, callback))]
     IssuerMismatch {
@@ -71,21 +84,12 @@ pub enum StartError {
 /// An error parsing authorization-callback parameters into a
 /// [`CompleteInput`](super::CompleteInput).
 ///
-/// The `OAuthError` variant is control flow for login UIs (e.g. the user
-/// denied access); the rest carry the underlying failure.
+/// An OAuth error response is not a parse failure: it parses, and completion
+/// surfaces it as [`CompleteError::OAuthError`].
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(super)))]
 #[non_exhaustive]
 pub enum ParseCallbackError {
-    /// The authorization server returned an error response instead of a code
-    /// (RFC 6749 §4.1.2.1).
-    #[snafu(display("Authorization server returned error: {error}"))]
-    OAuthError {
-        /// The `error` field in the `OAuth2` error response.
-        error: String,
-        /// The `error_description` field in the `OAuth2` error response.
-        error_description: Option<String>,
-    },
     /// The callback parameters could not be parsed (malformed query, or a
     /// single-valued parameter that appeared more than once — RFC 6749 §3.1).
     #[snafu(display("Failed to parse callback parameters: {source}"))]

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -23,15 +23,15 @@ use crate::{
         authorization_code::{
             AuthorizationCodeGrantParameters,
             error::{
-                IdTokenIssuerNotConfiguredSnafu, IdTokenVerifierNotConfiguredSnafu,
+                CompleteError, IdTokenIssuerNotConfiguredSnafu, IdTokenVerifierNotConfiguredSnafu,
                 IssuerMismatchSnafu, MissingIdTokenSnafu, MissingIssuerSnafu, StateMismatchSnafu,
             },
             grant::AuthorizationCodeGrant,
             par,
             pkce::Pkce,
             types::{
-                AuthorizationPayload, AuthorizationPayloadWithClientId, CompleteInput,
-                PendingState, StartInput, StartOutput,
+                AuthorizationPayload, AuthorizationPayloadWithClientId, CallbackPayload,
+                CompleteInput, PendingState, StartInput, StartOutput,
             },
         },
         core::{OAuth2ExchangeGrant, TokenResponse, form::with_dpop_nonce_retry, join_space},
@@ -42,6 +42,26 @@ use crate::{
 /// Wraps a completion-check failure as a protocol error.
 fn complete_error(source: super::error::CompleteError) -> Error {
     Error::new(ErrorKind::Protocol, source)
+}
+
+/// Constant-time `state` check — one layer of CSRF protection.
+///
+/// An absent one fails: RFC 6749 §4.1.2.1 requires `state` on any response to a
+/// request that carried it, and forbids redirecting at all when it could not.
+fn check_state(pending_state: &PendingState, callback_state: Option<&str>) -> Result<(), Error> {
+    let matched = callback_state.is_some_and(|state| {
+        pending_state
+            .state
+            .as_bytes()
+            .ct_eq(state.as_bytes())
+            .into()
+    });
+
+    if matched {
+        Ok(())
+    } else {
+        Err(complete_error(StateMismatchSnafu.build()))
+    }
 }
 
 impl AuthorizationCodeGrant {
@@ -321,9 +341,11 @@ impl AuthorizationCodeGrant {
     ///
     /// # Errors
     ///
-    /// Returns an error if the token request fails, a callback parameter check
-    /// fails, or a returned ID token fails validation (see
-    /// [`complete_oidc`](Self::complete_oidc) for the ID-token semantics).
+    /// Returns an error if the callback was an OAuth error response
+    /// ([`OAuthError`](super::CompleteError::OAuthError)), the token request
+    /// fails, a callback parameter check fails, or a returned ID token fails
+    /// validation (see [`complete_oidc`](Self::complete_oidc) for the
+    /// ID-token semantics).
     pub async fn complete(
         &self,
         pending_state: &PendingState,
@@ -342,30 +364,45 @@ impl AuthorizationCodeGrant {
     ///
     /// # Errors
     ///
-    /// Returns an error if one is returned when sending a message to the token endpoint,
-    /// a check failed against the callback parameters, a received ID token could not be
-    /// validated, or an OIDC flow's token response carried no ID token
+    /// Returns an error if the callback was an OAuth error response
+    /// ([`OAuthError`](super::CompleteError::OAuthError)), one is returned
+    /// when sending a message to the token endpoint, a check failed against
+    /// the callback parameters, a received ID token could not be validated,
+    /// or an OIDC flow's token response carried no ID token
     /// ([`MissingIdToken`](super::CompleteError::MissingIdToken)).
     pub async fn complete_oidc(
         &self,
         pending_state: &PendingState,
         complete_input: CompleteInput,
     ) -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), Error> {
-        // Required state check (one layer of CSRF protection).
-        if pending_state
-            .state
-            .as_bytes()
-            .ct_ne(complete_input.state.as_bytes())
-            .into()
-        {
-            return Err(complete_error(StateMismatchSnafu.build()));
-        }
+        // An error response surfaces here, not at parse time, so it is state-
+        // checked too: an unsolicited one is CSRF, not a denied login.
+        let (code, iss) = match complete_input.payload {
+            CallbackPayload::Success { code, state, iss } => {
+                check_state(pending_state, Some(&state))?;
+                (code, iss)
+            }
+            CallbackPayload::Error {
+                error,
+                error_description,
+                state,
+            } => {
+                check_state(pending_state, state.as_deref())?;
+
+                let (oauth_code, oauth_description) = (error.clone(), error_description.clone());
+                return Err(complete_error(CompleteError::OAuthError {
+                    error,
+                    error_description,
+                })
+                .with_oauth_error(oauth_code, oauth_description));
+            }
+        };
 
         // RFC 9207 - check issuer match.
         if self.authorization_response_iss_parameter_supported
             && let Some(config_issuer) = self.issuer.as_deref()
         {
-            if let Some(issuer) = complete_input.iss {
+            if let Some(issuer) = iss {
                 // The issuer is public, not a secret, so a constant-time
                 // comparison is not required here (unlike `state` above).
                 if issuer.as_bytes() != config_issuer.as_bytes() {
@@ -399,7 +436,7 @@ impl AuthorizationCodeGrant {
         let token = self
             .exchange(AuthorizationCodeGrantParameters {
                 dpop_jkt: pending_state.dpop_jkt.clone(),
-                code: complete_input.code,
+                code,
                 pkce_verifier: pending_state.pkce_verifier.clone(),
                 resource: complete_input.resource,
             })
@@ -518,6 +555,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use bytes::Bytes;
+    use rstest::rstest;
 
     use super::*;
     use crate::{
@@ -1394,6 +1432,49 @@ mod tests {
             let (_, id_token) = result.expect("completion must succeed");
             assert!(id_token.is_none());
         }
+    }
+
+    /// A state-matched OAuth error response surfaces from completion carrying
+    /// the server's code and description.
+    #[tokio::test]
+    async fn error_payload_surfaces_from_complete() {
+        let grant = completing_grant(None, r#"{"access_token":"t","token_type":"bearer"}"#).await;
+
+        let input: CompleteInput = "error=access_denied&error_description=user+denied&state=st"
+            .parse()
+            .unwrap();
+        let err = grant
+            .complete_oidc(&pending(false), input)
+            .await
+            .expect_err("an error payload must not complete");
+        assert_eq!(err.kind(), crate::core::ErrorKind::Protocol, "got {err:?}");
+        assert_eq!(err.oauth_error_code(), Some("access_denied"));
+        assert_eq!(err.oauth_error_description(), Some("user denied"));
+    }
+
+    /// An error response that is not bound to the pending state is CSRF, not a
+    /// denied login: it is rejected before the OAuth code is reported.
+    #[rstest]
+    #[case::mismatched_state("error=access_denied&state=other")]
+    #[case::absent_state("error=access_denied")]
+    #[tokio::test]
+    async fn unsolicited_error_payload_is_rejected_as_state_mismatch(#[case] callback: &str) {
+        use std::error::Error as _;
+
+        let grant = completing_grant(None, r#"{"access_token":"t","token_type":"bearer"}"#).await;
+
+        let err = grant
+            .complete_oidc(&pending(false), callback.parse().unwrap())
+            .await
+            .expect_err("an unbound error payload must not complete");
+        assert_eq!(err.oauth_error_code(), None, "got {err:?}");
+        assert!(
+            matches!(
+                err.source().and_then(<dyn std::error::Error>::downcast_ref),
+                Some(CompleteError::StateMismatch)
+            ),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/huskarl/src/grant/authorization_code/loopback.rs
+++ b/huskarl/src/grant/authorization_code/loopback.rs
@@ -18,7 +18,7 @@ use url::Url;
 use crate::{
     core::{Error, jwt::validator::ValidatedJwt},
     grant::{
-        authorization_code::{CompleteInput, ParseCallbackError},
+        authorization_code::{CompleteError, CompleteInput, ParseCallbackError},
         core::TokenResponse,
     },
     token::id_token::IdTokenClaims,
@@ -300,7 +300,7 @@ async fn complete_on_loopback_oidc_with_timeouts(
                 break Err(e);
             }
         };
-        let result = complete(complete_input).await.context(CompleteSnafu);
+        let result = complete(complete_input).await.map_err(map_complete_error);
 
         // Redirect to a clean URL so the authorization code and state
         // are not left in the browser's address bar or history.
@@ -438,18 +438,29 @@ fn parse_callback_params(path_and_query: &str) -> Result<CompleteInput, Loopback
     // The parser takes the query after the first `?`. For `response_mode=form_post`
     // the body is folded in as a query string upstream, so this handles both.
     path_and_query.parse().map_err(|e| match e {
-        ParseCallbackError::OAuthError {
-            error,
-            error_description,
-        } => LoopbackError::OAuthError {
-            error,
-            error_description,
-        },
         ParseCallbackError::InvalidParameters { source } => {
             LoopbackError::InvalidCallbackParameters { source }
         }
         ParseCallbackError::MissingParameter { param } => LoopbackError::MissingParameter { param },
     })
+}
+
+/// An AS error response surfaces from `complete` (after its checks run);
+/// recover it as the `OAuthError` control-flow variant for the error page.
+fn map_complete_error(source: Error) -> LoopbackError {
+    use std::error::Error as _;
+
+    if let Some(CompleteError::OAuthError {
+        error,
+        error_description,
+    }) = source.source().and_then(|s| s.downcast_ref())
+    {
+        return LoopbackError::OAuthError {
+            error: error.clone(),
+            error_description: error_description.clone(),
+        };
+    }
+    LoopbackError::Complete { source }
 }
 
 async fn send_redirect(stream: &mut TcpStream, location: &str) -> Result<(), std::io::Error> {
@@ -561,10 +572,59 @@ pub async fn bind_loopback(port: u16) -> std::io::Result<TcpListener> {
     all(target_arch = "wasm32", target_os = "wasi", target_env = "p2")
 ))]
 mod tests {
+    use bytes::Bytes;
     use tokio::net::TcpStream;
 
     use super::*;
-    use crate::token::{AccessToken, id_token::IdTokenClaims};
+    use crate::{
+        core::{
+            client_auth::NoAuth,
+            http::{HttpClient, HttpResponse, Idempotency},
+            platform::MaybeSendBoxFuture,
+        },
+        grant::authorization_code::{AuthorizationCodeGrant, PendingState, types::CallbackPayload},
+        token::{AccessToken, id_token::IdTokenClaims},
+    };
+
+    /// The error path short-circuits before the token request.
+    struct UnusedHttp;
+
+    impl HttpClient for UnusedHttp {
+        fn execute(
+            &self,
+            _request: http::Request<Bytes>,
+            _idempotency: Idempotency,
+        ) -> MaybeSendBoxFuture<'_, Result<HttpResponse, Error>> {
+            panic!("an error callback must not reach the token endpoint")
+        }
+    }
+
+    /// Drives the real
+    /// [`complete_oidc`](AuthorizationCodeGrant::complete_oidc), so the error
+    /// mapping is tested against what completion actually produces.
+    async fn error_path_grant() -> AuthorizationCodeGrant {
+        AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(UnusedHttp)
+            .client_auth(NoAuth)
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .redirect_uri("http://127.0.0.1/callback")
+            .build()
+            .await
+            .unwrap()
+    }
+
+    fn error_path_pending_state() -> PendingState {
+        PendingState {
+            redirect_uri: "http://127.0.0.1/callback".to_owned(),
+            pkce_verifier: None,
+            state: "xyz".to_owned(),
+            nonce: None,
+            dpop_jkt: None,
+            openid_requested: false,
+        }
+    }
 
     fn ok_token_response() -> (TokenResponse, Option<ValidatedJwt<IdTokenClaims>>) {
         (
@@ -676,7 +736,10 @@ mod tests {
                 "http://127.0.0.1/callback",
                 None,
                 async |input| {
-                    assert_eq!(input.iss.as_deref(), Some("https://issuer.example.com"));
+                    let CallbackPayload::Success { iss, .. } = &input.payload else {
+                        panic!("expected a success payload, got {:?}", input.payload)
+                    };
+                    assert_eq!(iss.as_deref(), Some("https://issuer.example.com"));
                     Ok(ok_token_response())
                 },
             )
@@ -697,21 +760,31 @@ mod tests {
         ));
     }
 
+    /// A state-bound error response reaches the error page as the `OAuthError`
+    /// control-flow variant.
     #[tokio::test]
     async fn test_oauth_error_callback() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let grant = error_path_grant().await;
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(&listener, "http://127.0.0.1/callback", None, async |_| {
-                Ok(ok_token_response())
-            })
+            complete_on_loopback_oidc(
+                &listener,
+                "http://127.0.0.1/callback",
+                None,
+                async |input| {
+                    grant
+                        .complete_oidc(&error_path_pending_state(), input)
+                        .await
+                },
+            )
             .await
         });
 
         send_http_request(
             addr,
-            "GET /callback?error=access_denied&error_description=user+denied HTTP/1.1",
+            "GET /callback?error=access_denied&error_description=user+denied&state=xyz HTTP/1.1",
         )
         .await;
         // Send the failure follow-up so the server can render the error page
@@ -719,7 +792,45 @@ mod tests {
 
         let err = handle.await.unwrap().unwrap_err();
         assert!(
-            matches!(&err, LoopbackError::OAuthError { error, .. } if error == "access_denied")
+            matches!(&err, LoopbackError::OAuthError { error, error_description }
+                if error == "access_denied" && error_description.as_deref() == Some("user denied")),
+            "got {err:?}"
+        );
+    }
+
+    /// An unsolicited error response fails completion's state check, so it must
+    /// not be dressed up as the `OAuthError` control-flow variant.
+    #[tokio::test]
+    async fn test_unsolicited_oauth_error_callback_is_not_control_flow() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let grant = error_path_grant().await;
+
+        let handle = tokio::spawn(async move {
+            complete_on_loopback_oidc(
+                &listener,
+                "http://127.0.0.1/callback",
+                None,
+                async |input| {
+                    grant
+                        .complete_oidc(&error_path_pending_state(), input)
+                        .await
+                },
+            )
+            .await
+        });
+
+        send_http_request(
+            addr,
+            "GET /callback?error=access_denied&state=forged HTTP/1.1",
+        )
+        .await;
+        send_http_request(addr, "GET /failure HTTP/1.1").await;
+
+        let err = handle.await.unwrap().unwrap_err();
+        assert!(
+            matches!(&err, LoopbackError::Complete { .. }),
+            "got {err:?}"
         );
     }
 
@@ -807,8 +918,11 @@ mod tests {
                 "http://127.0.0.1/callback",
                 None,
                 async |input| {
-                    assert_eq!(input.code, "abc");
-                    assert_eq!(input.state, "xyz");
+                    let CallbackPayload::Success { code, state, .. } = &input.payload else {
+                        panic!("expected a success payload, got {:?}", input.payload)
+                    };
+                    assert_eq!(code, "abc");
+                    assert_eq!(state, "xyz");
                     Ok(ok_token_response())
                 },
             )

--- a/huskarl/src/grant/authorization_code/mod.rs
+++ b/huskarl/src/grant/authorization_code/mod.rs
@@ -41,4 +41,7 @@ pub use jar::{Jar, NoJar};
 pub use loopback::{
     CallbackRenderer, CallbackResponse, ErrorContext, LoopbackError, SuccessContext, bind_loopback,
 };
-pub use types::{CompleteInput, CompleteInputBuilder, PendingState, StartInput, StartOutput};
+pub use types::{
+    CompleteInput, CompleteInputBuilder, CompleteInputCallbackBuilder, PendingState, StartInput,
+    StartOutput,
+};

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -1,4 +1,4 @@
-use bon::Builder;
+use bon::{Builder, bon};
 use rand::TryRng as _;
 use serde::{Deserialize, Serialize};
 
@@ -172,6 +172,25 @@ pub struct StartOutput {
     pub pending_state: PendingState,
 }
 
+/// What the authorization callback carried: the RFC 6749 §4.1.2 success
+/// parameters or the §4.1.2.1 error parameters.
+#[derive(Debug, Clone)]
+pub(super) enum CallbackPayload {
+    /// The success parameters, plus the RFC 9207 `iss`.
+    Success {
+        code: String,
+        state: String,
+        iss: Option<String>,
+    },
+    /// An OAuth error response (e.g. the user denied access). `state` mirrors
+    /// the wire, where it can be absent; completion rejects that.
+    Error {
+        error: String,
+        error_description: Option<String>,
+        state: Option<String>,
+    },
+}
+
 /// The information needed to complete an authorization code flow.
 ///
 /// Parse the callback URL or query string via [`FromStr`](std::str::FromStr)
@@ -179,23 +198,51 @@ pub struct StartOutput {
 /// [`builder_from_callback`](Self::builder_from_callback) also lets `resource`
 /// be set. When building by hand, include `iss` — it is required when the
 /// server advertises RFC 9207 support.
-#[derive(Debug, Clone, Builder)]
+///
+/// An OAuth error response also parses; completion checks its `state` like any
+/// other callback, then surfaces it as
+/// [`CompleteError::OAuthError`](super::CompleteError::OAuthError).
+#[derive(Debug, Clone)]
 pub struct CompleteInput {
-    #[builder(into)]
-    pub(super) code: String,
-    #[builder(into)]
-    pub(super) state: String,
-    #[builder(into)]
-    pub(super) iss: Option<String>,
+    pub(super) payload: CallbackPayload,
     pub(super) resource: Option<Vec<String>>,
 }
 
+#[bon]
 impl CompleteInput {
+    /// By-hand construction from already-extracted success parameters (e.g.
+    /// framework-typed query parameters).
+    #[builder]
+    pub fn new(
+        #[builder(into)] code: String,
+        #[builder(into)] state: String,
+        #[builder(into)] iss: Option<String>,
+        resource: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            payload: CallbackPayload::Success { code, state, iss },
+            resource,
+        }
+    }
+
+    /// Seeded from a parsed callback; the payload is fixed — only fields the
+    /// callback cannot carry are settable.
+    #[builder(start_fn(name = seeded, vis = ""), finish_fn(name = build, vis = "pub"), builder_type(vis = "pub", doc {
+        /// Builder returned by [`CompleteInput::builder_from_callback`]: the
+        /// parsed payload is fixed; only `resource` can be set before `build()`.
+    }))]
+    fn callback(
+        #[builder(start_fn)] payload: CallbackPayload,
+        #[builder(setters(vis = "pub"))] resource: Option<Vec<String>>,
+    ) -> Self {
+        Self { payload, resource }
+    }
+
     /// Parses the authorization-response parameters (RFC 6749 §4.1.2, plus
     /// the RFC 9207 `iss`) into a seeded builder, so fields the callback
     /// cannot carry — the RFC 8707
-    /// [`resource`](CompleteInputBuilder::resource) indicators — can be set
-    /// before building.
+    /// [`resource`](CompleteInputCallbackBuilder::resource) indicators — can
+    /// be set before building.
     ///
     /// Accepts the full callback URL, just its query, or a
     /// `response_mode=form_post` body. Unknown parameters are ignored; a
@@ -203,19 +250,11 @@ impl CompleteInput {
     ///
     /// # Errors
     ///
-    /// Fails when the parameters cannot be parsed, `code` or `state` is
-    /// missing, or the callback is an OAuth error response
-    /// ([`OAuthError`](super::ParseCallbackError::OAuthError)).
+    /// Fails when the parameters cannot be parsed, or `code` or `state` is
+    /// missing from a non-error response.
     pub fn builder_from_callback(
         callback: &str,
-    ) -> Result<
-        CompleteInputBuilder<
-            complete_input_builder::SetState<
-                complete_input_builder::SetIss<complete_input_builder::SetCode>,
-            >,
-        >,
-        super::ParseCallbackError,
-    > {
+    ) -> Result<CompleteInputCallbackBuilder, super::ParseCallbackError> {
         use snafu::ResultExt as _;
 
         use super::error::{InvalidParametersSnafu, ParseCallbackError};
@@ -237,25 +276,27 @@ impl CompleteInput {
         let params: CallbackParams =
             crate::core::oauth_form::from_str(query).context(InvalidParametersSnafu)?;
 
-        // An OAuth error response takes precedence (RFC 6749 §4.1.2.1).
-        if let Some(error) = params.error {
-            return Err(ParseCallbackError::OAuthError {
+        // An OAuth error response takes precedence (RFC 6749 §4.1.2.1):
+        // `error` and `code` are mutually exclusive on the wire.
+        let payload = if let Some(error) = params.error {
+            CallbackPayload::Error {
                 error,
                 error_description: params.error_description,
-            });
-        }
+                state: params.state,
+            }
+        } else {
+            CallbackPayload::Success {
+                code: params
+                    .code
+                    .ok_or(ParseCallbackError::MissingParameter { param: "code" })?,
+                state: params
+                    .state
+                    .ok_or(ParseCallbackError::MissingParameter { param: "state" })?,
+                iss: params.iss,
+            }
+        };
 
-        let code = params
-            .code
-            .ok_or(ParseCallbackError::MissingParameter { param: "code" })?;
-        let state = params
-            .state
-            .ok_or(ParseCallbackError::MissingParameter { param: "state" })?;
-
-        Ok(Self::builder()
-            .code(code)
-            .maybe_iss(params.iss)
-            .state(state))
+        Ok(Self::seeded(payload))
     }
 }
 
@@ -386,6 +427,16 @@ mod tests {
         assert_eq!(state.nonce.as_deref(), Some("n"));
     }
 
+    /// Asserts the payload is a success shape and returns its parts.
+    fn success_parts(input: &CompleteInput) -> (&str, &str, Option<&str>) {
+        match &input.payload {
+            CallbackPayload::Success { code, state, iss } => (code, state, iss.as_deref()),
+            other @ CallbackPayload::Error { .. } => {
+                panic!("expected a success payload, got {other:?}")
+            }
+        }
+    }
+
     // The URL part before the first `?` is discarded and the fragment cut.
     #[rstest]
     #[case::query_with_iss(
@@ -396,9 +447,7 @@ mod tests {
     #[case::full_url_with_fragment("https://app.example.com/cb?code=abc&state=xyz#fragment", None)]
     fn complete_input_parses_accepted_shapes(#[case] input: &str, #[case] iss: Option<&str>) {
         let parsed: CompleteInput = input.parse().unwrap();
-        assert_eq!(parsed.code, "abc");
-        assert_eq!(parsed.state, "xyz");
-        assert_eq!(parsed.iss.as_deref(), iss);
+        assert_eq!(success_parts(&parsed), ("abc", "xyz", iss));
     }
 
     #[test]
@@ -407,7 +456,7 @@ mod tests {
             .unwrap()
             .resource(bon::vec!["https://api.example.com"])
             .build();
-        assert_eq!(input.code, "abc");
+        assert_eq!(success_parts(&input).0, "abc");
         assert_eq!(
             input.resource,
             Some(vec!["https://api.example.com".to_owned()])
@@ -415,15 +464,39 @@ mod tests {
     }
 
     #[test]
+    fn complete_input_builder_produces_success_payload() {
+        let input = CompleteInput::builder()
+            .code("abc")
+            .state("xyz")
+            .iss("https://issuer.example.com")
+            .build();
+        assert_eq!(
+            success_parts(&input),
+            ("abc", "xyz", Some("https://issuer.example.com"))
+        );
+        assert!(input.resource.is_none());
+    }
+
+    /// An OAuth error response parses successfully (surfacing happens at
+    /// completion), and takes precedence over any success parameters
+    /// (RFC 6749 §4.1.2.1).
+    #[test]
     fn complete_input_parse_error_response_takes_precedence() {
-        let err = "code=abc&state=xyz&error=access_denied&error_description=user+denied"
+        let parsed = "code=abc&state=xyz&error=access_denied&error_description=user+denied"
             .parse::<CompleteInput>()
-            .unwrap_err();
-        assert!(matches!(
-            &err,
-            super::super::ParseCallbackError::OAuthError { error, error_description }
-                if error == "access_denied" && error_description.as_deref() == Some("user denied")
-        ));
+            .unwrap();
+        assert!(
+            matches!(
+                &parsed.payload,
+                // `state` is kept so completion can bind the error to the flow.
+                CallbackPayload::Error { error, error_description, state }
+                    if error == "access_denied"
+                        && error_description.as_deref() == Some("user denied")
+                        && state.as_deref() == Some("xyz")
+            ),
+            "got {:?}",
+            parsed.payload
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
This provides one approach to handle callback parameters, as another approach to having each individual integration do this. It also provides one place where we can hook on features like JARM.