### PR TITLE
feat(core): Add capability for verifier loading to fail without failing startup

### DIFF
--- a/huskarl-core/src/crypto/refreshable.rs
+++ b/huskarl-core/src/crypto/refreshable.rs
@@ -5,7 +5,13 @@
 //! are serialised so that only one factory call runs at a time; waiters that
 //! arrive while a refresh is in flight adopt the result.
 
-use std::{pin::Pin, sync::Arc};
+use std::{
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use arc_swap::ArcSwap;
 
@@ -65,6 +71,22 @@ impl<V: std::fmt::Debug + MaybeSendSync + 'static> Refreshable<V> {
             factory: Box::new(factory),
             refresh_lock: tokio::sync::Mutex::new(()),
         })
+    }
+
+    /// Seeds an explicit initial value without calling the factory (so it cannot
+    /// fail). The seam for a tolerated cold start: a placeholder value now,
+    /// refreshed through `factory` later.
+    pub(crate) fn from_seed(
+        seed: V,
+        factory: impl Fn() -> Pin<Box<dyn MaybeSendFuture<Output = Result<V, Error>>>>
+        + MaybeSendSync
+        + 'static,
+    ) -> Self {
+        Self {
+            value: ArcSwap::from_pointee(seed),
+            factory: Box::new(factory),
+            refresh_lock: tokio::sync::Mutex::new(()),
+        }
     }
 
     /// Refreshes the value by re-invoking the factory and atomically swapping
@@ -172,9 +194,13 @@ pub(crate) enum GatedRefresh {
 
 #[allow(clippy::struct_field_names)]
 struct RefreshTimestamps {
-    last_refreshed: Instant,
+    /// When a value last loaded successfully. `None` = never (cold seed): reads as
+    /// infinitely stale and selects the cold-backoff regime.
+    last_refreshed: Option<Instant>,
     last_failed_refresh: Option<Instant>,
     last_refresh_attempt: Option<Instant>,
+    /// Consecutive failures while cold; escalates the cold backoff, reset on success.
+    consecutive_cold_failures: u32,
 }
 
 /// A [`Refreshable`] combined with TTL, failure-backoff, and rate-limiting policy.
@@ -183,6 +209,13 @@ pub(crate) struct ScheduledRefreshable<V> {
     ttl: Duration,
     failure_backoff: Duration,
     min_refresh_interval: Duration,
+    /// Backoff floor while cold (no value has ever loaded). Escalates per
+    /// consecutive failure, capped at `failure_backoff`.
+    cold_backoff: Duration,
+    /// Lock-free mirror of `timestamps.last_refreshed.is_none()` for the per-verify
+    /// [`is_cold`](Self::is_cold) fast path. Monotonic: cleared once a value loads,
+    /// never re-set.
+    cold: AtomicBool,
     timestamps: std::sync::Mutex<RefreshTimestamps>,
 }
 
@@ -192,6 +225,7 @@ impl<V: std::fmt::Debug> std::fmt::Debug for ScheduledRefreshable<V> {
             .field("inner", &self.inner)
             .field("ttl", &self.ttl)
             .field("failure_backoff", &self.failure_backoff)
+            .field("cold_backoff", &self.cold_backoff)
             .finish_non_exhaustive()
     }
 }
