### PR TITLE
feat(client): Make auth code redirect_uri public.

### DIFF
--- a/huskarl/src/grant/authorization_code/grant.rs
+++ b/huskarl/src/grant/authorization_code/grant.rs
@@ -93,7 +93,7 @@ pub struct AuthorizationCodeGrant {
 
     // -- User-supplied grant-specific fields --
     /// A redirect URL registered with the authorization server.
-    pub(super) redirect_uri: String,
+    pub redirect_uri: String,
 
     /// Whether PKCE (RFC 7636) is disabled; see the `new` builder.
     pub(super) disable_pkce: bool,


### PR DESCRIPTION
This allows integrations to derive base URLs/etc. from the auth code configuration, rather than requiring it to be re-set elsewhere.