### PR TITLE
feat(client)!: Default jws_verifier_factory to a JwksSource

### DIFF
--- a/huskarl-core/src/crypto/verifier/scheduled.rs
+++ b/huskarl-core/src/crypto/verifier/scheduled.rs
@@ -66,7 +66,8 @@ use crate::{
 ///                 // Offline: serve the last good keyset so the build is warm.
 ///                 Err(_) => load_cached_keys(),
 ///             }
-///         }) as Pin<Box<dyn MaybeSendFuture<Output = Result<MultiKeyVerifier, Error>>>>
+///         })
+///             as Pin<Box<dyn MaybeSendFuture<Output = Result<MultiKeyVerifier, Error>>>>
 ///     })
 ///     .build()
 ///     .await?;

--- a/huskarl-core/src/prelude.rs
+++ b/huskarl-core/src/prelude.rs
@@ -11,13 +11,15 @@
 //! `huskarl::prelude`), so importing the outermost prelude is enough.
 
 pub use crate::{
-    crypto::cipher::{AeadDecryptor as _, AeadEncryptor as _, AeadEncryptorSelector as _},
-    crypto::seal::{AeadSealer as _, AeadUnsealer as _},
-    crypto::signer::{
-        AsymmetricJwsSigner as _, AsymmetricJwsSignerSelector as _, JwsSigner as _,
-        JwsSignerSelector as _,
+    crypto::{
+        cipher::{AeadDecryptor as _, AeadEncryptor as _, AeadEncryptorSelector as _},
+        seal::{AeadSealer as _, AeadUnsealer as _},
+        signer::{
+            AsymmetricJwsSigner as _, AsymmetricJwsSignerSelector as _, JwsSigner as _,
+            JwsSignerSelector as _,
+        },
+        verifier::{JwsVerifier as _, JwsVerifierFactory as _, JwsVerifierPlatform as _},
     },
-    crypto::verifier::{JwsVerifier as _, JwsVerifierFactory as _, JwsVerifierPlatform as _},
     dpop::{AuthorizationServerDPoP as _, ResourceServerDPoP as _},
     secrets::Secret as _,
 };

--- a/huskarl/docs/guide/authorization_code.md
+++ b/huskarl/docs/guide/authorization_code.md
@@ -133,16 +133,29 @@ dropped.
 
 Requesting the `openid` scope makes the flow an OIDC authentication: the
 grant sends a `nonce`, requires ID-token validation to be configured (a
-`jws_verifier_factory` and an issuer) before `start()` will proceed, and
+`jwks_uri` — or a custom `jws_verifier_factory` — and an issuer) before
+`start()` will proceed, and
 rejects a token response without an ID token (OIDC Core 1.0 §3.1.3.3) —
 unless the server narrowed `openid` out of the granted scope. `complete()`
 returns the validated ID token on `CompleteOutput::id_token` alongside the
 token response whenever the flow is OIDC.
 
+Validation is zero-config: given a `jwks_uri` — which `builder_from_metadata`
+fills in from the server's metadata — the grant builds a default `JwksSource`
+that fetches the signing keys over its `http_client`. The fetch is eager, so
+`build()` performs network I/O and live requests stay warm; for an `oidc(true)`
+or JARM grant an unreachable JWKS fails the build, while an inferred flow
+tolerates a cold start and self-heals. Set `jws_verifier_factory` only to
+customize this: a different refresh TTL, or a key source other than a JWKS
+endpoint (a KMS, or a static set). With no `jwks_uri` and no factory the grant
+has no verifier — fine for a plain-OAuth flow, and caught at build or start
+when the flow actually requires one.
+
 The `oidc` builder setting overrides this inference for non-standard
 servers. `oidc(false)` treats `openid` as an ordinary OAuth scope — for
-pure-OAuth servers whose scope merely happens to use that name. An ID
-token the server returns anyway is still validated. `oidc(true)` applies
+pure-OAuth servers whose scope merely happens to use that name. It builds no
+default verifier and fetches no JWKS; supply `jws_verifier_factory` to still
+validate an ID token the server returns anyway. `oidc(true)` applies
 OIDC semantics regardless of scope — for servers that issue ID tokens on
 their own rules — and a missing ID token is then an error even if the
 granted scope omits `openid`. Since `oidc(true)` declares every flow OIDC,
@@ -155,10 +168,8 @@ a signed JWT ([JARM](https://openid.net/specs/oauth-v2-jarm.html)), so the
 callback parameters cannot be tampered with in transit:
 
 ```rust
-use std::sync::Arc;
-
 use huskarl::{
-    core::{client_auth::NoAuth, jwk::JwksSource, server_metadata::AuthorizationServerMetadata},
+    core::{client_auth::NoAuth, server_metadata::AuthorizationServerMetadata},
     grant::authorization_code::{AuthorizationCodeGrant, ResponseMode},
 };
 # async fn setup_jarm_grant(
@@ -169,11 +180,12 @@ use huskarl::{
 let grant: AuthorizationCodeGrant = AuthorizationCodeGrant::builder_from_metadata(metadata)
     .expect("server does not support authorization code grant")
     .client_id("client_id")
-    .http_client(client.clone())
+    .http_client(client)
     .client_auth(NoAuth)
     .redirect_uri("https://my-app/callback")
+    // JARM requires signature verification; `builder_from_metadata` supplies the
+    // `jwks_uri`, so the default `JwksSource` verifier is used automatically.
     .response_mode(ResponseMode::QueryJwt)
-    .jws_verifier_factory(Arc::new(JwksSource::builder().http_client(client).build()))
     .build()
     .await?;
 # Ok(())
@@ -188,8 +200,8 @@ surfaces.
 
 Because the client now requires every callback to be a JWT, a JWT-secured
 `response_mode` requires ID-token-style validation to be configured — a
-`jws_verifier_factory` and an issuer — and the grant fails to build without
-them.
+`jwks_uri` (or a custom `jws_verifier_factory`) and an issuer — and the grant
+fails to build without them.
 
 Completion enforces the mode in both directions. A plain callback for a flow
 that requested JARM is rejected (`MissingJarmResponse`), since honoring it

--- a/huskarl/examples/authorization_code.rs
+++ b/huskarl/examples/authorization_code.rs
@@ -48,11 +48,9 @@ pub async fn main() -> Result<(), snafu::Whatever> {
         .client_auth(NoAuth)
         .redirect_uri("http://localhost:8080/login/callback")
         .dpop(DPoP::builder().signer(dpop_key).build())
-        .jws_verifier_factory(Arc::new(
-            JwksSource::builder()
-                .http_client(http_client.clone())
-                .build(),
-        ))
+        // ID-token verification is zero-config: the metadata's `jwks_uri` is
+        // used to build a default `JwksSource` over `http_client`. Set
+        // `jws_verifier_factory` only to customize (e.g. a KMS-backed verifier).
         .build()
         .await
         .whatever_context("Failed to build grant")?;

--- a/huskarl/src/grant/authorization_code/error.rs
+++ b/huskarl/src/grant/authorization_code/error.rs
@@ -49,7 +49,8 @@ pub enum CompleteError {
     /// The token response included an ID token but the grant cannot validate it.
     #[snafu(display(
         "ID token received but the grant cannot validate it; \
-         supply `jws_verifier_factory` on the builder"
+         configure a `jwks_uri` (via server metadata or the builder) or supply a \
+         `jws_verifier_factory`"
     ))]
     IdTokenVerifierNotConfigured,
     /// The token response included an ID token but no issuer was configured on the grant.
@@ -89,7 +90,8 @@ pub enum CompleteError {
     /// A JARM response was received but the grant cannot validate it.
     #[snafu(display(
         "JARM response received but the grant cannot validate it; \
-         supply `jws_verifier_factory` on the builder"
+         configure a `jwks_uri` (via server metadata or the builder) or supply a \
+         `jws_verifier_factory`"
     ))]
     JarmVerifierNotConfigured,
     /// A JARM response was received but no issuer is configured on the grant.
@@ -107,9 +109,10 @@ pub enum CompleteError {
 pub enum StartError {
     /// An OIDC flow was started but the grant cannot validate ID tokens.
     #[snafu(display(
-        "OIDC flow started (scope contains `openid`) but no `jws_verifier_factory` was \
-         supplied, so the required ID token (OIDC Core 1.0 §3.1.3.3) could never be \
-         validated; supply one on the builder, or set `oidc(false)` if `openid` is an \
+        "OIDC flow started (scope contains `openid`) but no `jwks_uri` is configured, \
+         so the required ID token (OIDC Core 1.0 §3.1.3.3) could never be \
+         validated; configure a `jwks_uri` (via server metadata or the builder) or \
+         supply a `jws_verifier_factory`, or set `oidc(false)` if `openid` is an \
          ordinary scope on this server"
     ))]
     OidcVerifierNotConfigured,
@@ -172,8 +175,9 @@ pub enum BuildError {
     RequiredParEndpointMissing,
     /// `oidc(true)` was set but the grant cannot validate ID tokens.
     #[snafu(display(
-        "oidc(true) was set but no `jws_verifier_factory` was supplied, \
-         so ID tokens could never be validated"
+        "oidc(true) was set but no `jwks_uri` is configured (via server \
+         metadata or the builder) and no `jws_verifier_factory` was supplied, so \
+         the verifier has no key source and ID tokens could never be validated"
     ))]
     OidcRequiresVerifier,
     /// `oidc(true)` was set but no issuer is configured.
@@ -184,8 +188,9 @@ pub enum BuildError {
     OidcRequiresIssuer,
     /// A JWT-secured response mode was set but the grant cannot validate JARM responses.
     #[snafu(display(
-        "a JWT-secured response_mode was set but no `jws_verifier_factory` was \
-         supplied, so the JARM responses could never be validated"
+        "a JWT-secured response_mode was set but no `jwks_uri` is configured \
+         (via server metadata or the builder) and no `jws_verifier_factory` was \
+         supplied, so JARM responses could never be validated"
     ))]
     JarmRequiresVerifier,
     /// A JWT-secured response mode was set but no issuer is configured.

--- a/huskarl/src/grant/authorization_code/flow.rs
+++ b/huskarl/src/grant/authorization_code/flow.rs
@@ -1063,7 +1063,7 @@ mod tests {
             .redirect_uri("http://127.0.0.1/cb")
             .oidc(true)
             .issuer("https://as.example.com")
-            .jws_verifier_factory(std::sync::Arc::new(StubVerifierFactory))
+            .jws_verifier_factory(StubVerifierFactory)
             .build()
             .await
             .unwrap();
@@ -1077,9 +1077,11 @@ mod tests {
     }
 
     /// `oidc(true)` declares every flow OIDC, so a grant that could never
-    /// validate an ID token fails at build time, not at start.
+    /// validate an ID token fails at build time, not at start. With no
+    /// `jwks_uri` the default `JwksSource` has no key source, and no custom
+    /// factory was supplied — so there is no verifier to configure.
     #[tokio::test]
-    async fn oidc_true_without_verifier_fails_the_build() {
+    async fn oidc_true_without_key_source_fails_the_build() {
         let result = AuthorizationCodeGrant::builder()
             .client_id("client")
             .http_client(NoHttp)
@@ -1093,7 +1095,7 @@ mod tests {
 
         let err = result
             .err()
-            .expect("oidc(true) without a verifier must not build");
+            .expect("oidc(true) with no key source (no jwks_uri, no factory) must not build");
         assert_eq!(err.kind(), crate::core::ErrorKind::Config, "got {err:?}");
         assert!(
             format!("{err:?}").contains("OidcRequiresVerifier"),
@@ -1112,7 +1114,7 @@ mod tests {
             .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
             .redirect_uri("http://127.0.0.1/cb")
             .oidc(true)
-            .jws_verifier_factory(std::sync::Arc::new(StubVerifierFactory))
+            .jws_verifier_factory(StubVerifierFactory)
             .build()
             .await;
 
@@ -1124,6 +1126,142 @@ mod tests {
             format!("{err:?}").contains("OidcRequiresIssuer"),
             "got {err:?}"
         );
+    }
+
+    /// A caller-supplied factory is honored even with no `jwks_uri`: a custom
+    /// factory may carry its own keys (a KMS/enclave signer, or a static JWKS)
+    /// and need no URI. The default `JwksSource` needs one, but an explicitly
+    /// supplied factory must never be silently dropped.
+    #[tokio::test]
+    async fn supplied_factory_builds_verifier_without_jwks_uri() {
+        let grant = AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(NoHttp)
+            .client_auth(NoAuth)
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .redirect_uri("http://127.0.0.1/cb")
+            .jws_verifier_factory(StubVerifierFactory)
+            .build()
+            .await
+            .expect("a supplied factory must build even without a jwks_uri");
+
+        assert!(
+            grant.jws_verifier.is_some(),
+            "the supplied factory must have produced a verifier"
+        );
+    }
+
+    /// With no factory and no `jwks_uri`, a plain-OAuth grant builds with no
+    /// verifier: verification is simply off, not a build error. The default
+    /// factory is a `JwksSource`, which has no key source without a URI.
+    #[tokio::test]
+    async fn default_factory_without_jwks_uri_builds_without_verifier() {
+        let grant = AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(NoHttp)
+            .client_auth(NoAuth)
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .redirect_uri("http://127.0.0.1/cb")
+            .build()
+            .await
+            .expect("a plain-OAuth grant must build without a verifier");
+
+        assert!(
+            grant.jws_verifier.is_none(),
+            "no factory and no jwks_uri means no verifier"
+        );
+    }
+
+    /// `oidc(false)` without JARM declares the flow non-OIDC, so no default
+    /// verifier is built even when a `jwks_uri` is present — and, crucially, no
+    /// JWKS fetch is attempted (the `NoHttp` client would fail one). A returned
+    /// ID token is then rejected at completion unless a factory is supplied.
+    #[tokio::test]
+    async fn oidc_false_builds_no_verifier_and_skips_the_fetch() {
+        let grant = AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(NoHttp)
+            .client_auth(NoAuth)
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .jwks_uri("https://as.example.com/jwks".parse().unwrap())
+            .redirect_uri("http://127.0.0.1/cb")
+            .oidc(false)
+            .build()
+            .await
+            .expect("oidc(false) must build without touching the JWKS endpoint");
+
+        assert!(
+            grant.jws_verifier.is_none(),
+            "oidc(false) without JARM must build no default verifier"
+        );
+    }
+
+    /// The default `JwksSource` is actually built, and its startup policy is
+    /// applied: `oidc(true)`/JARM fail the build on an unreachable JWKS
+    /// (`FailFast`), while an inferred flow (`oidc` unset) comes up cold and
+    /// self-heals (`SeedEmpty`). A `200` with a valid JWKS builds a working
+    /// verifier — proving the keys are fetched and parsed end-to-end (a
+    /// malformed key would fail the build even on `200`).
+    #[rstest]
+    #[case::oidc_true_failfast_fatal(Some(true), None, 500, false)]
+    #[case::oidc_true_valid_jwks_builds(Some(true), None, 200, true)]
+    #[case::inferred_seed_empty_tolerates(None, None, 500, true)]
+    #[case::jarm_failfast_fatal(None, Some(ResponseMode::QueryJwt), 500, false)]
+    #[tokio::test]
+    async fn default_verifier_startup_policy(
+        #[case] oidc: Option<bool>,
+        #[case] response_mode: Option<ResponseMode>,
+        #[case] status: u16,
+        #[case] expect_verifier: bool,
+    ) {
+        use httpmock::prelude::*;
+        use huskarl_reqwest::ReqwestClient;
+
+        // A valid P-256 public JWK (RFC 7517 §A.1): a `200` must build a real
+        // verifier, so a skipped fetch or a malformed key would be caught.
+        const JWKS: &str = r#"{"keys":[{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"}]}"#;
+
+        let server = MockServer::start_async().await;
+        let body = if status == 200 { JWKS } else { "{}" };
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/jwks");
+                then.status(status)
+                    .header("content-type", "application/json")
+                    .body(body);
+            })
+            .await;
+
+        let http: ReqwestClient = reqwest::Client::new().into();
+        let result = AuthorizationCodeGrant::builder()
+            .client_id("client")
+            .http_client(http)
+            .client_auth(NoAuth)
+            .token_endpoint("https://as.example.com/token".parse().unwrap())
+            .authorization_endpoint("https://as.example.com/authorize".parse().unwrap())
+            .jwks_uri(server.url("/jwks").parse().unwrap())
+            .issuer("https://as.example.com")
+            .maybe_oidc(oidc)
+            .maybe_response_mode(response_mode)
+            .redirect_uri("http://127.0.0.1/cb")
+            .build()
+            .await;
+
+        if expect_verifier {
+            let grant = result.expect("build should succeed and yield a verifier");
+            assert!(
+                grant.jws_verifier.is_some(),
+                "a default JwksSource verifier must be present",
+            );
+        } else {
+            assert!(
+                result.is_err(),
+                "FailFast must fail the build when the JWKS fetch fails",
+            );
+        }
     }
 
     /// An OIDC flow that could never validate its required ID token (OIDC
@@ -1419,7 +1557,7 @@ mod tests {
             .redirect_uri("http://127.0.0.1/cb")
             .maybe_oidc(oidc)
             .issuer("https://as.example.com")
-            .jws_verifier_factory(std::sync::Arc::new(StubVerifierFactory))
+            .jws_verifier_factory(StubVerifierFactory)
             .build()
             .await
             .unwrap()
@@ -1799,7 +1937,7 @@ mod tests {
             .response_mode(ResponseMode::QueryJwt);
         let result = if with_verifier {
             builder
-                .jws_verifier_factory(std::sync::Arc::new(StubVerifierFactory))
+                .jws_verifier_factory(StubVerifierFactory)
                 .build()
                 .await
         } else {
@@ -1866,7 +2004,7 @@ mod tests {
             .redirect_uri("http://127.0.0.1/cb")
             .response_mode(mode)
             .issuer("https://as.example.com")
-            .jws_verifier_factory(std::sync::Arc::new(StubVerifierFactory))
+            .jws_verifier_factory(StubVerifierFactory)
             .build()
             .await
             .unwrap();

--- a/huskarl/src/grant/authorization_code/grant.rs
+++ b/huskarl/src/grant/authorization_code/grant.rs
@@ -13,6 +13,7 @@ use crate::{
         },
         dpop::{AuthorizationServerDPoP, NoDPoP},
         http::HttpClient,
+        jwk::{JwksSource, JwksStartup},
     },
     grant::{
         authorization_code::{
@@ -155,6 +156,60 @@ impl AuthorizationCodeGrant {
             ..self.clone()
         })
     }
+}
+
+/// Resolves the grant's JWS verifier: a supplied factory as-is, otherwise a
+/// default [`JwksSource`] built only when a verifier could be needed and a
+/// `jwks_uri` is present.
+async fn resolve_jws_verifier(
+    factory: Option<Arc<dyn JwsVerifierFactory>>,
+    platform: Option<Arc<dyn JwsVerifierPlatform>>,
+    http_client: &Arc<dyn HttpClient>,
+    jwks_uri: Option<&EndpointUrl>,
+    oidc: Option<bool>,
+    response_mode: Option<ResponseMode>,
+) -> Result<Option<Arc<dyn JwsVerifier>>, Error> {
+    let require_platform = |platform: Option<Arc<dyn JwsVerifierPlatform>>| {
+        platform.ok_or_else(|| {
+            Error::new(
+                ErrorKind::Config,
+                super::error::MissingJwsVerifierPlatformSnafu.build(),
+            )
+        })
+    };
+
+    // A supplied factory is honored as-is, `jwks_uri` or not (it may carry its
+    // own keys — a KMS/enclave signer, or a static JWKS).
+    if let Some(factory) = factory {
+        let platform = require_platform(platform)?;
+        return Ok(Some(factory.build(jwks_uri, platform).await?));
+    }
+
+    let jarm = response_mode.is_some_and(ResponseMode::is_jwt_secured);
+
+    // `oidc(false)` without JARM declares the flow non-OIDC: build no default
+    // verifier and fetch no JWKS. A surprise ID token is then rejected as
+    // unvalidatable — supply a factory to validate one anyway. A missing
+    // `jwks_uri` likewise leaves the default `JwksSource` with no key source.
+    if (oidc == Some(false) && !jarm) || jwks_uri.is_none() {
+        return Ok(None);
+    }
+
+    let platform = require_platform(platform)?;
+    // Fail-fast only on declared need (`oidc(true)` or JARM). An inferred flow
+    // (`oidc` unset — the scope decides at `start()`) is unknown at build time,
+    // so come up lazily (`SeedEmpty`): a failed initial fetch is not fatal and
+    // the verifier self-heals when a token first needs it.
+    let startup = if oidc == Some(true) || jarm {
+        JwksStartup::FailFast
+    } else {
+        JwksStartup::SeedEmpty
+    };
+    let default = JwksSource::builder()
+        .http_client(Arc::clone(http_client))
+        .startup(startup)
+        .build();
+    Ok(Some(default.build(jwks_uri, platform).await?))
 }
 
 #[huskarl_macros::from_metadata(
@@ -308,23 +363,30 @@ impl AuthorizationCodeGrant {
         #[cfg(feature = "default-jws-verifier-platform")]
         #[cfg_attr(feature = "default-jws-verifier-platform", builder(default = crate::DefaultJwsVerifierPlatform::default().into()))]
         jws_verifier_platform: Arc<dyn JwsVerifierPlatform>,
+        /// Factory that builds the JWS verifier for ID tokens (OIDC) and JARM
+        /// responses.
+        ///
+        /// Defaults to a [`JwksSource`] wired from `http_client`: with a
+        /// `jwks_uri`, verification is zero-config; without one, there is no
+        /// verifier. A supplied factory is honored as-is, including with no
+        /// `jwks_uri` (it may carry its own keys).
+        #[builder(
+            with = |factory: impl JwsVerifierFactory + 'static| Arc::new(factory) as Arc<dyn JwsVerifierFactory>,
+        )]
         jws_verifier_factory: Option<Arc<dyn JwsVerifierFactory>>,
     ) -> Result<Self, Error> {
         #[cfg(feature = "default-jws-verifier-platform")]
         let jws_verifier_platform = Some(jws_verifier_platform);
 
-        let jws_verifier = match (jws_verifier_platform.clone(), jws_verifier_factory.clone()) {
-            (Some(platform), Some(factory)) => {
-                Some(factory.build(jwks_uri.as_ref(), platform).await?)
-            }
-            (None, Some(_)) => {
-                return Err(Error::new(
-                    ErrorKind::Config,
-                    super::error::MissingJwsVerifierPlatformSnafu.build(),
-                ));
-            }
-            (Some(_) | None, None) => None,
-        };
+        let jws_verifier = resolve_jws_verifier(
+            jws_verifier_factory,
+            jws_verifier_platform,
+            &http_client,
+            jwks_uri.as_ref(),
+            oidc,
+            response_mode,
+        )
+        .await?;
 
         let effective_token_endpoint = crate::grant::core::resolve_mtls_alias(
             http_client.as_ref(),

--- a/integration/huskarl-conformance/src/lib.rs
+++ b/integration/huskarl-conformance/src/lib.rs
@@ -13,7 +13,6 @@ use huskarl::{
         client_auth::ClientAuthentication,
         dpop::AuthorizationServerDPoP,
         http::{HttpClient, Idempotency},
-        jwk::JwksSource,
         server_metadata::AuthorizationServerMetadata,
     },
     grant::{
@@ -217,11 +216,7 @@ pub async fn run_auth_code_flow_with_listener<
         .redirect_uri(redirect_uri)
         .dpop(dpop)
         .jar(jar)
-        .jws_verifier_factory(Arc::new(
-            JwksSource::builder()
-                .http_client(http_client.clone())
-                .build(),
-        ))
+        // jws_verifier_factory defaults to a JwksSource wired from http_client.
         .build()
         .await
         .map_err(|e| format!("failed to build grant: {e}"))?;

--- a/integration/huskarl-integration/src/suite.rs
+++ b/integration/huskarl-integration/src/suite.rs
@@ -360,9 +360,7 @@ pub async fn auth_code_flow(provider: &dyn TestProvider, features: Features) {
         .http_client(http.clone())
         .client_auth(ClientSecret::new(ProvidedSecret::new(secret)))
         .redirect_uri(&redirect_uri)
-        .jws_verifier_factory(Arc::new(
-            JwksSource::builder().http_client(http.clone()).build(),
-        ))
+        // jws_verifier_factory defaults to a JwksSource wired from http_client.
         .maybe_jar(jar_key)
         // Knob defaults to true, so force off explicitly for the non-PAR variants.
         .prefer_pushed_authorization_requests(features.contains(Features::PAR))


### PR DESCRIPTION
BREAKING CHANGE: jws_verifier_factory takes a bare impl JwsVerifierFactory instead of Arc<dyn ...>; drop the Arc::new(...) wrapper at call sites.