@@ -219,19 +253,57 @@ impl<V: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshable<V> {
         /// Minimum time between any two refresh attempts, regardless of outcome.
         #[builder(default = Duration::from_mins(1))]
         min_refresh_interval: Duration,
+        /// Backoff floor while cold, before any value has loaded. Escalates per
+        /// consecutive failure up to `failure_backoff`.
+        #[builder(default = Duration::from_millis(250))]
+        cold_backoff: Duration,
+        /// Opt-in placeholder used if the initial fetch fails: construction then
+        /// succeeds in a cold state that self-heals, rather than failing. `None`
+        /// (the default) keeps a failed initial fetch fatal.
+        fallback: Option<V>,
     ) -> Result<Self, Error> {
-        let inner = Refreshable::builder().factory(factory).build().await?;
+        let now = Instant::now();
+        let (initial, timestamps) = match (factory().await, fallback) {
+            (Ok(value), _) => (
+                value,
+                RefreshTimestamps {
+                    last_refreshed: Some(now),
+                    last_failed_refresh: None,
+                    last_refresh_attempt: None,
+                    consecutive_cold_failures: 0,
+                },
+            ),
+            // Tolerated cold start: seed the placeholder and stamp the failed
+            // build as the last failure so the first retry waits one `cold_backoff`
+            // (the floor). Escalation begins only once a cold *retry* also fails.
+            (Err(_), Some(seed)) => (
+                seed,
+                RefreshTimestamps {
+                    last_refreshed: None,
+                    last_failed_refresh: Some(now),
+                    last_refresh_attempt: Some(now),
+                    consecutive_cold_failures: 0,
+                },
+            ),
+            (Err(e), None) => return Err(e),
+        };
+        let cold = AtomicBool::new(timestamps.last_refreshed.is_none());
         Ok(Self {
-            inner,
+            inner: Refreshable::from_seed(initial, factory),
             ttl,
             failure_backoff,
             min_refresh_interval,
-            timestamps: std::sync::Mutex::new(RefreshTimestamps {
-                last_refreshed: Instant::now(),
-                last_failed_refresh: None,
-                last_refresh_attempt: None,
-            }),
+            cold_backoff,
+            cold,
+            timestamps: std::sync::Mutex::new(timestamps),
         })
+    }
+
+    /// Whether no value has ever loaded (the initial fetch failed and a placeholder
+    /// was seeded). Drives the caller's cold-vs-warm read path. Lock-free: a stale
+    /// `true` self-corrects, since the caller re-checks after the miss-refresh.
+    pub(crate) fn is_cold(&self) -> bool {
+        self.cold.load(Ordering::Acquire)
     }
 
     /// The abuse-prevention gate — *may* a refresh be attempted right now, quite
