### PR TITLE
feat(client)!: Carry error_uri alongside the OAuth error code

### DIFF
--- a/huskarl/src/grant/authorization_code/error.rs
+++ b/huskarl/src/grant/authorization_code/error.rs
@@ -17,12 +17,18 @@ pub enum CompleteError {
     ///
     /// Only a response bound to the flow reaches this variant; an unsolicited
     /// one is [`StateMismatch`](Self::StateMismatch).
-    #[snafu(display("Authorization server returned error: {error}"))]
+    #[snafu(display(
+        "Authorization server returned error: {error}{}",
+        error_uri.as_ref().map(|uri| format!(" (see {uri})")).unwrap_or_default()
+    ))]
+    #[non_exhaustive]
     OAuthError {
         /// The `error` field in the `OAuth2` error response.
         error: String,
         /// The `error_description` field in the `OAuth2` error response.
         error_description: Option<String>,
+        /// The `error_uri` field in the `OAuth2` error response.
+        error_uri: Option<String>,
     },
     /// There was a mismatch between the required and returned issuer values.
     #[snafu(display("Issuer mismatch: original = {}, callback = {}", original, callback))]

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -37,7 +37,7 @@ use crate::{
                 StartInput, StartOutput,
             },
         },
-        core::{OAuth2ExchangeGrant, form::with_dpop_nonce_retry, join_space},
+        core::{OAuth2ExchangeGrant, TokenResponse, form::with_dpop_nonce_retry, join_space},
     },
     token::id_token::IdTokenValidator,
 };
