### PR TITLE
feat!: Make builder_from_metadata/etc. return Result instead of Option

### DIFF
--- a/huskarl-core/src/server_metadata.rs
+++ b/huskarl-core/src/server_metadata.rs
@@ -13,6 +13,18 @@ use crate::{
     http::HttpClient,
 };
 
+/// Builds the [`ErrorKind::Config`] error returned by the
+/// `builder_from_metadata` constructors when [`AuthorizationServerMetadata`]
+/// lacks a field the target requires.
+///
+/// `field` names the absent field as it appears in the discovery document,
+/// dotted for a nested one (`mtls_endpoint_aliases.token_endpoint`).
+#[must_use]
+pub fn missing_field(field: &str) -> Error {
+    Error::from(ErrorKind::Config)
+        .with_context(format!("authorization server metadata has no `{field}`"))
+}
+
 /// mTLS endpoint aliases from AS discovery metadata (RFC 8705 §5.1).
 #[derive(Debug, Clone, Deserialize, bon::Builder)]
 #[non_exhaustive]

--- a/huskarl-macros/src/from_metadata.rs
+++ b/huskarl-macros/src/from_metadata.rs
@@ -20,9 +20,11 @@
 //! have the target type, so the conversion is required to succeed.
 //!
 //! Gating: if exactly one *required* field (not `Option<T>`) draws from an
-//! Option-typed extraction, the generated function returns `Option<Builder<…>>`
-//! and the body is wrapped in `.as_ref().map(|x| …)`. Multiple gates aren't
-//! supported.
+//! Option-typed extraction, the generated function returns
+//! `Result<Builder<…>, huskarl_core::Error>` and the body is wrapped in
+//! `.as_ref().map(|x| …).ok_or_else(…)`, the error naming the absent field.
+//! Multiple gates aren't supported. Only this branch names `::huskarl_core`;
+//! ungated invocations stay dependency-free.
 
 use darling::{FromMeta, ast::NestedMeta};
 use proc_macro2::{Span, TokenStream};