@@ -246,6 +318,25 @@ impl<V: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshable<V> {
     /// miss-triggered reload — see [`should_refresh_stale`](Self::should_refresh_stale)
     /// versus [`policy_permits_miss_refresh`](Self::policy_permits_miss_refresh).
     fn policy_permits_attempt(&self, now: Instant, ts: &RefreshTimestamps) -> bool {
+        // Cold: no value has ever loaded, so every request is failing now — recover
+        // far more urgently than the warm `failure_backoff`/`min_refresh_interval`,
+        // which assume a good value is still being served. The first retry waits
+        // one `cold_backoff` (the floor), then doubles per consecutive cold
+        // failure, capped at `failure_backoff`.
+        if ts.last_refreshed.is_none() {
+            let backoff = self
+                .cold_backoff
+                .saturating_mul(1u32 << ts.consecutive_cold_failures.min(16))
+                .min(self.failure_backoff);
+            return match ts
+                .last_failed_refresh
+                .and_then(|t| now.checked_duration_since(t))
+            {
+                Some(elapsed) => elapsed >= backoff,
+                None => true,
+            };
+        }
+
         // Rate limit: hard floor on refresh frequency.
         if ts
             .last_refresh_attempt
@@ -277,10 +368,12 @@ impl<V: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshable<V> {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // Not stale yet — the read path leaves a within-TTL value alone.
-        if now
-            .checked_duration_since(ts.last_refreshed)
-            .is_some_and(|elapsed| elapsed < self.ttl)
+        // Not stale yet — a within-TTL value is left alone. A cold seed
+        // (`last_refreshed == None`) reads as infinitely stale.
+        if let Some(last) = ts.last_refreshed
+            && now
+                .checked_duration_since(last)
+                .is_some_and(|elapsed| elapsed < self.ttl)
         {
             return false;
         }
@@ -312,10 +405,19 @@ impl<V: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshable<V> {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         ts.last_refresh_attempt = Some(now);
         if success {
-            ts.last_refreshed = now;
+            ts.last_refreshed = Some(now);
             ts.last_failed_refresh = None;
+            ts.consecutive_cold_failures = 0;
+            // Warm now; publish to the lock-free `is_cold` mirror. `Release`
+            // pairs with the `Acquire` load, ordering it after the value swap.
+            self.cold.store(false, Ordering::Release);
         } else {
             ts.last_failed_refresh = Some(now);
+            // Escalate only while still cold; a warm failure keeps serving the
+            // last good value and uses the warm backoff.
+            if ts.last_refreshed.is_none() {
+                ts.consecutive_cold_failures = ts.consecutive_cold_failures.saturating_add(1);
+            }
         }
     }
 
@@ -378,8 +480,9 @@ impl<V: std::fmt::Debug + MaybeSendSync + 'static> ScheduledRefreshable<V> {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 
             if ttl_gated
+                && let Some(last) = ts.last_refreshed
                 && now
-                    .checked_duration_since(ts.last_refreshed)
+                    .checked_duration_since(last)
                     .is_some_and(|elapsed| elapsed < self.ttl)
             {
                 return false;
@@ -729,6 +832,100 @@ mod tests {
             calls.load(Ordering::SeqCst),
             2,
             "a stale value is reloaded on the read path"
+        );
+    }
+
+    /// A factory whose first call (the initial build) fails and every later call
+    /// succeeds — an upstream that is down at startup and then recovers.
+    fn ok_after_first_failure(
+        calls: Arc<AtomicUsize>,
+    ) -> impl Fn() -> Pin<Box<dyn MaybeSendFuture<Output = Result<usize, Error>>>>
+    + MaybeSendSync
+    + 'static {
+        move || {
+            let calls = Arc::clone(&calls);
+            Box::pin(async move {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Err(Error::new(
+                        crate::error::ErrorKind::Transport { retryable: true },
+                        "upstream down at boot",
+                    ))
+                } else {
+                    Ok(n)
+                }
+            })
+        }
+    }
+
+    /// A failed initial fetch with a `fallback` is tolerated: construction succeeds
+    /// cold, serves the placeholder, and a later refresh clears the cold state.
+    #[tokio::test]
+    async fn cold_start_seeds_then_recovers() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let sr = ScheduledRefreshable::builder()
+            .factory(ok_after_first_failure(calls))
+            .cold_backoff(Duration::ZERO) // no wait between cold retries in the test
+            .fallback(999_usize)
+            .build()
+            .await
+            .expect("cold start is tolerated, not fatal");
+        assert!(sr.is_cold(), "no value has loaded yet");
+        assert_eq!(*sr.load_full(), 999, "serving the seeded placeholder");
+
+        assert!(
+            sr.try_refresh_on_miss().await,
+            "the recovered upstream loads"
+        );
+        assert!(!sr.is_cold(), "warm once a value has loaded");
+        assert_eq!(*sr.load_full(), 1, "serving the fetched value");
+    }
+
+    /// A nonzero `cold_backoff` gates the very first cold retry: immediately
+    /// after a tolerated cold build (which stamps the failure but leaves the
+    /// escalation count at zero), the miss path is held off for one `cold_backoff`
+    /// rather than hammering a just-failed upstream, so the source stays cold and
+    /// the factory is not re-invoked.
+    #[tokio::test]
+    async fn cold_backoff_gates_the_first_retry() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let sr = ScheduledRefreshable::builder()
+            .factory(ok_after_first_failure(Arc::clone(&calls)))
+            .cold_backoff(Duration::from_secs(10)) // long enough to block an immediate retry
+            .fallback(999_usize)
+            .build()
+            .await
+            .expect("cold start is tolerated");
+        assert!(sr.is_cold());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "only the failed build has run"
+        );
+
+        assert!(
+            !sr.try_refresh_on_miss().await,
+            "the cold_backoff floor has not elapsed, so the retry is held off"
+        );
+        assert!(sr.is_cold(), "still cold; no second fetch was attempted");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the factory was not re-invoked"
+        );
+    }
+
+    /// Without a `fallback`, a failed initial fetch stays fatal (fail-fast).
+    #[tokio::test]
+    async fn no_fallback_keeps_initial_failure_fatal() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = ScheduledRefreshable::builder()
+            .factory(ok_after_first_failure(calls))
+            .build()
+            .await;
+        assert!(
+            result.is_err(),
+            "no fallback => a failed initial fetch is fatal"
         );
     }
 }

