### PR TITLE
chore: Move some deps to workspace, fix -Zdirect-minimal-versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,27 +261,25 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
 dependencies = [
  "bon-macros",
- "rustversion",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "ident_case",
  "prettyplease",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1441,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1821,7 +1819,6 @@ dependencies = [
  "huskarl-macros",
  "reqwest",
  "snafu",
- "strum",
  "tokio",
 ]
 
@@ -2708,12 +2705,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,19 +46,36 @@ huskarl-google-cloud = { version = "0.8", path = "./huskarl-google-cloud" }
 huskarl-resource-server = { version = "0.11", path = "./huskarl-resource-server" }
 
 base64 = { version = "0.23", default-features = false, features = ["std"] }
-bon = { version = "3.9", default-features = false, features = [
+bon = { version = "3.10", default-features = false, features = [
   "alloc",
   "experimental-generics-setters",
-  "implied-bounds",
 ] }
-form_urlencoded = { version = "1", default-features = false, features = ["std"] }
-hex = { version = "0.4", default-features = false, features = ["std"] }
-httpdate = { version = "1.0.3", default-features = false }
-rand = { version = "0.10", default-features = false, features = ["std", "sys_rng", "thread_rng"] }
-serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
-serde_json = { version = "1", default-features = false, features = ["std"] }
+bytes = { version = "1.10", default-features = false }
+form_urlencoded = { version = "1.2.1", default-features = false, features = [
+  "std",
+] }
+hex = { version = "0.4.3", default-features = false, features = ["std"] }
+http = { version = "1.1", default-features = false }
+httpdate = { version = "1", default-features = false }
+rand = { version = "0.10", default-features = false, features = [
+  "std",
+  "sys_rng",
+  "thread_rng",
+] }
+reqwest = { version = "0.13", default-features = false }
+rstest = { version = "0.26", default-features = false }
+serde = { version = "1.0.228", default-features = false, features = [
+  "derive",
+  "std",
+] }
+serde_json = { version = "1.0.148", default-features = false, features = ["std"] }
 sha2 = { version = "0.11", default-features = false }
-snafu = { version = "0.9", default-features = false, features = ["rust_1_81", "std"] }
+snafu = { version = "0.9", default-features = false, features = [
+  "rust_1_81",
+  "std",
+] }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
-metrics = { version = "0.24", default-features = false }
-url = { version = "2", default-features = false }
+subtle = { version = "2.6", default-features = false }
+tokio = { version = "1.45.1", default-features = false }
+metrics = { version = "0.24.2", default-features = false }
+url = { version = "2.5", default-features = false }

--- a/huskarl-core/Cargo.toml
+++ b/huskarl-core/Cargo.toml
@@ -40,11 +40,11 @@ arc-swap = "1"
 metrics = { workspace = true, optional = true }
 base64 = { workspace = true }
 bon = { workspace = true }
-bytes = { version = "1", default-features = false }
+bytes = { workspace = true }
 form_urlencoded = { workspace = true }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 hex = { workspace = true }
-http = { version = "1", default-features = false, features = ["std"] }
+http = { workspace = true, features = ["std"] }
 httpdate = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
@@ -52,29 +52,29 @@ serde_json = { workspace = true }
 sha2 = { workspace = true, default-features = false }
 snafu = { workspace = true }
 strum = { workspace = true }
-subtle = { version = "2.6.1", default-features = false }
-tokio = { version = "1", default-features = false, features = ["sync"] }
+subtle = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true, optional = true }
-zeroize = { version = "1.6", default-features = false, features = ["alloc"] }
+zeroize = { version = "1.8", default-features = false, features = ["alloc"] }
 
 ### Dependencies available on native and WASI (not browser WASM)
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
-tokio = { version = "1", default-features = false, features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 
 ### Dependencies available on browser WASM (wasm32-unknown-unknown)
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
-web-time = { version = "1", default-features = false, features = ["serde"] }
+web-time = { version = "1.1", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
-rstest = { version = "0.26.1", default-features = false }
+rstest = { workspace = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 ### Integration tests require multi-threaded runtime and network access.
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 httpmock = "0.8.3"
-tempfile = "3"
+tempfile = "3.23"

--- a/huskarl-crypto-native/Cargo.toml
+++ b/huskarl-crypto-native/Cargo.toml
@@ -23,10 +23,10 @@ rand = { version = "0.10", default-features = false, features = ["std", "sys_rng
 rsa = { version = "=0.10.0-rc.18", default-features = false, features = ["encoding", "sha2"] }
 sha2 = { version = "0.11", default-features = false }
 signature = { version = "3.0", default-features = false }
-serde_json = { version = "1", default-features = false, features = ["std"] }
-snafu = { version = "0.9", default-features = false, features = ["rust_1_81", "std"] }
+serde_json = { workspace = true }
+snafu = { workspace = true }
 strum = { workspace = true }
-subtle = { version = "2.6.1", default-features = false }
+subtle = { workspace = true }
 aes-gcm = { version = "0.11", default-features = false, features = ["aes", "alloc", "rand_core", "zeroize"] }
 chacha20poly1305 = { version = "0.11", default-features = false, features = ["alloc", "rand_core", "zeroize"] }
 # The AEAD error type shared by both ciphers above; named directly rather than
@@ -39,5 +39,5 @@ aead = { version = "0.6", default-features = false }
 # `huskarl_core::Error::propagate`.
 huskarl-core = { workspace = true, features = ["strict-propagation"] }
 base64 = { workspace = true }
-tokio = { version = "1", default-features = false, features = ["macros", "rt"] }
-serde = { version = "1", default-features = false, features = ["derive", "std"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+serde = { workspace = true }

--- a/huskarl-crypto-webcrypto/Cargo.toml
+++ b/huskarl-crypto-webcrypto/Cargo.toml
@@ -20,13 +20,13 @@ huskarl-macros = { workspace = true }
 huskarl-core = { workspace = true }
 
 serde-wasm-bindgen = { version = "0.6", default-features = false }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
-wasm-bindgen = { version = "0.2", default-features = false }
-wasm-bindgen-futures = { version = "0.4", default-features = false }
-serde = { version = "1.0", default-features = false }
+serde_json = { workspace = true }
+wasm-bindgen = { version = "0.2.114", default-features = false }
+wasm-bindgen-futures = { version = "0.4.18", default-features = false }
+serde = { workspace = true }
 serde_bytes = { version = "0.11", default-features = false }
-snafu = { version = "0.9", default-features = false }
-web-sys = { version = "0.3", features = [
+snafu = { workspace = true }
+web-sys = { version = "0.3.91", features = [
   "Crypto",
   "CryptoKey",
   "CryptoKeyPair",

--- a/huskarl-google-cloud/Cargo.toml
+++ b/huskarl-google-cloud/Cargo.toml
@@ -32,10 +32,13 @@ huskarl-core = { workspace = true }
 
 bon = { workspace = true }
 der = { version = "0.8", optional = true, default-features = false, features = ["derive"] }
-futures-util = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3", optional = true, default-features = false, features = [
+  "alloc",
+  "async-await-macro",
+] }
 # A direct dependency is needed to inspect the `RetryInfo` detail on a failed
 # RPC. Both service clients re-export their `Error` from this crate.
-google-cloud-gax = { version = "1", optional = true, default-features = false }
+google-cloud-gax = { version = "1.6", optional = true, default-features = false }
 google-cloud-kms-v1 = { version = "1.4", optional = true, default-features = false }
 google-cloud-secretmanager-v1 = { version = "1.4", optional = true, default-features = false }
 p256 = { version = "0.14", optional = true, default-features = false, features = ["ecdsa", "pem"] }
@@ -55,5 +58,5 @@ google-cloud-wkt = { version = "1", default-features = false }
 # multi-version secret sources compose into ciphers and verifiers whose `kid`
 # is derived from the secret version.
 huskarl-crypto-native = { workspace = true }
-rstest = { version = "0.26", default-features = false }
-tokio = { version = "1", default-features = false, features = ["macros", "rt"] }
+rstest = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/huskarl-macros/Cargo.toml
+++ b/huskarl-macros/Cargo.toml
@@ -15,14 +15,14 @@ proc-macro = true
 doc = false
 
 [dependencies]
-darling = "0.24"
-proc-macro2 = "1"
+darling = "0.24.1"
+proc-macro2 = "1.0.91"
 proc-macro-crate = "3"
-quote = "1"
-syn = { version = "3", features = ["full"] }
+quote = "1.0.37"
+syn = { version = "3.0.3", features = ["full"] }
 
 [dev-dependencies]
 bon = { workspace = true }
 huskarl-core = { path = "../huskarl-core" }
-rustversion = "1"
-trybuild = { version = "1", features = ["diff"] }
+rustversion = "1.0.6"
+trybuild = { version = "1.0.86", features = ["diff"] }

--- a/huskarl-redis/Cargo.toml
+++ b/huskarl-redis/Cargo.toml
@@ -29,6 +29,6 @@ snafu = { workspace = true }
 # off for dependents, whose own causes may legitimately wrap one. See
 # `huskarl_core::Error::propagate`.
 huskarl-core = { workspace = true, features = ["strict-propagation"] }
-redis-test = { version = "1", features = ["aio"] }
-rstest = { version = "0.26", default-features = false }
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
+redis-test = { version = "1.0.1", features = ["aio"] }
+rstest = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/huskarl-reqwest/Cargo.toml
+++ b/huskarl-reqwest/Cargo.toml
@@ -16,11 +16,11 @@ native-tls = ["reqwest/native-tls"]
 
 [dependencies]
 huskarl-macros = { workspace = true }
-bon = { version = "3", default-features = false }
-bytes = { version = "1", default-features = false }
-http = { version = "1", default-features = false }
+bon = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
 huskarl-core = { workspace = true }
-reqwest = { version = "0.13", default-features = false }
+reqwest = { workspace = true }
 snafu = { workspace = true }
 
 [dev-dependencies]
@@ -28,8 +28,6 @@ snafu = { workspace = true }
 # off for dependents, whose own causes may legitimately wrap one. See
 # `huskarl_core::Error::propagate`.
 huskarl-core = { workspace = true, features = ["strict-propagation"] }
-# Only for the `EnumCount` exhaustiveness checks.
-strum = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/huskarl-resource-server/Cargo.toml
+++ b/huskarl-resource-server/Cargo.toml
@@ -28,8 +28,8 @@ default-jws-verifier-platform = ["dep:huskarl-crypto-native", "dep:huskarl-crypt
 huskarl-core = { workspace = true }
 
 bon = { workspace = true }
-bytes = { version = "1", default-features = false }
-http = { version = "1" }
+bytes = { workspace = true }
+http = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
@@ -40,7 +40,7 @@ base64 = { workspace = true }
 
 ### Dependencies available on all platforms except WASM-not-WASI
 [target.'cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))'.dependencies]
-tokio = { version = "1", default-features = false, features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 huskarl-crypto-native = { workspace = true, optional = true }
 
 ### Dependencies available on WASM-not-WASI
@@ -48,7 +48,7 @@ huskarl-crypto-native = { workspace = true, optional = true }
 huskarl-crypto-webcrypto = { workspace = true, optional = true }
 getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
-web-time = { version = "1", default-features = false }
+web-time = { version = "1.1", default-features = false }
 
 [dev-dependencies]
 # Turns a dropped classification into a panic during this workspace's tests;
@@ -63,9 +63,9 @@ wasm-bindgen-test = "0.3"
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 huskarl-crypto-native = { path = "../huskarl-crypto-native" }
 huskarl-reqwest = { path = "../huskarl-reqwest" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 httpmock = "0.8.3"
-rstest = { version = "0.26", default-features = false }
+rstest = { workspace = true }
 
 # The example uses dev-dependencies, so rustdoc skips scraping it unless we
 # opt in explicitly. docs.rs scrapes examples, so this surfaces `basic` as a

--- a/huskarl/Cargo.toml
+++ b/huskarl/Cargo.toml
@@ -44,16 +44,16 @@ huskarl-macros = { workspace = true }
 arc-swap = "1"
 base64 = { workspace = true }
 bon = { workspace = true }
-bytes = { version = "1", default-features = false }
+bytes = { workspace = true }
 form_urlencoded = { workspace = true }
-http = { version = "1", default-features = false, features = ["std"] }
+http = { workspace = true, features = ["std"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 snafu = { workspace = true }
-subtle = { version = "2", default-features = false }
-tokio = { version = "1.51", default-features = false, features = ["sync"] }
+subtle = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true, optional = true }
 
 ### Dependencies available on all platforms except WASM-not-WASI
@@ -65,7 +65,7 @@ huskarl-crypto-native = { workspace = true, optional = true }
 huskarl-crypto-webcrypto = { workspace = true, optional = true }
 getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
-web-time = { version = "1", default-features = false }
+web-time = { version = "1.1", default-features = false }
 
 [[example]]
 name = "authorization_code"
@@ -94,7 +94,7 @@ wasm-bindgen-test = "0.3"
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 huskarl = { path = ".", features = ["authorization-flow-loopback"] }
 huskarl-reqwest = { path = "../huskarl-reqwest", features = ["rustls-tls"] }
-rstest = { version = "0.26", default-features = false }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "time"] }
-reqwest = { version = "0.13", features = ["cookies", "form", "json", "query"] }
+rstest = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "time"] }
+reqwest = { workspace = true, default-features = true, features = ["cookies", "form", "json", "query"] }
 httpmock = "0.8.3"

--- a/integration/huskarl-conformance/Cargo.toml
+++ b/integration/huskarl-conformance/Cargo.toml
@@ -11,18 +11,18 @@ publish = false
 conformance-suite-tests = []
 
 [dependencies]
-bytes = "1"
-http = "1"
+bytes = { workspace = true, features = ["std"] }
+http = { workspace = true, features = ["std"] }
 huskarl = { workspace = true, features = ["url", "authorization-flow-loopback"] }
 huskarl-reqwest = { workspace = true, features = ["rustls-tls"] }
-reqwest = { version = "0.13", default-features = false, features = ["cookies", "json", "query"] }
+reqwest = { workspace = true, features = ["cookies", "json", "query"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1", default-features = false, features = ["rt", "sync", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "sync", "macros", "time"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 bon = { workspace = true }
 huskarl-crypto-native = { workspace = true }
 huskarl-testkit = { path = "../huskarl-testkit" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/integration/huskarl-downstream/Cargo.toml
+++ b/integration/huskarl-downstream/Cargo.toml
@@ -9,9 +9,9 @@ description = "Scratch downstream consumer — verifies ergonomics from outside 
 [dependencies]
 huskarl = { workspace = true }
 
-bytes = { version = "1", default-features = false }
-http = { version = "1", default-features = false, features = ["std"] }
-thiserror = "2"
+bytes = { workspace = true }
+http = { workspace = true, features = ["std"] }
+thiserror = "2.0.12"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/integration/huskarl-integration/Cargo.toml
+++ b/integration/huskarl-integration/Cargo.toml
@@ -20,13 +20,13 @@ huskarl-reqwest = { workspace = true, features = ["rustls-tls"] }
 huskarl-resource-server = { path = "../../huskarl-resource-server", default-features = true }
 huskarl-testkit = { path = "../huskarl-testkit" }
 bon = { workspace = true }
-http = "1"
+http = { workspace = true, features = ["std"] }
 # Custom `harness = false` test harness for the per-provider `tests/*.rs`.
 libtest-mimic = "0.8"
 pem = "4"
-reqwest = { version = "0.13", features = ["cookies", "form", "json", "query"] }
+reqwest = { workspace = true, default-features = true, features = ["cookies", "form", "json", "query"] }
 serde_json = { workspace = true }
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[test]]
 name = "keycloak"

--- a/integration/huskarl-testkit/Cargo.toml
+++ b/integration/huskarl-testkit/Cargo.toml
@@ -10,9 +10,9 @@ name = "huskarl_testkit"
 
 [dependencies]
 huskarl-core = { workspace = true }
-async-trait = "0.1"
-bitflags = "2"
-reqwest = { version = "0.13", features = ["cookies", "json", "form"] }
+async-trait = "0.1.85"
+bitflags = "2.6.0"
+reqwest = { workspace = true, default-features = true, features = ["cookies", "json", "form"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 bon = { workspace = true }


### PR DESCRIPTION
This updates the workspace deps so that code still compiles, and tests pass, with -Zdirect-minimal-versions