@@ -269,12 +271,14 @@ fn emit_impl(
             // so the closure sees the same `&Metadata` as in non-gate position.
             Extraction::With { closure, .. } => quote! { (#closure)(#metadata_var) },
         };
+        let missing_field = gate_field_name(gate);
         quote! {
             #outer_extract
                 .as_ref()
                 .map(|#gate_var| {
                     Self::#start_fn() #setter_chain
                 })
+                .ok_or_else(|| ::huskarl_core::server_metadata::missing_field(#missing_field))
         }
     } else {
         quote! { Self::#start_fn() #setter_chain }
@@ -282,8 +286,9 @@ fn emit_impl(
 
     let return_ty = if gate.is_some() {
         quote! {
-            ::core::option::Option<
-                #builder_ident<#builder_type_args #state_chain>
+            ::core::result::Result<
+                #builder_ident<#builder_type_args #state_chain>,
+                ::huskarl_core::Error,
             >
         }
     } else {
@@ -307,13 +312,30 @@ fn emit_impl(
     let state_alias_doc = format!(" State of [`{builder_ident}`] returned by [`{method_name}`].");
     let method_doc = format!(" Returns a [`{builder_ident}`] pre-populated from server metadata.");
 
+    // A gated method returns `Result`, which is itself `#[must_use]` — adding
+    // the attribute would trip `clippy::double_must_use` — and needs an
+    // `# Errors` section for `clippy::missing_errors_doc`.
+    let (must_use, errors_doc) = match gate {
+        Some(gate) => {
+            let field = gate_field_name(gate);
+            let doc = format!(
+                " # Errors\n\n Returns an error of kind [`ErrorKind::Config`] if the \
+                 metadata has no `{field}`.\n\n \
+                 [`ErrorKind::Config`]: ::huskarl_core::ErrorKind::Config"
+            );
+            (quote! {}, quote! { #[doc = ""] #[doc = #doc] })
+        }
+        None => (quote! { #[must_use] }, quote! {}),
+    };
+
     Ok(quote! {
         #[doc = #state_alias_doc]
         #method_vis type #alias_ident = #state_chain;
 
         #impl_head #struct_ident<#self_type_args> #where_clause {
             #[doc = #method_doc]
-            #[must_use]
+            #errors_doc
+            #must_use
             #method_vis fn #method_name(
                 #metadata_var: &#metadata_type,
             ) -> #return_ty {
@@ -321,6 +343,20 @@ fn emit_impl(
             }
         }
     })
+}
+
+/// The metadata field a gate draws from, as it appears in the discovery
+/// document: the dotted path with `?` markers stripped. A `with =` gate has no
+/// path to render, so it falls back to the target field's own name.
+fn gate_field_name(gate: &MetadataField) -> String {
+    match &gate.extraction {
+        Extraction::Path(segs) => segs
+            .iter()
+            .map(|s| s.name.to_string())
+            .collect::<Vec<_>>()
+            .join("."),
+        Extraction::With { .. } => gate.field_ident.to_string(),
+    }
 }
 
 fn find_fn_new_mut(item: &mut ItemImpl) -> Result<&mut syn::ImplItemFn> {

--- a/huskarl-macros/src/lib.rs
+++ b/huskarl-macros/src/lib.rs
@@ -35,7 +35,13 @@ mod util;
 ///
 /// If a *required* grant field (not `Option<T>`) draws from an `Option`-typed
 /// extraction, the generated function gates on it and returns
-/// `Option<Builder<…>>`. At most one gating field per struct is supported.
+/// `Result<Builder<…>, huskarl_core::Error>` of kind `ErrorKind::Config`, whose
+/// message names the absent field. At most one gating field per struct is
+/// supported.
+///
+/// Gated code names `::huskarl_core`, so a struct with a gating field must be in
+/// a crate depending on `huskarl-core` under its default name. Ungated
+/// invocations (like the example below) have no such requirement.
 ///
 /// The macro is generic over the metadata type — `metadata = …` names any
 /// type, and the generated `builder_from_metadata(&Meta)` pre-fills the

--- a/huskarl-macros/tests/ui/pass_from_metadata.rs
+++ b/huskarl-macros/tests/ui/pass_from_metadata.rs
@@ -3,7 +3,7 @@
 //! - nested-through-Option path
 //! - `with =` escape hatch
 //! - gating field (required-on-target draws from Option-in-source) →
-//!   `Option<Builder<…>>` return type.
+//!   `Result<Builder<…>, huskarl_core::Error>` naming the absent field.
 
 #[derive(Debug)]
 struct Meta {
@@ -137,13 +137,19 @@ fn main() {
     assert_eq!(built.nested_value, None);
     assert_eq!(built.counter_doubled, None);
 
-    let opt = WithGate::builder_from_metadata(&meta);
-    assert!(opt.is_some());
-    let built = opt.unwrap().build();
+    let gated = WithGate::builder_from_metadata(&meta);
+    let built = gated.unwrap().build();
     assert_eq!(built.required_in_target, 42);
 
-    let opt = WithGate::builder_from_metadata(&meta_none);
-    assert!(opt.is_none());
+    // `.err()`, not `unwrap_err()`: bon builders aren't `Debug`.
+    let err = WithGate::builder_from_metadata(&meta_none)
+        .err()
+        .expect("required_in_target absent");
+    assert_eq!(err.kind(), huskarl_core::ErrorKind::Config);
+    assert_eq!(
+        err.to_string(),
+        "authorization server metadata has no `required_in_target`: invalid configuration"
+    );
 
     let built = WithWhere::<()>::builder_from_metadata(&meta).build();
     assert_eq!(built.name.as_deref(), Some("hello"));

--- a/huskarl-macros/tests/ui/pass_method_config.rs
+++ b/huskarl-macros/tests/ui/pass_method_config.rs
@@ -56,7 +56,9 @@ pub struct Client {
 impl Client {
     /// Public wrapper spelling out the generated state alias by name, exactly
     /// as the production crate does.
-    pub fn from_meta(meta: &Meta) -> Option<ClientBuilder<ClientFromMetaInternalState>> {
+    pub fn from_meta(
+        meta: &Meta,
+    ) -> Result<ClientBuilder<ClientFromMetaInternalState>, huskarl_core::Error> {
         Self::from_meta_internal(meta)
     }
 }
@@ -70,12 +72,15 @@ fn main() {
     assert_eq!(client.endpoint, Url("https://as.example.com".to_owned()));
     assert_eq!(client.issuer.as_deref(), Some("https://as.example.com"));
 
-    // Absent gate source → no builder.
+    // Absent gate source → an error naming the field, not a bare `None`.
     let meta = Meta {
         endpoint: None,
         issuer: String::new(),
     };
-    assert!(Client::from_meta(&meta).is_none());
+    // `.err()`, not `unwrap_err()`: bon builders aren't `Debug`.
+    let err = Client::from_meta(&meta).err().expect("endpoint absent");
+    assert_eq!(err.kind(), huskarl_core::ErrorKind::Config);
+    assert!(err.to_string().contains("endpoint"));
 
     // The fallible setter still works for manual construction.
     let client = Client::builder()

--- a/huskarl-resource-server/docs/guide/introspection.md
+++ b/huskarl-resource-server/docs/guide/introspection.md
@@ -43,8 +43,9 @@ let client_auth: ClientSecret = ClientSecret::new(client_secret);
 
 ## 3a. Build the validator from authorization server metadata
 
-Note: `builder_from_metadata` returns `None` if the server does not advertise
-an introspection endpoint.
+Note: `builder_from_metadata` errors if the server advertises no introspection
+endpoint. Since introspection is optional, add `.ok()` to treat an absent
+endpoint as "unsupported" rather than a failure.
 
 ```rust
 use huskarl_resource_server::{
@@ -65,8 +66,7 @@ let metadata = AuthorizationServerMetadata::fetch()
     .call()
     .await?;
 
-let validator = IntrospectionValidator::builder_from_metadata(&metadata)
-    .expect("authorization server does not support token introspection")
+let validator = IntrospectionValidator::builder_from_metadata(&metadata)?
     .client_id("my-resource-server")
     .aud("api://my-resource")
     .client_auth(ClientSecret::new(client_secret))
@@ -134,7 +134,7 @@ non-absolute URI fails every DPoP validation with an integration error.
 # let http_client = huskarl_reqwest::ReqwestClient::builder().build().await?;
 # let client_secret = EnvVarSecret::new("CLIENT_SECRET", &StringEncoding)?;
 # let metadata = AuthorizationServerMetadata::fetch().http_client(&http_client).issuer("https://my-issuer").call().await?;
-# let validator = IntrospectionValidator::builder_from_metadata(&metadata).expect("").client_id("my-resource-server").aud("api://my-resource").client_auth(ClientSecret::new(client_secret)).http_client(http_client.clone()).build().await?;
+# let validator = IntrospectionValidator::builder_from_metadata(&metadata)?.client_id("my-resource-server").aud("api://my-resource").client_auth(ClientSecret::new(client_secret)).http_client(http_client.clone()).build().await?;
 use http::{HeaderValue, Method, Uri, header::AUTHORIZATION};
 
 let mut headers = http::HeaderMap::new();

--- a/huskarl-resource-server/src/validator/custom/mod.rs
+++ b/huskarl-resource-server/src/validator/custom/mod.rs
@@ -182,6 +182,11 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> CustomValidator<Claims
     }
 }
 
+/// State of [`CustomValidatorBuilder`] returned by
+/// [`CustomValidator::builder_from_metadata`]: `authorization_server` and
+/// `jwks_uri` set.
+pub type CustomValidatorBuilderFromMetadataState = SetJwksUri<SetAuthorizationServer>;
+
 impl CustomValidator<()> {
     /// Creates a builder for [`CustomValidator`].
     ///
@@ -200,7 +205,7 @@ impl CustomValidator<()> {
     /// claims type.
     pub fn builder_from_metadata(
         metadata: &AuthorizationServerMetadata,
-    ) -> CustomValidatorBuilder<(), SetJwksUri<SetAuthorizationServer>> {
+    ) -> CustomValidatorBuilder<(), CustomValidatorBuilderFromMetadataState> {
         Self::builder()
             .authorization_server(metadata.issuer.clone())
             .maybe_jwks_uri(metadata.jwks_uri.clone())

--- a/huskarl-resource-server/src/validator/introspection/mod.rs
+++ b/huskarl-resource-server/src/validator/introspection/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         jwk::JwksSource,
         jwt::{JtiUniquenessChecker, validator::ClaimCheck},
         platform::{Duration, MaybeSendSync},
-        server_metadata::AuthorizationServerMetadata,
+        server_metadata::{AuthorizationServerMetadata, missing_field},
     },
     introspection::TokenIntrospection,
     validator::{
@@ -241,6 +241,12 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> IntrospectionValidator
     }
 }
 
+/// State of [`IntrospectionValidatorBuilder`] returned by
+/// [`IntrospectionValidator::builder_from_metadata`]: `issuer`,
+/// `introspection_endpoint`, `jwks_uri`, and `token_endpoint` set.
+pub type IntrospectionValidatorBuilderFromMetadataState =
+    SetTokenEndpoint<SetJwksUri<SetIntrospectionEndpoint<SetIssuer>>>;
+
 impl IntrospectionValidator<()> {
     /// Creates a builder for [`IntrospectionValidator`].
     ///
@@ -255,14 +261,18 @@ impl IntrospectionValidator<()> {
     /// Pre-fills `issuer`, `introspection_endpoint`, `jwks_uri`, and
     /// `token_endpoint` from the metadata. Call `.with_claims::<MyClaims>()` to
     /// use a custom claims type.
-    #[allow(clippy::type_complexity)]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of kind [`ErrorKind::Config`] if the metadata has no
+    /// `introspection_endpoint`.
+    ///
+    /// [`ErrorKind::Config`]: huskarl_core::ErrorKind::Config
     pub fn builder_from_metadata(
         metadata: &AuthorizationServerMetadata,
-    ) -> Option<
-        IntrospectionValidatorBuilder<
-            (),
-            SetTokenEndpoint<SetJwksUri<SetIntrospectionEndpoint<SetIssuer>>>,
-        >,
+    ) -> Result<
+        IntrospectionValidatorBuilder<(), IntrospectionValidatorBuilderFromMetadataState>,
+        Error,
     > {
         metadata
             .introspection_endpoint
@@ -274,6 +284,7 @@ impl IntrospectionValidator<()> {
                     .maybe_jwks_uri(metadata.jwks_uri.clone())
                     .token_endpoint(metadata.token_endpoint.clone())
             })
+            .ok_or_else(|| missing_field("introspection_endpoint"))
     }
 }
 

--- a/huskarl-resource-server/src/validator/rfc9068/mod.rs
+++ b/huskarl-resource-server/src/validator/rfc9068/mod.rs
@@ -188,6 +188,11 @@ impl<Claims: for<'de> Deserialize<'de> + Clone + 'static> Rfc9068Validator<Claim
     }
 }
 
+/// State of [`Rfc9068ValidatorBuilder`] returned by
+/// [`Rfc9068Validator::builder_from_metadata`]: `issuer` and `jwks_uri` set.
+pub type Rfc9068ValidatorBuilderFromMetadataState =
+    rfc9068_validator_builder::SetJwksUri<rfc9068_validator_builder::SetIssuer>;
+
 impl Rfc9068Validator<()> {
     /// Creates a builder for [`Rfc9068Validator`].
     ///
@@ -203,10 +208,7 @@ impl Rfc9068Validator<()> {
     /// Call `.with_claims::<MyClaims>()` on the builder to use a custom claims type.
     pub fn builder_from_metadata(
         metadata: &AuthorizationServerMetadata,
-    ) -> Rfc9068ValidatorBuilder<
-        (),
-        rfc9068_validator_builder::SetJwksUri<rfc9068_validator_builder::SetIssuer>,
-    > {
+    ) -> Rfc9068ValidatorBuilder<(), Rfc9068ValidatorBuilderFromMetadataState> {
         Self::builder()
             .issuer(metadata.issuer.clone())
             .maybe_jwks_uri(metadata.jwks_uri.clone())

--- a/huskarl/docs/guide/authorization_code.md
+++ b/huskarl/docs/guide/authorization_code.md
@@ -15,8 +15,8 @@ this page assumes. Public clients (single-page apps, CLI tools) typically use
 
 ## 2a. Set up the grant with authorization server metadata
 
-Note: `builder_from_metadata` returns `None` if the server does not advertise
-an authorization endpoint.
+Note: `builder_from_metadata` errors if the server advertises no authorization
+endpoint.
 
 ```rust
 use huskarl::{
@@ -32,8 +32,7 @@ let metadata = AuthorizationServerMetadata::fetch()
     .call()
     .await?;
 
-let grant: AuthorizationCodeGrant = AuthorizationCodeGrant::builder_from_metadata(&metadata)
-    .expect("server does not support authorization code grant")
+let grant: AuthorizationCodeGrant = AuthorizationCodeGrant::builder_from_metadata(&metadata)?
     .client_id("client_id")
     .http_client(client)
     .client_auth(NoAuth)
@@ -177,8 +176,7 @@ use huskarl::{
 # ) -> Result<(), Box<dyn std::error::Error>> {
 # let client = huskarl_reqwest::ReqwestClient::builder().build().await?;
 
-let grant: AuthorizationCodeGrant = AuthorizationCodeGrant::builder_from_metadata(metadata)
-    .expect("server does not support authorization code grant")
+let grant: AuthorizationCodeGrant = AuthorizationCodeGrant::builder_from_metadata(metadata)?
     .client_id("client_id")
     .http_client(client)
     .client_auth(NoAuth)

--- a/huskarl/docs/guide/device_authorization.md
+++ b/huskarl/docs/guide/device_authorization.md
@@ -16,8 +16,9 @@ credentials instead.
 
 ## 2a. Set up the grant with authorization server metadata
 
-Note: `builder_from_metadata` returns `None` if the server does not advertise
-a device authorization endpoint.
+Note: `builder_from_metadata` errors if the server advertises no device
+authorization endpoint. Since the device flow is optional, add `.ok()` to treat
+an absent endpoint as "unsupported" rather than a failure.
 
 ```rust
 use huskarl::{
@@ -36,8 +37,7 @@ let metadata = AuthorizationServerMetadata::fetch()
     .await?;
 
 let grant: DeviceAuthorizationGrant =
-    DeviceAuthorizationGrant::builder_from_metadata(&metadata)
-        .expect("server does not support device authorization")
+    DeviceAuthorizationGrant::builder_from_metadata(&metadata)?
         .client_id("client_id")
         .http_client(client)
         .client_auth(NoAuth)

--- a/huskarl/docs/guide/registration.md
+++ b/huskarl/docs/guide/registration.md
@@ -13,8 +13,8 @@ to obtain tokens.
 
 The registration endpoint (and its mTLS alias) is discovered from
 [`AuthorizationServerMetadata`](crate::core::server_metadata::AuthorizationServerMetadata)
-via `builder_from_metadata` — which returns `None` if the server does not
-advertise a registration endpoint — or supplied directly with
+via `builder_from_metadata` — which errors if the server advertises no
+registration endpoint — or supplied directly with
 [`ClientRegistration::builder`](crate::registration::ClientRegistration::builder).
 
 ## Handling the issued client secret
@@ -38,9 +38,8 @@ use huskarl::registration::{ClientMetadata, ClientRegistration};
 # async fn example(
 #     http_client: impl HttpClient + 'static,
 #     metadata: AuthorizationServerMetadata,
-# ) {
-let registration = ClientRegistration::builder_from_metadata(&metadata)
-    .expect("server does not support dynamic client registration")
+# ) -> Result<(), huskarl::core::Error> {
+let registration = ClientRegistration::builder_from_metadata(&metadata)?
     .build();
 
 let desired = ClientMetadata::builder()
@@ -56,6 +55,7 @@ println!("registered client_id: {}", info.client_id);
 if let Some(secret) = &info.client_secret {
     persist_to_secret_store(secret);
 }
+# Ok(())
 # }
 # fn persist_to_secret_store(_secret: &huskarl::core::secrets::SecretString) {}
 ```

--- a/huskarl/examples/authorization_code.rs
+++ b/huskarl/examples/authorization_code.rs
@@ -42,7 +42,7 @@ pub async fn main() -> Result<(), snafu::Whatever> {
         .whatever_context("Failed to generate DPoP key")?;
 
     let grant = AuthorizationCodeGrant::builder_from_metadata(&metadata)
-        .whatever_context("Authorization server metadata didn't include authorization URL")?
+        .whatever_context("Authorization server does not support the authorization code grant")?
         .client_id(client_id)
         .http_client(http_client.clone())
         .client_auth(NoAuth)

--- a/huskarl/src/registration/client.rs
+++ b/huskarl/src/registration/client.rs
@@ -23,7 +23,7 @@ use crate::core::{
 /// Construct it with [`builder`](Self::builder), or with `builder_from_metadata`
 /// to fill the endpoint from
 /// [`AuthorizationServerMetadata`](crate::core::server_metadata::AuthorizationServerMetadata)
-/// (which returns `None` when the server advertises no registration endpoint).
+/// (which errors when the server advertises no registration endpoint).
 ///
 /// If the server requires an initial access token (RFC 7591 §3.1), supply it via
 /// the builder; it is sent as a bearer token on the registration request.

--- a/huskarl/src/userinfo.rs
+++ b/huskarl/src/userinfo.rs
@@ -18,7 +18,7 @@ use crate::{
             JwsParseError, parse_compact_jws,
             validator::{ClaimCheck, JwtValidationError, JwtValidator},
         },
-        server_metadata::AuthorizationServerMetadata,
+        server_metadata::{AuthorizationServerMetadata, missing_field},
     },
     grant::core::OAuth2ExchangeGrant,
     token::{AccessToken, id_token::StandardOidcProfileClaims},
@@ -56,10 +56,13 @@ pub struct UserInfoClient {
     require_signed_response: bool,
 }
 
-/// State of [`UserInfoClientBuilder`] returned by [`UserInfoClient::from_grant`]:
-/// `userinfo_endpoint`, `mtls_userinfo_endpoint`, `dpop`, `jws_verifier`,
-/// `issuer`, and `client_id` set.
-pub type UserInfoClientFromGrantState = user_info_client_builder::SetClientId<
+/// State of [`UserInfoClientBuilder`] returned by
+/// [`UserInfoClient::builder_from_grant`]: `userinfo_endpoint`,
+/// `mtls_userinfo_endpoint`, `dpop`, `jws_verifier`, `issuer`, and `client_id`
+/// set.
+// Name mirrors the `{Struct}{Method}State` alias `#[from_metadata]` generates,
+// so the hand-written and generated constructors read alike.
+pub type UserInfoClientBuilderFromGrantState = user_info_client_builder::SetClientId<
     user_info_client_builder::SetIssuer<
         user_info_client_builder::SetJwsVerifier<
             user_info_client_builder::SetDpop<
@@ -224,7 +227,10 @@ impl UserInfoClient {
     /// Remaining fields — notably `require_signed_response`, which no grant
     /// records — are left to the caller.
     ///
-    /// Returns `None` if the metadata has no `userinfo_endpoint`.
+    /// # Errors
+    ///
+    /// Returns an error of kind [`ErrorKind::Config`] if the metadata has no
+    /// `userinfo_endpoint`.
     ///
     /// ```rust
     /// use huskarl::userinfo::UserInfoClient;
@@ -236,8 +242,7 @@ impl UserInfoClient {
     /// #     grant: AuthorizationCodeGrant,
     /// #     metadata: AuthorizationServerMetadata,
     /// # ) -> Result<(), Error> {
-    /// let client = UserInfoClient::from_grant(&grant, &metadata)
-    ///     .expect("provider publishes a userinfo_endpoint")
+    /// let client = UserInfoClient::builder_from_grant(&grant, &metadata)?
     ///     .require_signed_response(true)
     ///     .build()
     ///     .await?;
@@ -245,27 +250,27 @@ impl UserInfoClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[must_use]
-    pub fn from_grant(
+    pub fn builder_from_grant(
         grant: &impl OAuth2ExchangeGrant,
         metadata: &AuthorizationServerMetadata,
-    ) -> Option<UserInfoClientBuilder<UserInfoClientFromGrantState>> {
-        let userinfo_endpoint = metadata.userinfo_endpoint.clone()?;
+    ) -> Result<UserInfoClientBuilder<UserInfoClientBuilderFromGrantState>, Error> {
+        let userinfo_endpoint = metadata
+            .userinfo_endpoint
+            .clone()
+            .ok_or_else(|| missing_field("userinfo_endpoint"))?;
 
-        Some(
-            Self::builder()
-                .userinfo_endpoint(userinfo_endpoint)
-                .maybe_mtls_userinfo_endpoint(
-                    metadata
-                        .mtls_endpoint_aliases
-                        .as_ref()
-                        .and_then(|a| a.userinfo_endpoint.clone()),
-                )
-                .dpop(grant.dpop().to_resource_server_dpop())
-                .maybe_jws_verifier(grant.jws_verifier())
-                .maybe_issuer(grant.issuer())
-                .maybe_client_id(grant.client_id()),
-        )
+        Ok(Self::builder()
+            .userinfo_endpoint(userinfo_endpoint)
+            .maybe_mtls_userinfo_endpoint(
+                metadata
+                    .mtls_endpoint_aliases
+                    .as_ref()
+                    .and_then(|a| a.userinfo_endpoint.clone()),
+            )
+            .dpop(grant.dpop().to_resource_server_dpop())
+            .maybe_jws_verifier(grant.jws_verifier())
+            .maybe_issuer(grant.issuer())
+            .maybe_client_id(grant.client_id()))
     }
     /// Call the `UserInfo` endpoint with the given access token.
     ///
@@ -1393,7 +1398,7 @@ mod tests {
         assert_eq!(result.sub, "user1");
     }
 
-    // --- from_grant validator derivation ---
+    // --- builder_from_grant validator derivation ---
 
     /// Factory yielding [`AcceptAllVerifier`], standing in for a JWKS-backed one.
     struct AcceptAllFactory;
@@ -1443,7 +1448,7 @@ mod tests {
     /// A grant's verifier reaches the built client, so a signed `UserInfo`
     /// response validates instead of hard-erroring.
     #[tokio::test]
-    async fn from_grant_derives_jwt_validator() {
+    async fn builder_from_grant_derives_jwt_validator() {
         let jwt = build_test_jwt(
             &serde_json::json!({"alg": "RS256"}),
             &serde_json::json!({
@@ -1455,7 +1460,7 @@ mod tests {
         );
 
         let grant = code_grant(true).await;
-        let client = UserInfoClient::from_grant(&grant, &userinfo_metadata())
+        let client = UserInfoClient::builder_from_grant(&grant, &userinfo_metadata())
             .expect("metadata carries a userinfo_endpoint")
             .build()
             .await
@@ -1477,14 +1482,14 @@ mod tests {
     #[case::wrong_audience("https://op.example.com", "other-client")]
     #[case::wrong_issuer("https://evil.example.com", "my-client")]
     #[tokio::test]
-    async fn from_grant_validator_checks_claims(#[case] iss: &str, #[case] aud: &str) {
+    async fn builder_from_grant_validator_checks_claims(#[case] iss: &str, #[case] aud: &str) {
         let jwt = build_test_jwt(
             &serde_json::json!({"alg": "RS256"}),
             &serde_json::json!({"sub": "user1", "iss": iss, "aud": aud}),
         );
 
         let grant = code_grant(true).await;
-        let client = UserInfoClient::from_grant(&grant, &userinfo_metadata())
+        let client = UserInfoClient::builder_from_grant(&grant, &userinfo_metadata())
             .unwrap()
             .build()
             .await
@@ -1505,14 +1510,14 @@ mod tests {
     /// A grant with no verifier cannot produce one: the JWT path stays closed
     /// and reports the missing configuration rather than skipping validation.
     #[tokio::test]
-    async fn from_grant_without_verifier_rejects_jwt_response() {
+    async fn builder_from_grant_without_verifier_rejects_jwt_response() {
         let jwt = build_test_jwt(
             &serde_json::json!({"alg": "RS256"}),
             &serde_json::json!({"sub": "user1", "iss": "https://op.example.com", "aud": "my-client"}),
         );
 
         let grant = code_grant(false).await;
-        let client = UserInfoClient::from_grant(&grant, &userinfo_metadata())
+        let client = UserInfoClient::builder_from_grant(&grant, &userinfo_metadata())
             .unwrap()
             .build()
             .await
@@ -1530,11 +1535,11 @@ mod tests {
         ));
     }
 
-    /// `require_signed_response` carries through `from_grant`.
+    /// `require_signed_response` carries through `builder_from_grant`.
     #[tokio::test]
-    async fn from_grant_honors_require_signed_response() {
+    async fn builder_from_grant_honors_require_signed_response() {
         let grant = code_grant(true).await;
-        let client = UserInfoClient::from_grant(&grant, &userinfo_metadata())
+        let client = UserInfoClient::builder_from_grant(&grant, &userinfo_metadata())
             .unwrap()
             .require_signed_response(true)
             .build()
@@ -1561,9 +1566,9 @@ mod tests {
     /// Requiring signed responses from a grant that has no verifier is the
     /// same misconfiguration the builder rejects.
     #[tokio::test]
-    async fn from_grant_require_signed_without_verifier_errors() {
+    async fn builder_from_grant_require_signed_without_verifier_errors() {
         let grant = code_grant(false).await;
-        let err = UserInfoClient::from_grant(&grant, &userinfo_metadata())
+        let err = UserInfoClient::builder_from_grant(&grant, &userinfo_metadata())
             .unwrap()
             .require_signed_response(true)
             .build()
@@ -1573,10 +1578,9 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::Config);
     }
 
-    /// No `userinfo_endpoint` in metadata is not an error — the provider
-    /// simply does not offer one.
+    /// Absent `userinfo_endpoint` errors, and the message names the field.
     #[tokio::test]
-    async fn from_grant_without_userinfo_endpoint_is_none() {
+    async fn builder_from_grant_without_userinfo_endpoint_names_the_field() {
         let metadata: AuthorizationServerMetadata = serde_json::from_value(serde_json::json!({
             "issuer": "https://op.example.com",
             "authorization_endpoint": "https://op.example.com/authorize",
@@ -1586,14 +1590,23 @@ mod tests {
         .unwrap();
 
         let grant = code_grant(true).await;
-        assert!(UserInfoClient::from_grant(&grant, &metadata).is_none());
+        // `.err()`, not `unwrap_err()`: bon builders aren't `Debug`.
+        let err = UserInfoClient::builder_from_grant(&grant, &metadata)
+            .err()
+            .expect("metadata carries no userinfo_endpoint");
+
+        assert_eq!(err.kind(), ErrorKind::Config);
+        assert_eq!(
+            err.to_string(),
+            "authorization server metadata has no `userinfo_endpoint`: invalid configuration"
+        );
     }
 
-    /// Plain JSON still works through `from_grant` when a validator is derived.
+    /// Plain JSON still works through `builder_from_grant` when a validator is derived.
     #[tokio::test]
-    async fn from_grant_still_accepts_json() {
+    async fn builder_from_grant_still_accepts_json() {
         let grant = code_grant(true).await;
-        let client = UserInfoClient::from_grant(&grant, &userinfo_metadata())
+        let client = UserInfoClient::builder_from_grant(&grant, &userinfo_metadata())
             .unwrap()
             .build()
             .await

--- a/integration/huskarl-conformance/src/lib.rs
+++ b/integration/huskarl-conformance/src/lib.rs
@@ -209,7 +209,7 @@ pub async fn run_auth_code_flow_with_listener<
         })?;
 
     let grant: AuthorizationCodeGrant = AuthorizationCodeGrant::builder_from_metadata(&metadata)
-        .ok_or("authorization server does not advertise an authorization endpoint")?
+        .map_err(|e| e.to_string())?
         .client_id(client_id)
         .http_client(http_client.clone())
         .client_auth(client_auth)

--- a/integration/huskarl-conformance/tests/oidc.rs
+++ b/integration/huskarl-conformance/tests/oidc.rs
@@ -105,8 +105,11 @@ async fn run_plan(plan_name: &str) -> Vec<String> {
             .call()
             .await
             .ok()
+            // `.ok()`: a module without a `userinfo_endpoint` still runs.
             .and_then(|m| {
-                UserInfoClient::builder_from_metadata(&m).map(|b| b.dpop(NoDPoP).build())
+                UserInfoClient::builder_from_metadata(&m)
+                    .ok()
+                    .map(|b| b.dpop(NoDPoP).build())
             });
         // Await the async builder outside the Option chain.
         let userinfo_client = match userinfo_client {


### PR DESCRIPTION
This allows them to be used consistently in a function that returns a result, including an error for why it couldn't be used. Can always be turned back into an Option using `.ok()`.

Also all the builders now have a pub type alias for the builder type they return.