--- a/huskarl-core/src/crypto/verifier/error.rs
+++ b/huskarl-core/src/crypto/verifier/error.rs
@@ -16,6 +16,12 @@ pub enum VerifyError {
     /// No key matched the requested algorithm/kid pair.
     #[snafu(display("no matching key"))]
     NoMatchingKey,
+    /// No keyset has ever loaded — the initial JWKS fetch failed and the source
+    /// came up in a seeded-empty (cold) state that has not yet self-healed. Kept
+    /// distinct from [`NoMatchingKey`](Self::NoMatchingKey) so a still-unreachable
+    /// upstream reads as infrastructure, not a bad/unknown-`kid` token.
+    #[snafu(display("no keys available: JWKS has not loaded since startup"))]
+    KeysUnavailable,
     /// Multiple keys matched but the token has no `kid` to disambiguate.
     #[snafu(display("ambiguous key: multiple keys match but token has no kid"))]
     AmbiguousKeyMatch,
@@ -38,6 +44,8 @@ impl VerifyError {
             VerifyError::NoMatchingKey
             | VerifyError::AmbiguousKeyMatch
             | VerifyError::SignatureMismatch => false,
+            // A cold source may become ready once the upstream is reachable again.
+            VerifyError::KeysUnavailable => true,
             VerifyError::Other { source } => source.is_retryable(),
         }
     }