@@ -344,6 +344,7 @@ impl AuthorizationCodeGrant {
             AuthorizationResponse::Error {
                 error,
                 error_description,
+                error_uri,
                 state,
             } => {
                 check_state(pending_state, state.as_deref())?;
@@ -352,6 +353,7 @@ impl AuthorizationCodeGrant {
                 return Err(complete_error(CompleteError::OAuthError {
                     error,
                     error_description,
+                    error_uri,
                 })
                 .with_oauth_error(oauth_code, oauth_description));
             }
@@ -401,6 +403,17 @@ impl AuthorizationCodeGrant {
             })
             .await?;
 
+        self.finalize_id_token(pending_state, token).await
+    }
+
+    /// Validates the token response's ID token when present, or enforces the
+    /// OIDC "ID token required" rule when it is absent, folding either outcome
+    /// into a [`CompleteOutput`].
+    async fn finalize_id_token(
+        &self,
+        pending_state: &PendingState,
+        token: TokenResponse,
+    ) -> Result<CompleteOutput, Error> {
         if let Some(id_token) = &token.id_token() {
             let verifier = self
                 .jws_verifier
@@ -493,6 +506,7 @@ impl AuthorizationCodeGrant {
             state: Option<String>,
             error: Option<String>,
             error_description: Option<String>,
+            error_uri: Option<String>,
         }
 
         let verifier = self
@@ -522,6 +536,7 @@ impl AuthorizationCodeGrant {
             return Ok(AuthorizationResponse::Error {
                 error,
                 error_description: claims.error_description,
+                error_uri: claims.error_uri,
                 state: claims.state,
             });
         }
@@ -1491,7 +1506,8 @@ mod tests {
     async fn error_payload_surfaces_from_complete() {
         let grant = completing_grant(None, r#"{"access_token":"t","token_type":"bearer"}"#).await;
 
-        let input: CompleteInput = "error=access_denied&error_description=user+denied&state=st"
+        let input: CompleteInput = "error=access_denied&error_description=user+denied\
+                                    &error_uri=https%3A%2F%2Fas.example.com%2Fdoc&state=st"
             .parse()
             .unwrap();
         let err = grant
@@ -1501,6 +1517,15 @@ mod tests {
         assert_eq!(err.kind(), crate::core::ErrorKind::Protocol, "got {err:?}");
         assert_eq!(err.oauth_error_code(), Some("access_denied"));
         assert_eq!(err.oauth_error_description(), Some("user denied"));
+
+        let source: &CompleteError = std::error::Error::source(&err)
+            .and_then(|s| s.downcast_ref())
+            .expect("source is a CompleteError");
+        assert!(
+            matches!(source, CompleteError::OAuthError { error_uri, .. }
+                if error_uri.as_deref() == Some("https://as.example.com/doc")),
+            "got {source:?}"
+        );
     }
 
     /// An error response that is not bound to the pending state is CSRF, not a

--- a/huskarl/src/grant/authorization_code/loopback.rs
+++ b/huskarl/src/grant/authorization_code/loopback.rs
@@ -46,12 +46,18 @@ pub enum LoopbackError {
         source: std::io::Error,
     },
     /// Authorization server returned error.
-    #[snafu(display("Authorization server returned error: {error}"))]
+    #[snafu(display(
+        "Authorization server returned error: {error}{}",
+        error_uri.as_ref().map(|uri| format!(" (see {uri})")).unwrap_or_default()
+    ))]
+    #[non_exhaustive]
     OAuthError {
         /// The `error` field in the `OAuth2` error response.
         error: String,
         /// The `error_description` field in the `OAuth2` error response.
         error_description: Option<String>,
+        /// The `error_uri` field in the `OAuth2` error response.
+        error_uri: Option<String>,
     },
     /// The callback parameters could not be parsed (malformed query, or a
     /// single-valued parameter that appeared more than once — RFC 6749 §3.1).
@@ -99,6 +105,7 @@ pub struct SuccessContext {
 #[non_exhaustive]
 pub enum ErrorContext {
     /// The authorization server returned an OAuth error response (e.g. `access_denied`).
+    #[non_exhaustive]
     OAuthError {
         /// The port the loopback server is listening on.
         port: u16,
@@ -106,6 +113,8 @@ pub enum ErrorContext {
         error: String,
         /// The optional human-readable error description.
         description: Option<String>,
+        /// The optional `error_uri` documenting the error.
+        error_uri: Option<String>,
     },
     /// Token exchange or another internal operation failed.
     InternalError {
@@ -174,18 +183,25 @@ fn error_query_string(ctx: &ErrorContext) -> String {
         error: &'a str,
         #[serde(skip_serializing_if = "Option::is_none")]
         error_description: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_uri: Option<&'a str>,
     }
 
     let params = match ctx {
         ErrorContext::OAuthError {
-            error, description, ..
+            error,
+            description,
+            error_uri,
+            ..
         } => Params {
             error,
             error_description: description.as_deref(),
+            error_uri: error_uri.as_deref(),
         },
         ErrorContext::InternalError { message, .. } => Params {
             error: "server_error",
             error_description: Some(message),
+            error_uri: None,
         },
     };
 
@@ -197,10 +213,12 @@ fn to_error_context(port: u16, err: &LoopbackError) -> ErrorContext {
         LoopbackError::OAuthError {
             error,
             error_description,
+            error_uri,
         } => ErrorContext::OAuthError {
             port,
             error: error.clone(),
             description: error_description.clone(),
+            error_uri: error_uri.clone(),
         },
         _ => ErrorContext::InternalError {
             port,
@@ -443,11 +461,13 @@ fn map_complete_error(source: Error) -> LoopbackError {
     if let Some(CompleteError::OAuthError {
         error,
         error_description,
+        error_uri,
     }) = source.source().and_then(|s| s.downcast_ref())
     {
         return LoopbackError::OAuthError {
             error: error.clone(),
             error_description: error_description.clone(),
+            error_uri: error_uri.clone(),
         };
     }
     LoopbackError::Complete { source }
@@ -776,7 +796,8 @@ mod tests {
 
         send_http_request(
             addr,
-            "GET /callback?error=access_denied&error_description=user+denied&state=xyz HTTP/1.1",
+            "GET /callback?error=access_denied&error_description=user+denied\
+             &error_uri=https%3A%2F%2Fas.example.com%2Fdoc&state=xyz HTTP/1.1",
         )
         .await;
         // Send the failure follow-up so the server can render the error page
@@ -784,8 +805,10 @@ mod tests {
 
         let err = handle.await.unwrap().unwrap_err();
         assert!(
-            matches!(&err, LoopbackError::OAuthError { error, error_description }
-                if error == "access_denied" && error_description.as_deref() == Some("user denied")),
+            matches!(&err, LoopbackError::OAuthError { error, error_description, error_uri }
+                if error == "access_denied"
+                    && error_description.as_deref() == Some("user denied")
+                    && error_uri.as_deref() == Some("https://as.example.com/doc")),
             "got {err:?}"
         );
     }

--- a/huskarl/src/grant/authorization_code/types.rs
+++ b/huskarl/src/grant/authorization_code/types.rs
@@ -244,6 +244,7 @@ pub(super) enum AuthorizationResponse {
     Error {
         error: String,
         error_description: Option<String>,
+        error_uri: Option<String>,
         state: Option<String>,
     },
 }
@@ -331,6 +332,7 @@ impl CompleteInput {
             state: Option<String>,
             error: Option<String>,
             error_description: Option<String>,
+            error_uri: Option<String>,
             iss: Option<String>,
             response: Option<String>,
         }
@@ -353,6 +355,7 @@ impl CompleteInput {
             CallbackPayload::Plain(AuthorizationResponse::Error {
                 error,
                 error_description: params.error_description,
+                error_uri: params.error_uri,
                 state: params.state,
             })
         } else {
@@ -578,16 +581,18 @@ mod tests {
     /// (RFC 6749 §4.1.2.1).
     #[test]
     fn complete_input_parse_error_response_takes_precedence() {
-        let parsed = "code=abc&state=xyz&error=access_denied&error_description=user+denied"
+        let parsed = "code=abc&state=xyz&error=access_denied&error_description=user+denied\
+                      &error_uri=https%3A%2F%2Fas.example.com%2Fdoc"
             .parse::<CompleteInput>()
             .unwrap();
         assert!(
             matches!(
                 &parsed.payload,
                 // `state` is kept so completion can bind the error to the flow.
-                CallbackPayload::Plain(AuthorizationResponse::Error { error, error_description, state })
+                CallbackPayload::Plain(AuthorizationResponse::Error { error, error_description, error_uri, state })
                     if error == "access_denied"
                         && error_description.as_deref() == Some("user denied")
+                        && error_uri.as_deref() == Some("https://as.example.com/doc")
                         && state.as_deref() == Some("xyz")
             ),
             "got {:?}",


### PR DESCRIPTION
BREAKING CHANGE: CompleteError::OAuthError, LoopbackError::OAuthError, and ErrorContext::OAuthError gain an error_uri field and become #[non_exhaustive]; struct-variant matches must now bind fields with a trailing `..`.