### PR TITLE
fix(auth): Set more headers as sensitive if they have sensitive information

### DIFF
--- a/huskarl-core/src/client_auth/client_secret.rs
+++ b/huskarl-core/src/client_auth/client_secret.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use base64::prelude::*;
 use bon::Builder;
-use http::HeaderMap;
+use http::{HeaderMap, HeaderValue};
 
 use crate::{
     client_auth::{AuthenticationContext, AuthenticationParams, ClientAuthentication},
@@ -58,14 +58,15 @@ impl ClientSecret {
         let credentials = format!("{client_id}:{client_secret}");
         let auth_header = format!("Basic {}", BASE64_STANDARD.encode(credentials.as_bytes()));
 
+        let mut auth_value: HeaderValue = auth_header.parse().map_err(|source| {
+            Error::new(ErrorKind::Auth, source).with_context("building Basic Authorization header")
+        })?;
+        // The base64 blob is the client secret; keep it out of the HPACK/QPACK
+        // dynamic table and out of `AuthenticationParams`' derived `Debug`.
+        auth_value.set_sensitive(true);
+
         let mut headers = HeaderMap::new();
-        headers.insert(
-            http::header::AUTHORIZATION,
-            auth_header.parse().map_err(|source| {
-                Error::new(ErrorKind::Auth, source)
-                    .with_context("building Basic Authorization header")
-            })?,
-        );
+        headers.insert(http::header::AUTHORIZATION, auth_value);
 
         Ok(AuthenticationParams::builder().headers(headers).build())
     }
@@ -256,7 +257,7 @@ mod tests {
             .await
             .unwrap();
 
-        let headers = params.headers.unwrap();
+        let headers = params.headers.as_ref().unwrap();
         let auth = headers.get(http::header::AUTHORIZATION).unwrap();
         let auth_str = auth.to_str().unwrap();
         assert!(auth_str.starts_with("Basic "));
@@ -269,6 +270,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(decoded, "my-client:my-secret");
+
+        // The header carries the client secret: it must be sensitive, so that
+        // neither HPACK nor `AuthenticationParams`' `Debug` leaks it.
+        assert!(auth.is_sensitive());
+        assert!(!format!("{params:?}").contains("Basic "));
     }
 
     #[tokio::test]

--- a/huskarl/src/grant/core/form.rs
+++ b/huskarl/src/grant/core/form.rs
@@ -47,13 +47,12 @@ impl<F: Serialize> OAuth2FormRequest<'_, F> {
             .proof(&parts.method, &parts.uri, self.dpop_jkt)
             .await?
         {
-            parts.headers.insert(
-                "DPoP",
-                HeaderValue::from_str(proof.expose_secret()).map_err(|e| {
-                    Error::new(ErrorKind::DPoP, e)
-                        .with_context("DPoP proof is not a valid header value")
-                })?,
-            );
+            let mut proof_value = HeaderValue::from_str(proof.expose_secret()).map_err(|e| {
+                Error::new(ErrorKind::DPoP, e)
+                    .with_context("DPoP proof is not a valid header value")
+            })?;
+            proof_value.set_sensitive(true);
+            parts.headers.insert("DPoP", proof_value);
         }
 
         parts.headers.insert(

--- a/huskarl/src/registration/client.rs
+++ b/huskarl/src/registration/client.rs
@@ -106,8 +106,9 @@ impl ClientRegistration {
             HeaderValue::from_static("application/json"),
         );
         if let Some(token) = &self.initial_access_token {
-            let value = HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))
+            let mut value = HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))
                 .map_err(|source| registration_error(RegistrationError::AuthHeader { source }))?;
+            value.set_sensitive(true);
             parts.headers.insert(header::AUTHORIZATION, value);
         }
         let request = http::Request::from_parts(parts, Bytes::from(body));

--- a/huskarl/src/userinfo.rs
+++ b/huskarl/src/userinfo.rs
@@ -213,9 +213,10 @@ impl UserInfoClient {
             &self.userinfo_endpoint
         };
 
-        let header_value = access_token
+        let mut header_value = access_token
             .expose_header_value()
             .map_err(|source| userinfo_error(UserInfoError::BadAuthorizationHeader { source }))?;
+        header_value.set_sensitive(true);
 
         let dpop_jkt = access_token.dpop_jkt();
         let mut retried = false;
@@ -232,11 +233,10 @@ impl UserInfoClient {
                     .await
                     .map_err(|e| e.with_context("generating DPoP proof for UserInfo request"))?
             {
-                headers.insert(
-                    "DPoP",
-                    HeaderValue::from_str(proof.expose_secret())
-                        .map_err(|source| userinfo_error(UserInfoError::DPoPHeader { source }))?,
-                );
+                let mut proof_value = HeaderValue::from_str(proof.expose_secret())
+                    .map_err(|source| userinfo_error(UserInfoError::DPoPHeader { source }))?;
+                proof_value.set_sensitive(true);
+                headers.insert("DPoP", proof_value);
             }
 
             let (mut parts, ()) = http::Request::new(()).into_parts();


### PR DESCRIPTION
This prevents those header values from being presented in debug, added to HPACK, etc.