--- a/huskarl-core/src/crypto/verifier/metrics_verifier.rs
+++ b/huskarl-core/src/crypto/verifier/metrics_verifier.rs
@@ -131,6 +131,7 @@ impl<V: JwsVerifier> JwsVerifier for MetricsJwsVerifier<V> {
             let outcome = match &result {
                 Ok(()) => "success",
                 Err(VerifyError::NoMatchingKey) => "no_matching_key",
+                Err(VerifyError::KeysUnavailable) => "keys_unavailable",
                 Err(VerifyError::AmbiguousKeyMatch) => "ambiguous_key",
                 Err(VerifyError::SignatureMismatch) => "signature_mismatch",
                 Err(VerifyError::Other { .. }) => "error",

--- a/huskarl-core/src/crypto/verifier/scheduled.rs
+++ b/huskarl-core/src/crypto/verifier/scheduled.rs
@@ -28,6 +28,52 @@ use crate::{
 /// [`JwksSource`](crate::jwk::JwksSource) rather than composing by hand; its `ttl`
 /// is this layer's TTL. See [composing crypto
 /// strategies](crate::_docs::explanation::crypto_strategies) for the full stack.
+///
+/// # Warm start from a persisted cache
+///
+/// The factory's `Ok` value is served immediately as the current keyset, so a
+/// factory that falls back to a *trusted local cache* comes up **warm** — able to
+/// verify at once — even when the authorization server is unreachable at boot,
+/// then picks up live keys on the next TTL refresh. This is distinct from
+/// [`JwksStartup::SeedEmpty`](crate::jwk::JwksStartup::SeedEmpty), which comes up
+/// *cold* and returns [`KeysUnavailable`](VerifyError::KeysUnavailable) until a
+/// live fetch lands. Persist each successful fetch so the cache tracks key
+/// rotations rather than a stale bake-in; if there is no live fetch *and* no
+/// cache (a first-ever offline boot), the build still fails — you genuinely have
+/// no keys.
+///
+/// ```rust,no_run
+/// # use std::pin::Pin;
+/// # use huskarl_core::{
+/// #     crypto::verifier::{MultiKeyVerifier, ScheduledRefreshVerifier},
+/// #     error::Error,
+/// #     platform::MaybeSendFuture,
+/// # };
+/// # async fn fetch_live_keys() -> Result<MultiKeyVerifier, Error> { unimplemented!() }
+/// # fn save_cached_keys(_keys: &MultiKeyVerifier) {}
+/// # fn load_cached_keys() -> Result<MultiKeyVerifier, Error> { unimplemented!() }
+/// # async fn example() -> Result<(), Error> {
+/// let verifier = ScheduledRefreshVerifier::builder()
+///     .factory(|| {
+///         Box::pin(async {
+///             match fetch_live_keys().await {
+///                 // Persist every good fetch so a later cold boot loads the
+///                 // freshest keyset the process ever saw, not a stale bake-in.
+///                 Ok(keys) => {
+///                     save_cached_keys(&keys);
+///                     Ok(keys)
+///                 }
+///                 // Offline: serve the last good keyset so the build is warm.
+///                 Err(_) => load_cached_keys(),
+///             }
+///         }) as Pin<Box<dyn MaybeSendFuture<Output = Result<MultiKeyVerifier, Error>>>>
+///     })
+///     .build()
+///     .await?;
+/// # let _ = verifier;
+/// # Ok(())
+/// # }
+/// ```
 pub struct ScheduledRefreshVerifier<V> {
     inner: ScheduledRefreshable<V>,
 }
@@ -64,14 +110,31 @@ impl<V: JwsVerifier + 'static> ScheduledRefreshVerifier<V> {
         /// Acts as a hard ceiling on refresh frequency for abuse prevention.
         #[builder(default = Duration::from_mins(1))]
         min_refresh_interval: Duration,
+        /// Backoff floor while cold (no keyset has loaded), escalating up to
+        /// `failure_backoff`.
+        #[builder(default = Duration::from_millis(250))]
+        cold_backoff: Duration,
+        /// Opt-in placeholder verifier used if the initial fetch fails, so the
+        /// stack comes up cold and self-heals instead of failing construction.
+        /// `None` (the default) keeps a failed initial fetch fatal.
+        fallback: Option<V>,
     ) -> Result<Self, Error> {
         let inner = ScheduledRefreshable::builder()
             .factory(factory)
             .ttl(ttl)
             .failure_backoff(failure_backoff)
             .min_refresh_interval(min_refresh_interval)
+            .cold_backoff(cold_backoff)
+            .maybe_fallback(fallback)
             .build()
             .await?;
+        // Coming up cold (initial fetch failed, placeholder seeded) is no longer a
+        // construction error, so surface it here — the only startup-time signal
+        // that the stack is degraded until it self-heals.
+        #[cfg(feature = "metrics")]
+        if inner.is_cold() {
+            ::metrics::counter!("huskarl.jws.cold_start").increment(1);
+        }
         Ok(Self { inner })
     }
 }
@@ -88,11 +151,23 @@ impl<V: JwsVerifier + 'static> JwsVerifier for ScheduledRefreshVerifier<V> {
         key_match: &'a KeyMatch<'a>,
     ) -> MaybeSendBoxFuture<'a, Result<(), VerifyError>> {
         Box::pin(async move {
-            // Bound staleness on the read path: if the keyset has outlived its
-            // TTL, the first verify to notice reloads it (single-flight,
-            // non-blocking for others) before verifying. This is what drops a
-            // retired key even when no token ever fails to verify.
-            self.inner.poll_refresh_ahead().await;
+            // Cold: no keyset has ever loaded (the initial fetch failed and an
+            // empty placeholder was seeded). Block on a single-flight reload so a
+            // burst of first requests adopts one shared fetch rather than each
+            // eating its own, then distinguish "keys never loaded" (infra) from an
+            // unknown-`kid` miss (bad token).
+            if self.inner.is_cold() {
+                self.inner.try_refresh_on_miss().await;
+                if self.inner.is_cold() {
+                    return Err(VerifyError::KeysUnavailable);
+                }
+            } else {
+                // Bound staleness on the read path: if the keyset has outlived its
+                // TTL, the first verify to notice reloads it (single-flight,
+                // non-blocking for others) before verifying. This is what drops a
+                // retired key even when no token ever fails to verify.
+                self.inner.poll_refresh_ahead().await;
+            }
             self.inner
                 .load_full()
                 .verify(input, signature, key_match)
@@ -319,5 +394,73 @@ mod tests {
             2,
             "initial build + one miss-driven reload"
         );
+    }
+
+    /// An always-failing factory: the upstream is down at boot and stays down.
+    #[allow(clippy::type_complexity)]
+    fn always_down()
+    -> impl Fn() -> Pin<Box<dyn MaybeSendFuture<Output = Result<MissVerifier, Error>>>>
+    + MaybeSendSync
+    + 'static {
+        || {
+            Box::pin(async {
+                Err(Error::new(
+                    crate::error::ErrorKind::Transport { retryable: true },
+                    "down",
+                ))
+            })
+        }
+    }
+
+    /// A seeded-empty cold start reports [`VerifyError::KeysUnavailable`] — not a
+    /// bare miss — while the upstream stays unreachable, so the failure reads as
+    /// infrastructure rather than a bad token.
+    #[tokio::test]
+    async fn cold_verify_reports_keys_unavailable_while_upstream_down() {
+        let verifier = ScheduledRefreshVerifier::builder()
+            .factory(always_down())
+            .cold_backoff(Duration::ZERO) // retry immediately in the test
+            .fallback(MissVerifier { present: false })
+            .build()
+            .await
+            .expect("cold start is tolerated, not fatal");
+
+        let err = verifier
+            .verify(b"input", b"sig", &km())
+            .await
+            .expect_err("no keys have ever loaded");
+        assert!(matches!(err, VerifyError::KeysUnavailable));
+    }
+
+    /// The first verify recovers once the upstream returns: the cold miss-refresh
+    /// loads the real keyset and the token verifies — no `KeysUnavailable`.
+    #[tokio::test]
+    async fn cold_verify_recovers_when_upstream_returns() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let factory = move || {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                if n == 0 {
+                    Err(Error::new(
+                        crate::error::ErrorKind::Transport { retryable: true },
+                        "down at boot",
+                    ))
+                } else {
+                    Ok(MissVerifier { present: true })
+                }
+            }) as Pin<Box<dyn MaybeSendFuture<Output = Result<MissVerifier, Error>>>>
+        };
+        let verifier = ScheduledRefreshVerifier::builder()
+            .factory(factory)
+            .cold_backoff(Duration::ZERO)
+            .fallback(MissVerifier { present: false })
+            .build()
+            .await
+            .expect("cold start is tolerated");
+
+        verifier
+            .verify(b"input", b"sig", &km())
+            .await
+            .expect("the cold miss-refresh loads the recovered keyset and verifies");
     }
 }

