### PR TITLE
fix(client): Forward normal and mtls token endpoints to refresh grant.

### DIFF
--- a/huskarl/src/grant/authorization_code/grant.rs
+++ b/huskarl/src/grant/authorization_code/grant.rs
@@ -50,6 +50,11 @@ pub struct AuthorizationCodeGrant {
     /// metadata (before RFC 8705 §5 mTLS-alias resolution).
     pub(super) token_endpoint: EndpointUrl,
 
+    /// The mTLS alias for the token endpoint (RFC 8705 §5). Retained alongside
+    /// the resolved `effective_token_endpoint` so a derived grant can re-resolve
+    /// it rather than inherit a flattened endpoint pair.
+    pub(super) mtls_token_endpoint: Option<EndpointUrl>,
+
     /// The token endpoint used for token requests: the RFC 8705 §5 mTLS alias
     /// when the HTTP client uses mTLS, the primary token endpoint otherwise.
     pub(super) effective_token_endpoint: EndpointUrl,
@@ -456,6 +461,7 @@ impl AuthorizationCodeGrant {
             dpop,
             issuer,
             token_endpoint,
+            mtls_token_endpoint,
             effective_token_endpoint,
             token_endpoint_auth_methods_supported,
             jws_verifier,
@@ -548,7 +554,8 @@ impl OAuth2ExchangeGrant for AuthorizationCodeGrant {
             .http_client(self.http_client.clone())
             .client_auth(self.client_auth.clone())
             .dpop(self.dpop.clone())
-            .token_endpoint(self.effective_token_endpoint.clone())
+            .token_endpoint(self.token_endpoint.clone())
+            .maybe_mtls_token_endpoint(self.mtls_token_endpoint.clone())
             .maybe_token_endpoint_auth_methods_supported(
                 self.token_endpoint_auth_methods_supported.clone(),
             )

--- a/huskarl/src/grant/client_credentials.rs
+++ b/huskarl/src/grant/client_credentials.rs
@@ -133,7 +133,8 @@ impl OAuth2ExchangeGrant for ClientCredentialsGrant {
             .http_client(self.http_client.clone())
             .client_auth(self.client_auth.clone())
             .dpop(self.dpop.clone())
-            .token_endpoint(self.effective_token_endpoint.clone())
+            .token_endpoint(self.token_endpoint.clone())
+            .maybe_mtls_token_endpoint(self.mtls_token_endpoint.clone())
             .maybe_token_endpoint_auth_methods_supported(
                 self.token_endpoint_auth_methods_supported.clone(),
             )

--- a/huskarl/src/grant/device_authorization/grant.rs
+++ b/huskarl/src/grant/device_authorization/grant.rs
@@ -310,7 +310,8 @@ impl OAuth2ExchangeGrant for DeviceAuthorizationGrant {
             .http_client(self.http_client.clone())
             .client_auth(self.client_auth.clone())
             .dpop(self.dpop.clone())
-            .token_endpoint(self.effective_token_endpoint.clone())
+            .token_endpoint(self.token_endpoint.clone())
+            .maybe_mtls_token_endpoint(self.mtls_token_endpoint.clone())
             .maybe_token_endpoint_auth_methods_supported(
                 self.token_endpoint_auth_methods_supported.clone(),
             )

--- a/huskarl/src/grant/jwt_bearer.rs
+++ b/huskarl/src/grant/jwt_bearer.rs
@@ -165,7 +165,8 @@ impl OAuth2ExchangeGrant for JwtBearerGrant {
             .http_client(self.http_client.clone())
             .maybe_client_auth(self.client_auth.clone())
             .dpop(self.dpop.clone())
-            .token_endpoint(self.effective_token_endpoint.clone())
+            .token_endpoint(self.token_endpoint.clone())
+            .maybe_mtls_token_endpoint(self.mtls_token_endpoint.clone())
             .maybe_token_endpoint_auth_methods_supported(
                 self.token_endpoint_auth_methods_supported.clone(),
             )

--- a/huskarl/src/grant/token_exchange.rs
+++ b/huskarl/src/grant/token_exchange.rs
@@ -162,7 +162,8 @@ impl OAuth2ExchangeGrant for TokenExchangeGrant {
             .http_client(self.http_client.clone())
             .maybe_client_auth(self.client_auth.clone())
             .dpop(self.dpop.clone())
-            .token_endpoint(self.effective_token_endpoint.clone())
+            .token_endpoint(self.token_endpoint.clone())
+            .maybe_mtls_token_endpoint(self.mtls_token_endpoint.clone())
             .maybe_token_endpoint_auth_methods_supported(
                 self.token_endpoint_auth_methods_supported.clone(),
             )
@@ -289,12 +290,72 @@ mod tests {
         }
     }
 
+    /// An [`HttpClient`] presenting an RFC 8705 mTLS client certificate, so that
+    /// endpoint resolution takes the alias branch.
+    struct MtlsClient;
+
+    impl HttpClient for MtlsClient {
+        fn execute(
+            &self,
+            _request: Request<Bytes>,
+            _idempotency: Idempotency,
+        ) -> MaybeSendBoxFuture<'_, Result<HttpResponse, Error>> {
+            Box::pin(async { unreachable!("endpoint resolution performs no HTTP request") })
+        }
+
+        fn uses_mtls(&self) -> bool {
+            true
+        }
+    }
+
     fn grant() -> TokenExchangeGrant {
         TokenExchangeGrant::builder()
             .token_endpoint("https://as.example/token".parse::<EndpointUrl>().unwrap())
             .client_id("exchange-client")
             .http_client(UnusedClient)
             .build()
+    }
+
+    // RFC 8705 §5: the published token endpoint and the mTLS alias serve
+    // different roles — the former is the `Audience::TokenEndpoint` assertion
+    // `aud`, the latter is where the request is actually sent. A derived refresh
+    // grant must inherit both, not the resolved alias flattened into each.
+    #[test]
+    fn to_refresh_grant_keeps_published_and_alias_endpoints_distinct() {
+        let published: EndpointUrl = "https://as.example/token".parse().unwrap();
+        let alias: EndpointUrl = "https://mtls.as.example/token".parse().unwrap();
+
+        let grant = TokenExchangeGrant::builder()
+            .token_endpoint(published.clone())
+            .mtls_token_endpoint(alias.clone())
+            .client_id("exchange-client")
+            .http_client(MtlsClient)
+            .build();
+
+        assert_eq!(grant.token_endpoint(), &published);
+        assert_eq!(grant.effective_token_endpoint(), &alias);
+
+        let refresh = grant.to_refresh_grant();
+        assert_eq!(
+            refresh.token_endpoint(),
+            &published,
+            "the assertion audience must stay the published endpoint"
+        );
+        assert_eq!(
+            refresh.effective_token_endpoint(),
+            &alias,
+            "requests must still go to the mTLS alias"
+        );
+    }
+
+    // Without mTLS the alias is inert, and both endpoints stay the published one.
+    #[test]
+    fn to_refresh_grant_without_mtls_uses_the_published_endpoint_throughout() {
+        let published: EndpointUrl = "https://as.example/token".parse().unwrap();
+        let refresh = grant().to_refresh_grant();
+
+        assert_eq!(refresh.token_endpoint(), &published);
+        assert_eq!(refresh.effective_token_endpoint(), &published);
     }
 
     fn subject() -> SecurityToken {


### PR DESCRIPTION
JWT-based credentials care about the original token endpoint as the audience, and passing the mtls endpoint instead would cause an incorrect audience for refresh grant requests in this case.