### PR TITLE
feat(client)!: Return CompleteOutput from auth completion.

### DIFF
--- a/huskarl/docs/guide/authorization_code.md
+++ b/huskarl/docs/guide/authorization_code.md
@@ -112,8 +112,8 @@ use huskarl::{
 // ("code=..&state=..&iss=..").
 let complete_input: CompleteInput = callback_url.parse()?;
 
-let response = grant.complete(pending_state, complete_input).await?;
-let token: &AccessToken = response.access_token();
+let completed = grant.complete(pending_state, complete_input).await?;
+let token: &AccessToken = completed.token_response.access_token();
 # Ok(())
 # }
 ```
@@ -135,9 +135,9 @@ Requesting the `openid` scope makes the flow an OIDC authentication: the
 grant sends a `nonce`, requires ID-token validation to be configured (a
 `jws_verifier_factory` and an issuer) before `start()` will proceed, and
 rejects a token response without an ID token (OIDC Core 1.0 §3.1.3.3) —
-unless the server narrowed `openid` out of the granted scope. Use
-`complete_oidc()` instead of `complete()` to receive the validated ID token
-alongside the token response.
+unless the server narrowed `openid` out of the granted scope. `complete()`
+returns the validated ID token on `CompleteOutput::id_token` alongside the
+token response whenever the flow is OIDC.
 
 The `oidc` builder setting overrides this inference for non-standard
 servers. `oidc(false)` treats `openid` as an ordinary OAuth scope — for

--- a/huskarl/examples/authorization_code.rs
+++ b/huskarl/examples/authorization_code.rs
@@ -69,12 +69,12 @@ pub async fn main() -> Result<(), snafu::Whatever> {
 
     println!("Open this URL in your browser:\n{}", authorization_url);
 
-    let (token_response, id_token) = grant
-        .complete_on_loopback_oidc(&listener, &pending_state, None)
+    let completed = grant
+        .complete_on_loopback(&listener, &pending_state, None)
         .await
         .whatever_context("Getting token failed")?;
 
-    println!("ID token: {:?}", id_token);
+    println!("ID token: {:?}", completed.id_token);
 
     // Hand the token response from the authorization code exchange to the
     // source; it serves the token and refreshes it automatically. DPoP proof
@@ -85,7 +85,7 @@ pub async fn main() -> Result<(), snafu::Whatever> {
         .refresh_store(InMemoryRefreshTokenStore::default())
         .build();
     source
-        .prime(token_response)
+        .prime(completed.token_response)
         .await
         .whatever_context("Failed to prime the token source")?;
 

--- a/huskarl/src/grant/authorization_code/error.rs
+++ b/huskarl/src/grant/authorization_code/error.rs
@@ -5,7 +5,7 @@ use snafu::Snafu;
 /// Carried as the source of [`ErrorKind::Protocol`](crate::core::ErrorKind::Protocol)
 /// errors returned by
 /// [`complete`](super::AuthorizationCodeGrant::complete) /
-/// [`complete_oidc`](super::AuthorizationCodeGrant::complete_oidc) — match on
+/// [`complete`](super::AuthorizationCodeGrant::complete) — match on
 /// the error kind, and read an `OAuthError`'s members off the wrapping
 /// [`Error`](crate::core::Error), rather than downcasting to this type.
 #[derive(Debug, Snafu)]

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -33,13 +33,13 @@ use crate::{
             pkce::Pkce,
             types::{
                 AuthorizationPayload, AuthorizationPayloadWithClientId, AuthorizationResponse,
-                CallbackPayload, CompleteInput, PendingState, ResponseMode, StartInput,
-                StartOutput,
+                CallbackPayload, CompleteInput, CompleteOutput, PendingState, ResponseMode,
+                StartInput, StartOutput,
             },
         },
-        core::{OAuth2ExchangeGrant, TokenResponse, form::with_dpop_nonce_retry, join_space},
+        core::{OAuth2ExchangeGrant, form::with_dpop_nonce_retry, join_space},
     },
-    token::id_token::{IdTokenClaims, IdTokenValidator},
+    token::id_token::IdTokenValidator,
 };
 
 /// Wraps a completion-check failure as a protocol error.
@@ -69,18 +69,19 @@ fn check_state(pending_state: &PendingState, callback_state: Option<&str>) -> Re
 
 impl AuthorizationCodeGrant {
     /// Completes the authorization code flow on `listener`, returning the token
-    /// response.
+    /// response and, for an OIDC flow, the validated ID token.
     ///
     /// Runs a minimal HTTP server on `listener` to receive the redirect callback
-    /// at the redirect URI — handy for command-line tools. To also recover the
-    /// validated ID token, use
-    /// [`complete_on_loopback_oidc`](Self::complete_on_loopback_oidc).
+    /// at the redirect URI — handy for command-line tools. See [`complete`] for
+    /// the ID-token semantics carried on [`CompleteOutput`].
+    ///
+    /// [`complete`]: Self::complete
     ///
     /// # Errors
     ///
-    /// Errors if a callback URL cannot be parsed, the HTTP exchange or callback
-    /// handling fails, the token request fails, or a returned ID token fails
-    /// validation (see [`complete_oidc`](Self::complete_oidc)).
+    /// Returns a [`LoopbackError`] if the callback server fails, a callback URL
+    /// cannot be parsed, the authorization server returns an error response, or
+    /// the token (and ID token) exchange fails.
     #[cfg(all(
         feature = "authorization-flow-loopback",
         any(
@@ -93,42 +94,12 @@ impl AuthorizationCodeGrant {
         listener: &tokio::net::TcpListener,
         pending_state: &PendingState,
         renderer: Option<loopback::CallbackRenderer>,
-    ) -> Result<TokenResponse, LoopbackError> {
-        self.complete_on_loopback_oidc(listener, pending_state, renderer)
-            .await
-            .map(|v| v.0)
-    }
-
-    /// Completes the authorization code flow on `listener`, returning the token
-    /// response together with the validated ID token when the flow was an OIDC
-    /// flow.
-    ///
-    /// Like [`complete_on_loopback`](Self::complete_on_loopback), but also yields
-    /// the validated ID token. Same minimal callback server and the same errors.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`LoopbackError`] if the callback server fails, the
-    /// authorization server returns an error response, or the token (and ID
-    /// token) exchange fails.
-    #[cfg(all(
-        feature = "authorization-flow-loopback",
-        any(
-            not(target_family = "wasm"),
-            all(target_arch = "wasm32", target_os = "wasi", target_env = "p2")
-        )
-    ))]
-    pub async fn complete_on_loopback_oidc(
-        &self,
-        listener: &tokio::net::TcpListener,
-        pending_state: &PendingState,
-        renderer: Option<loopback::CallbackRenderer>,
-    ) -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), LoopbackError> {
-        loopback::complete_on_loopback_oidc(
+    ) -> Result<CompleteOutput, LoopbackError> {
+        loopback::complete_on_loopback(
             listener,
             &pending_state.redirect_uri,
             renderer,
-            async |complete_input| self.complete_oidc(pending_state, complete_input).await,
+            async |complete_input| self.complete(pending_state, complete_input).await,
         )
         .await
     }
@@ -339,47 +310,24 @@ impl AuthorizationCodeGrant {
     }
 
     /// Attempts to complete the authorization code flow, returning the token
-    /// response.
+    /// response and, for an OIDC flow, the validated ID token.
     ///
-    /// To also recover the validated ID token, use
-    /// [`complete_oidc`](Self::complete_oidc).
+    /// [`CompleteOutput::id_token`] is `Some` — validated — whenever the flow
+    /// is OIDC (see the `oidc` builder setting); `None` means the flow was not
+    /// OIDC, or the server narrowed `openid` out of the granted scope.
     ///
     /// # Errors
     ///
     /// Returns an error if the callback was an OAuth error response
     /// ([`OAuthError`](super::CompleteError::OAuthError)), the token request
-    /// fails, a callback parameter check fails, or a returned ID token fails
-    /// validation (see [`complete_oidc`](Self::complete_oidc) for the
-    /// ID-token semantics).
+    /// failed, a check failed against the callback parameters, a received ID
+    /// token could not be validated, or an OIDC flow's token response carried
+    /// no ID token ([`MissingIdToken`](super::CompleteError::MissingIdToken)).
     pub async fn complete(
         &self,
         pending_state: &PendingState,
         complete_input: CompleteInput,
-    ) -> Result<TokenResponse, Error> {
-        self.complete_oidc(pending_state, complete_input)
-            .await
-            .map(|(token_response, _)| token_response)
-    }
-
-    /// Attempts to complete the authorization code flow, returning both the token response and the validated ID token.
-    ///
-    /// The ID token is `Some` — validated — whenever the flow is OIDC (see
-    /// the `oidc` builder setting); `None` means the flow was not OIDC, or
-    /// the server narrowed `openid` out of the granted scope.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the callback was an OAuth error response
-    /// ([`OAuthError`](super::CompleteError::OAuthError)), one is returned
-    /// when sending a message to the token endpoint, a check failed against
-    /// the callback parameters, a received ID token could not be validated,
-    /// or an OIDC flow's token response carried no ID token
-    /// ([`MissingIdToken`](super::CompleteError::MissingIdToken)).
-    pub async fn complete_oidc(
-        &self,
-        pending_state: &PendingState,
-        complete_input: CompleteInput,
-    ) -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), Error> {
+    ) -> Result<CompleteOutput, Error> {
         // Fold the callback into a single response shape (JARM verified, then
         // plain params) so every check below runs the same way on both.
         let response = self
@@ -479,7 +427,10 @@ impl AuthorizationCodeGrant {
                     Error::new(ErrorKind::Protocol, e).with_context("validating ID token")
                 })?;
 
-            Ok((token, Some(verified_token)))
+            Ok(CompleteOutput {
+                token_response: token,
+                id_token: Some(verified_token),
+            })
         } else {
             // OIDC Core 1.0 §3.1.3.3: the token response must carry an ID
             // token when `openid` is granted. Granted scope defaults to the
@@ -496,7 +447,10 @@ impl AuthorizationCodeGrant {
             if expected && !narrowed {
                 return Err(complete_error(MissingIdTokenSnafu.build()));
             }
-            Ok((token, None))
+            Ok(CompleteOutput {
+                token_response: token,
+                id_token: None,
+            })
         }
     }
 
@@ -828,7 +782,7 @@ mod tests {
             .await
             .unwrap();
 
-        let token = grant
+        let completed = grant
             .with_session_dpop_key(key)
             .unwrap()
             .complete(
@@ -841,7 +795,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(token.access_token(), AccessToken::DPoP(_)));
+        assert!(matches!(
+            completed.token_response.access_token(),
+            AccessToken::DPoP(_)
+        ));
 
         let seen = http.seen.lock().unwrap();
         assert!(
@@ -1515,7 +1472,7 @@ mod tests {
         let grant = completing_grant(oidc, body).await;
 
         let result = grant
-            .complete_oidc(&pending(openid_requested), complete_input())
+            .complete(&pending(openid_requested), complete_input())
             .await;
 
         if expect_error {
@@ -1523,8 +1480,8 @@ mod tests {
             assert_eq!(err.kind(), crate::core::ErrorKind::Protocol, "got {err:?}");
             assert!(format!("{err:?}").contains("MissingIdToken"), "got {err:?}");
         } else {
-            let (_, id_token) = result.expect("completion must succeed");
-            assert!(id_token.is_none());
+            let output = result.expect("completion must succeed");
+            assert!(output.id_token.is_none());
         }
     }
 
@@ -1538,7 +1495,7 @@ mod tests {
             .parse()
             .unwrap();
         let err = grant
-            .complete_oidc(&pending(false), input)
+            .complete(&pending(false), input)
             .await
             .expect_err("an error payload must not complete");
         assert_eq!(err.kind(), crate::core::ErrorKind::Protocol, "got {err:?}");
@@ -1558,7 +1515,7 @@ mod tests {
         let grant = completing_grant(None, r#"{"access_token":"t","token_type":"bearer"}"#).await;
 
         let err = grant
-            .complete_oidc(&pending(false), callback.parse().unwrap())
+            .complete(&pending(false), callback.parse().unwrap())
             .await
             .expect_err("an unbound error payload must not complete");
         assert_eq!(err.oauth_error_code(), None, "got {err:?}");
@@ -1646,7 +1603,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         grant
-            .complete_oidc(&pending_jarm(), input)
+            .complete(&pending_jarm(), input)
             .await
             .expect("a valid JARM response must complete");
     }
@@ -1666,7 +1623,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         let err = grant
-            .complete_oidc(&pending_jarm(), input)
+            .complete(&pending_jarm(), input)
             .await
             .expect_err("a JARM error response must not complete");
         assert_eq!(err.oauth_error_code(), Some("access_denied"));
@@ -1686,7 +1643,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         let err = grant
-            .complete_oidc(&pending_jarm(), input)
+            .complete(&pending_jarm(), input)
             .await
             .expect_err("a JARM state mismatch must be rejected");
         assert!(format!("{err:?}").contains("StateMismatch"), "got {err:?}");
@@ -1707,7 +1664,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         let err = grant
-            .complete_oidc(&pending_jarm(), input)
+            .complete(&pending_jarm(), input)
             .await
             .expect_err("a JARM error without state must be rejected");
         assert_eq!(err.oauth_error_code(), None, "got {err:?}");
@@ -1725,7 +1682,7 @@ mod tests {
         let (grant, _) = jarm_grant(r#"{"access_token":"t","token_type":"bearer"}"#).await;
 
         let err = grant
-            .complete_oidc(&pending_jarm(), callback.parse().unwrap())
+            .complete(&pending_jarm(), callback.parse().unwrap())
             .await
             .expect_err("plain parameters must not satisfy a JARM flow");
         assert!(
@@ -1747,7 +1704,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         let err = grant
-            .complete_oidc(&pending(false), input)
+            .complete(&pending(false), input)
             .await
             .expect_err("an unrequested JARM response must be rejected");
         assert!(
@@ -1770,7 +1727,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         let err = grant
-            .complete_oidc(&pending_jarm(), input)
+            .complete(&pending_jarm(), input)
             .await
             .expect_err("a JARM response for another client must be rejected");
         assert!(format!("{err:?}").contains("JarmValidation"), "got {err:?}");
@@ -1791,7 +1748,7 @@ mod tests {
 
         let input: CompleteInput = format!("response={jarm}").parse().unwrap();
         let err = grant
-            .complete_oidc(&pending_jarm(), input)
+            .complete(&pending_jarm(), input)
             .await
             .expect_err("an ES256 JARM response must be rejected by a PS256 allowlist");
         assert!(format!("{err:?}").contains("JarmValidation"), "got {err:?}");

--- a/huskarl/src/grant/authorization_code/loopback.rs
+++ b/huskarl/src/grant/authorization_code/loopback.rs
@@ -16,12 +16,8 @@ use tokio::{
 use url::Url;
 
 use crate::{
-    core::{Error, jwt::validator::ValidatedJwt},
-    grant::{
-        authorization_code::{CompleteError, CompleteInput, ParseCallbackError},
-        core::TokenResponse,
-    },
-    token::id_token::IdTokenClaims,
+    core::Error,
+    grant::authorization_code::{CompleteError, CompleteInput, CompleteOutput, ParseCallbackError},
 };
 
 /// Errors that can occur when handling the authorization code callback with the loopback implementation.
@@ -231,16 +227,13 @@ const RESULT_PAGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(
 
 /// Waits for the authorization callback on `listener`, completes the flow
 /// via `complete`, and serves a result page to the browser.
-pub async fn complete_on_loopback_oidc(
+pub async fn complete_on_loopback(
     listener: &TcpListener,
     redirect_uri: &str,
     renderer: Option<CallbackRenderer>,
-    complete: impl AsyncFnOnce(
-        CompleteInput,
-    )
-        -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), Error>,
-) -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), LoopbackError> {
-    complete_on_loopback_oidc_with_timeouts(
+    complete: impl AsyncFnOnce(CompleteInput) -> Result<CompleteOutput, Error>,
+) -> Result<CompleteOutput, LoopbackError> {
+    complete_on_loopback_with_timeouts(
         listener,
         redirect_uri,
         renderer,
@@ -251,17 +244,14 @@ pub async fn complete_on_loopback_oidc(
     .await
 }
 
-async fn complete_on_loopback_oidc_with_timeouts(
+async fn complete_on_loopback_with_timeouts(
     listener: &TcpListener,
     redirect_uri: &str,
     renderer: Option<CallbackRenderer>,
     read_timeout: std::time::Duration,
     result_page_timeout: std::time::Duration,
-    complete: impl AsyncFnOnce(
-        CompleteInput,
-    )
-        -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), Error>,
-) -> Result<(TokenResponse, Option<ValidatedJwt<IdTokenClaims>>), LoopbackError> {
+    complete: impl AsyncFnOnce(CompleteInput) -> Result<CompleteOutput, Error>,
+) -> Result<CompleteOutput, LoopbackError> {
     let port = listener.local_addr().map_or(0, |a| a.port());
 
     let expected_path = Url::parse(redirect_uri)
@@ -586,7 +576,7 @@ mod tests {
             AuthorizationCodeGrant, PendingState,
             types::{AuthorizationResponse, CallbackPayload},
         },
-        token::{AccessToken, id_token::IdTokenClaims},
+        token::AccessToken,
     };
 
     /// The error path short-circuits before the token request.
@@ -603,7 +593,7 @@ mod tests {
     }
 
     /// Drives the real
-    /// [`complete_oidc`](AuthorizationCodeGrant::complete_oidc), so the error
+    /// [`complete`](AuthorizationCodeGrant::complete), so the error
     /// mapping is tested against what completion actually produces.
     async fn error_path_grant() -> AuthorizationCodeGrant {
         AuthorizationCodeGrant::builder()
@@ -630,16 +620,16 @@ mod tests {
         }
     }
 
-    fn ok_token_response() -> (TokenResponse, Option<ValidatedJwt<IdTokenClaims>>) {
-        (
-            crate::grant::core::token_response::RawTokenResponse::builder()
+    fn ok_token_response() -> CompleteOutput {
+        CompleteOutput {
+            token_response: crate::grant::core::token_response::RawTokenResponse::builder()
                 .access_token(crate::core::secrets::SecretString::new("test-token"))
                 .token_type("Bearer")
                 .build()
                 .into_token_response(None, crate::core::platform::SystemTime::now())
                 .unwrap(),
-            None,
-        )
+            id_token: None,
+        }
     }
 
     async fn send_http_request(addr: std::net::SocketAddr, request_line: &str) {
@@ -666,7 +656,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(
+            complete_on_loopback(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
@@ -680,17 +670,17 @@ mod tests {
         // Send the success follow-up
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, id_token) = handle.await.unwrap().unwrap();
+        let output = handle.await.unwrap().unwrap();
 
         assert!(matches!(
-            token_response.access_token(),
+            output.token_response.access_token(),
             AccessToken::Bearer(_)
         ));
         assert_eq!(
-            token_response.access_token().token().expose_secret(),
+            output.token_response.access_token().token().expose_secret(),
             "test-token"
         );
-        assert!(id_token.is_none());
+        assert!(output.id_token.is_none());
     }
 
     /// Regression: a connection torn down with RST mid-read (a browser
@@ -703,7 +693,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(
+            complete_on_loopback(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
@@ -722,7 +712,7 @@ mod tests {
         send_http_request(addr, "GET /callback?code=abc&state=xyz HTTP/1.1").await;
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"
@@ -735,7 +725,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(
+            complete_on_loopback(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
@@ -759,7 +749,7 @@ mod tests {
         .await;
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert!(matches!(
             token_response.access_token(),
             AccessToken::Bearer(_)
@@ -775,15 +765,11 @@ mod tests {
         let grant = error_path_grant().await;
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(
+            complete_on_loopback(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
-                async |input| {
-                    grant
-                        .complete_oidc(&error_path_pending_state(), input)
-                        .await
-                },
+                async |input| grant.complete(&error_path_pending_state(), input).await,
             )
             .await
         });
@@ -813,15 +799,11 @@ mod tests {
         let grant = error_path_grant().await;
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(
+            complete_on_loopback(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
-                async |input| {
-                    grant
-                        .complete_oidc(&error_path_pending_state(), input)
-                        .await
-                },
+                async |input| grant.complete(&error_path_pending_state(), input).await,
             )
             .await
         });
@@ -846,7 +828,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(&listener, "http://127.0.0.1/callback", None, async |_| {
+            complete_on_loopback(&listener, "http://127.0.0.1/callback", None, async |_| {
                 Ok(ok_token_response())
             })
             .await
@@ -869,7 +851,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(&listener, "http://127.0.0.1/callback", None, async |_| {
+            complete_on_loopback(&listener, "http://127.0.0.1/callback", None, async |_| {
                 Ok(ok_token_response())
             })
             .await
@@ -893,7 +875,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(&listener, "http://127.0.0.1/callback", None, async |_| {
+            complete_on_loopback(&listener, "http://127.0.0.1/callback", None, async |_| {
                 Ok(ok_token_response())
             })
             .await
@@ -906,7 +888,7 @@ mod tests {
         // Follow-up success page
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"
@@ -919,7 +901,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(
+            complete_on_loopback(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
@@ -951,7 +933,7 @@ mod tests {
         send_raw_request(addr, &raw).await;
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"
@@ -964,7 +946,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc_with_timeouts(
+            complete_on_loopback_with_timeouts(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
@@ -982,7 +964,7 @@ mod tests {
         send_http_request(addr, "GET /callback?code=abc&state=xyz HTTP/1.1").await;
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"
@@ -996,7 +978,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc_with_timeouts(
+            complete_on_loopback_with_timeouts(
                 &listener,
                 "http://127.0.0.1/callback",
                 None,
@@ -1012,7 +994,7 @@ mod tests {
         // completed result must still be returned after the bounded wait.
         send_http_request(addr, "GET /callback?code=abc&state=xyz HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"
@@ -1025,7 +1007,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(&listener, "http://127.0.0.1/callback", None, async |_| {
+            complete_on_loopback(&listener, "http://127.0.0.1/callback", None, async |_| {
                 Ok(ok_token_response())
             })
             .await
@@ -1041,7 +1023,7 @@ mod tests {
         send_http_request(addr, "GET /callback?code=abc&state=xyz HTTP/1.1").await;
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"
@@ -1054,7 +1036,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let handle = tokio::spawn(async move {
-            complete_on_loopback_oidc(&listener, "http://127.0.0.1/callback", None, async |_| {
+            complete_on_loopback(&listener, "http://127.0.0.1/callback", None, async |_| {
                 Ok(ok_token_response())
             })
             .await
@@ -1073,7 +1055,7 @@ mod tests {
         send_http_request(addr, "GET /callback?code=abc&state=xyz HTTP/1.1").await;
         send_http_request(addr, "GET /success HTTP/1.1").await;
 
-        let (token_response, _) = handle.await.unwrap().unwrap();
+        let token_response = handle.await.unwrap().unwrap().token_response;
         assert_eq!(
             token_response.access_token().token().expose_secret(),
             "test-token"

--- a/huskarl/src/grant/authorization_code/mod.rs
+++ b/huskarl/src/grant/authorization_code/mod.rs
@@ -42,6 +42,6 @@ pub use loopback::{
     CallbackRenderer, CallbackResponse, ErrorContext, LoopbackError, SuccessContext, bind_loopback,
 };
 pub use types::{
-    CompleteInput, CompleteInputBuilder, CompleteInputCallbackBuilder, PendingState, ResponseMode,
-    StartInput, StartOutput,
+    CompleteInput, CompleteInputBuilder, CompleteInputCallbackBuilder, CompleteOutput,
+    PendingState, ResponseMode, StartInput, StartOutput,
 };

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -3,8 +3,9 @@ use rand::TryRng as _;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    core::{AuthorizationDetail, platform::Duration},
-    token::IdToken,
+    core::{AuthorizationDetail, jwt::validator::ValidatedJwt, platform::Duration},
+    grant::core::TokenResponse,
+    token::{IdToken, id_token::IdTokenClaims},
 };
 
 /// The authorization-request parameters sent to the authorization endpoint
@@ -206,6 +207,23 @@ pub struct StartOutput {
     pub expires_at: Option<crate::core::platform::SystemTime>,
     /// State that must be persisted until the callback completes.
     pub pending_state: PendingState,
+}
+
+/// The result of completing an authorization code flow: the token endpoint
+/// response, plus the validated ID token when the flow was OIDC.
+///
+/// Returned by
+/// [`complete`](crate::grant::authorization_code::AuthorizationCodeGrant::complete)
+/// and its loopback variant.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct CompleteOutput {
+    /// The token endpoint response.
+    pub token_response: TokenResponse,
+    /// The validated ID token — `Some` whenever the flow is OIDC (see
+    /// [`complete`](crate::grant::authorization_code::AuthorizationCodeGrant::complete)),
+    /// `None` otherwise.
+    pub id_token: Option<ValidatedJwt<IdTokenClaims>>,
 }
 
 /// An authorization response in its final form: the RFC 6749 §4.1.2 success

--- a/huskarl/src/grant/core/token_response.rs
+++ b/huskarl/src/grant/core/token_response.rs
@@ -90,7 +90,7 @@ impl TokenResponse {
     ///
     /// The library validates it only on the authorization-code callback path
     /// — use the validated form returned by
-    /// [`complete_oidc`](crate::grant::authorization_code::AuthorizationCodeGrant::complete_oidc)
+    /// [`complete`](crate::grant::authorization_code::AuthorizationCodeGrant::complete)
     /// there. On every other grant (refresh, device, token exchange) this is
     /// untrusted wire data: validate it before use.
     #[must_use]

--- a/integration/huskarl-conformance/src/lib.rs
+++ b/integration/huskarl-conformance/src/lib.rs
@@ -269,7 +269,8 @@ pub async fn run_auth_code_flow_with_listener<
                 Err(e) => Err(format!("browser navigation failed: {e}")),
             }
         }
-    }?;
+    }?
+    .token_response;
 
     // Prime the source so get_headers() immediately returns the fresh token.
     source

--- a/integration/huskarl-integration/src/suite.rs
+++ b/integration/huskarl-integration/src/suite.rs
@@ -410,7 +410,7 @@ pub async fn auth_code_flow(provider: &dyn TestProvider, features: Features) {
     // Run login and loopback completion concurrently so a login error surfaces
     // immediately instead of blocking on the accept loop until timeout.
     let auth_fut = provider.authenticate(&authorization_url);
-    let complete_fut = grant.complete_on_loopback_oidc(&listener, &pending_state, None);
+    let complete_fut = grant.complete_on_loopback(&listener, &pending_state, None);
     tokio::pin!(auth_fut, complete_fut);
 
     let token_and_id = tokio::time::timeout(std::time::Duration::from_secs(30), async {
@@ -424,7 +424,7 @@ pub async fn auth_code_flow(provider: &dyn TestProvider, features: Features) {
     })
     .await
     .expect("auth-code flow timed out — login likely did not reach the loopback callback");
-    let (_token_response, id_token) = token_and_id.expect("complete auth-code flow");
+    let id_token = token_and_id.expect("complete auth-code flow").id_token;
 
     let id_token = id_token.expect("id_token present for the openid scope");
     assert!(


### PR DESCRIPTION
This makes it possible to add extra fields in future from auth completion. Also, collapses complete and complete_oidc into one.

BREAKING CHANGE: Replace complete_oidc with complete, and extract from the returned struct instead of a tuple.