--- a/huskarl-core/src/jwk/mod.rs
+++ b/huskarl-core/src/jwk/mod.rs
@@ -17,7 +17,7 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
-pub use source::JwksSource;
+pub use source::{JwksSource, JwksStartup};
 use zeroize::Zeroize;
 
 use crate::{

--- a/huskarl-core/src/jwk/source.rs
+++ b/huskarl-core/src/jwk/source.rs
@@ -36,6 +36,34 @@ pub struct JwksSource {
     max_keys: usize,
     /// How long a fetched keyset is served before it is reloaded on the read path.
     ttl: Duration,
+    /// How a failed initial JWKS fetch at build time is handled.
+    startup: JwksStartup,
+}
+
+/// How [`JwksSource`] handles a failed initial JWKS fetch at build time.
+///
+/// The fetch is always attempted eagerly; this only governs whether *failure*
+/// is fatal. Neither variant accepts an unvalidated token — a cold source
+/// returns [`KeysUnavailable`](crate::crypto::verifier::VerifyError::KeysUnavailable).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum JwksStartup {
+    /// Fail construction if the initial fetch fails — surfaces a wrong `jwks_uri`
+    /// or an unreachable authorization server at boot rather than as a running
+    /// cold state. The default: a config error is louder at deploy than a
+    /// silently-degraded service.
+    #[default]
+    FailFast,
+    /// Come up with an empty keyset and self-heal via cold-backoff retries. The
+    /// happy-path fetch still populates keys before construction returns. Opt in
+    /// when boot must not be gated on the authorization server being reachable.
+    ///
+    /// Note this comes up *cold*: until a live fetch lands it verifies nothing and
+    /// returns [`KeysUnavailable`](crate::crypto::verifier::VerifyError::KeysUnavailable).
+    /// To instead come up **warm** from a trusted local cache — verifying
+    /// immediately while offline — build the verifier with a factory that falls
+    /// back to that cache; see
+    /// [`ScheduledRefreshVerifier`](crate::crypto::verifier::ScheduledRefreshVerifier).
+    SeedEmpty,
 }
 
 #[bon]
