### PR TITLE
fix(core): Implement PartialEq for oct keys in constant time.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "sha2",
  "snafu",
  "strum",
+ "subtle",
  "tempfile",
  "tokio",
  "url",

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true, default-features = false }
 snafu = { workspace = true }
 strum = { workspace = true }
+subtle = { version = "2.6.1", default-features = false }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 url = { workspace = true, optional = true }
 zeroize = { version = "1", default-features = false }

--- a/huskarl-core/src/jwk/key.rs
+++ b/huskarl-core/src/jwk/key.rs
@@ -1,5 +1,7 @@
 //! JWK wire-format key types, including optional private parameters (RFC 7518).
 
+use subtle::ConstantTimeEq as _;
+
 use super::*;
 
 /// Additional prime factor info for multi-prime RSA keys (RFC 7518 §6.3.2.7).
@@ -305,13 +307,21 @@ where
 /// Used for HMAC signing and symmetric encryption (e.g., `A128KW`).
 /// Has no public key equivalent — purely secret material.
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Builder, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Builder, Clone)]
 #[builder(derive(Into))]
 pub struct OctKey {
     /// The key value.
     #[builder(with = <_>::from_iter)]
     #[serde(with = "base64url")]
     pub k: Vec<u8>,
+}
+
+/// `k` is raw secret material — a derived `==` would short-circuit on the first
+/// differing byte. Length is not secret and is compared directly.
+impl PartialEq for OctKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.k.ct_eq(&other.k).into()
+    }
 }
 
 impl std::fmt::Debug for OctKey {

--- a/huskarl-core/src/jwk/tests.rs
+++ b/huskarl-core/src/jwk/tests.rs
@@ -650,3 +650,20 @@ fn test_private_jwk_try_from_wrong_variant() {
     // The matching variant converts cleanly.
     assert!(SymmetricJwk::try_from(pjwk).is_ok());
 }
+
+#[test]
+fn test_oct_key_eq_is_still_equality() {
+    // `OctKey`'s `PartialEq` is hand-written to compare in constant time; guard
+    // against it degenerating into always-equal or always-unequal.
+    let oct = |bytes: Vec<u8>| OctKey::builder().k(bytes).build();
+
+    assert_eq!(oct(vec![7u8; 32]), oct(vec![7u8; 32]));
+    assert_ne!(oct(vec![7u8; 32]), oct(vec![8u8; 32]));
+    // Differs only in the last byte — a short-circuiting compare would agree
+    // here too, but this is where a truncating one would not.
+    let mut tail = vec![7u8; 32];
+    tail[31] = 8;
+    assert_ne!(oct(vec![7u8; 32]), oct(tail));
+    // Unequal lengths.
+    assert_ne!(oct(vec![7u8; 32]), oct(vec![7u8; 16]));
+}


### PR DESCRIPTION
Minor fix to make sure that PartialEq doesn't leak private key contents.