@@ -53,11 +81,16 @@ impl JwksSource {
         /// hour.
         #[builder(default = Duration::from_hours(1))]
         ttl: Duration,
+        /// How a failed initial fetch is handled. Defaults to
+        /// [`FailFast`](JwksStartup::FailFast): a failed boot-time fetch is fatal.
+        #[builder(default)]
+        startup: JwksStartup,
     ) -> Self {
         Self {
             http_client: Arc::new(http_client),
             max_keys,
             ttl,
+            startup,
         }
     }
 }
@@ -77,6 +110,12 @@ impl JwsVerifierFactory for JwksSource {
         let client = self.http_client.clone();
         let max_keys = self.max_keys;
         let ttl = self.ttl;
+        // SeedEmpty tolerates a failed initial fetch by seeding an empty keyset
+        // (which misses on everything) and self-healing via cold-backoff retries.
+        let fallback = match self.startup {
+            JwksStartup::SeedEmpty => Some(MultiKeyVerifier::new(Vec::new())),
+            JwksStartup::FailFast => None,
+        };
         let Some(uri) = jwks_uri.cloned() else {
             return Box::pin(async {
                 Err(Error::new(
@@ -89,6 +128,7 @@ impl JwsVerifierFactory for JwksSource {
         Box::pin(async move {
             let refreshing = ScheduledRefreshVerifier::builder()
                 .ttl(ttl)
+                .maybe_fallback(fallback)
                 .factory(move || {
                     let client = client.clone();
                     let uri = uri.clone();
@@ -126,7 +166,7 @@ mod tests {
     use bytes::Bytes;
     use http::{HeaderMap, Request, StatusCode};
 
-    use super::JwksSource;
+    use super::{JwksSource, JwksStartup};
     use crate::{
         EndpointUrl,
         crypto::verifier::{
@@ -195,6 +235,9 @@ mod tests {
                 body: jwks_with_keys(n_keys),
             })
             .max_keys(max_keys)
+            // Assert the fetch outcome directly: SeedEmpty would tolerate a
+            // rejected fetch and come up cold instead of surfacing the error.
+            .startup(JwksStartup::FailFast)
             .build();
         let uri = EndpointUrl::try_from("https://as.example.com/jwks").unwrap();
         source


### PR DESCRIPTION
In some configurations users may want their system to start in a degraded state if they can't access the JWKS endpoint, rather than failing to start altogether.

This has the system try to request JWKS on a more aggressive schedule than JWKS fetch failures when there are already keys.

Defaults to failing fast.